### PR TITLE
Write contribution guide

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,60 @@
+{
+  "projectName": "grammY",
+  "projectOwner": "grammyjs",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": [
+    "README.md"
+  ],
+  "imageSize": 100,
+  "commit": true,
+  "commitConvention": "none",
+  "contributors": [
+    {
+      "login": "KnorpelSenf",
+      "name": "KnorpelSenf",
+      "avatar_url": "https://avatars.githubusercontent.com/u/12952387?v=4",
+      "profile": "https://github.com/KnorpelSenf",
+      "contributions": [
+        "ideas",
+        "code",
+        "doc",
+        "design",
+        "example",
+        "question",
+        "test",
+        "plugin",
+        "platform"
+      ]
+    },
+    {
+      "login": "Tecardo1",
+      "name": "Tecardo1",
+      "avatar_url": "https://avatars.githubusercontent.com/u/42873000?v=4",
+      "profile": "https://github.com/Tecardo1",
+      "contributions": [
+        "plugin",
+        "userTesting"
+      ]
+    },
+    {
+      "login": "wojpawlik",
+      "name": "Wojciech Pawlik",
+      "avatar_url": "https://avatars.githubusercontent.com/u/23058303?v=4",
+      "profile": "https://github.com/wojpawlik",
+      "contributions": [
+        "ideas"
+      ]
+    },
+    {
+      "login": "MegaITA",
+      "name": "Alessandro Bertozzi",
+      "avatar_url": "https://avatars.githubusercontent.com/u/32493080?v=4",
+      "profile": "https://github.com/MegaITA",
+      "contributions": [
+        "doc"
+      ]
+    }
+  ],
+  "contributorsPerLine": 7
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing to grammY
+
+First of all, thanks for your interest in helping out!
+We appreciate any kind of support, be it small bug fixes, large feature contributions, or even just if you drop us a message with some constructive criticism how grammY can be improved for your use case.
+This library would not be possible without you.
+
+We believe it is a strength of grammY to provide an integrated experience to its users.
+Important plugins have a dedicated page right inside the main documentation, and they are published under @grammyjs both on GitHub and on npm.
+If you have a good idea, don't hesitate to tell us in the group chat!
+We can grant you access to the GitHub Organization, so you can get a dedicated repository under our name, and publish your code as an offcial plugin of grammY.
+You will be responsible for maintaining it.
+
+## A Few Words on Deno and Node
+
+**TL;DR** working on grammY means working on a Deno project, and that is a good thing.
+
+grammY started out as a hybrid project, targeting both Deno and Node.js as runtimes not long after the Deno 1.0 release.
+Naturally, this poses a challenge to grammY.
+So far, there are no sufficiently good tools to convert a codebase back and forth between the ecosystems.
+As a result, grammY maintains its own backporting script to convert Deno code (`deno/` subdirectory) for the Node.js platform (`node-backport/` subdirectoy), which is much simpler than doing it the other way around.
+
+The script is simple.
+There are three steps to do in order to obtain TypeScript code for Node from the grammY codebase that runs on Deno.
+
+1. Platform-specifics (`Deno.open`) etc are replaced by their equivalents (`fs.createReadStream`).
+2. Built-in functions in Deno (`fetch`) are replaced by equivalent dependencies (`node-fetch`)
+3. Explicit file extensions are stripped because Node uses implicit ones
+
+Steps 2. and 3. are achieved using regular coreutil operations on the codebase that replace file extensions in imports and inject polyfilling import calls for Node.js.
+Step 1. is achieved by having extracted all platform-specific code into a file called `platform.ts` that resides in the top level of the project.
+The backporting script's first operation (after duplicating the codebase into a fresh directory) is to replace the `platform.ts` file with a predefined second, Node-specific version of the same file that “coincidentally” exports exactly the same set of members with identical (or at least compatible) type signatures.
+Also, all dependencies of grammY are imported and re-exported here, as the import syntax for external modules differs between the platforms.
+
+Long story short: if you want to work on grammY, you effectively work on a Deno project.
+We use Deno testing, Deno linting, and the [Deno extension](https://marketplace.visualstudio.com/items?itemName=denoland.vscode-deno) for VSCode.
+We just make sure that _the code also runs on Node.js_, but this transpilation process is automated, and you usually don't even have to think about it.
+
+> Note that not all plugins of grammY have to have the same setup: many of them only integrate with grammY itself, and hence can be written for Node and automatically ported to Deno via <https://skypack.dev/> and similar services.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # <h1 align="center">[![grammY](https://raw.githubusercontent.com/grammyjs/website/main/logos/grammY.png)](https://grammy.dev)</h1>
 
-<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-
-[![All Contributors](https://img.shields.io/badge/all_contributors-4-orange.svg?style=flat-square)](#contributors-)
-
-<!-- ALL-CONTRIBUTORS-BADGE:END -->
-
 _<h3 align="right">—The Telegram Bot Framework</h3>_
 
 ---
 
 _<h1 align="center">[Docs](https://grammy.dev) | [API Reference](https://doc.deno.land/https/deno.land/x/grammy/mod.ts) | [Chat](https://telegram.me/grammyjs)</h1>_
+
+<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
+[![All Contributors](https://img.shields.io/badge/all_contributors-4-orange.svg?style=flat-square)](#contributors-)
+
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 > This project has not reached 1.0. Please try it out and give some feedback before the release :)
 

--- a/README.md
+++ b/README.md
@@ -118,43 +118,4 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!
 
-## Contribution Guide
-
-> This section is intended for people who want to develop the grammY core package or one of its plugins. If you want to develop a Telegram bot, check out the [documentation](https://grammy.dev/).
-
-First of all, thanks for your interest in helping out!
-We appreciate any kind of support, be it small bug fixes, large feature contributions, or even just if you drop us a message with some constructive criticism how grammY can be improved for your use case.
-This library would not be possible without you.
-
-We believe it is a strength of grammY to provide an integrated experience to its users.
-Important plugins have a dedicated page right inside the main documentation, and they are published under @grammyjs both on GitHub and on npm.
-If you have a good idea, don't hesitate to tell us in the group chat!
-We can grant you access to the GitHub Organization, so you can get a dedicated repository under our name, and publish your code as an offcial plugin of grammY.
-You will be responsible for maintaining it.
-
-### A Few Words on Deno and Node
-
-**TL;DR** working on grammY means working on a Deno project, and that is a good thing.
-
-grammY started out as a hybrid project, targeting both Deno and Node.js as runtimes not long after the Deno 1.0 release.
-Naturally, this poses a challenge to grammY.
-So far, there are no sufficiently good tools to convert a codebase back and forth between the ecosystems.
-As a result, grammY maintains its own backporting script to convert Deno code (`deno/` subdirectory) for the Node.js platform (`node-backport/` subdirectoy), which is much simpler than doing it the other way around.
-
-The script is simple.
-There are three steps to do in order to obtain TypeScript code for Node from the grammY codebase that runs on Deno.
-
-1. Platform-specifics (`Deno.open`) etc are replaced by their equivalents (`fs.createReadStream`).
-2. Built-in functions in Deno (`fetch`) are replaced by equivalent dependencies (`node-fetch`)
-3. Explicit file extensions are stripped because Node uses implicit ones
-
-Steps 2. and 3. are achieved using regular coreutil operations on the codebase that replace file extensions in imports and inject polyfilling import calls for Node.js.
-Step 1. is achieved by having extracted all platform-specific code into a file called `platform.ts` that resides in the top level of the project.
-The backporting script's first operation (after duplicating the codebase into a fresh directory) is to replace the `platform.ts` file with a predefined second, Node-specific version of the same file that “coincidentally” exports exactly the same set of members with identical (or at least compatible) type signatures.
-Also, all dependencies of grammY are imported and re-exported here, as the import syntax for external modules differs between the platforms.
-
-Long story short: if you want to work on grammY, you effectively work on a Deno project.
-We use Deno testing, Deno linting, and the [Deno extension](https://marketplace.visualstudio.com/items?itemName=denoland.vscode-deno) for VSCode.
-We just make sure that _the code also runs on Node.js_, but this transpilation process is automated, and you usually don't even have to think about it.
-
-> Note that not all plugins of grammY have to have the same setup: many of them only integrate with grammY itself, and hence can be written for Node and automatically ported to Deno via <https://skypack.dev/> and similar services.
+## [Contribution Guide »](./CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
-# <h1 align="center">[![grammY](https://raw.githubusercontent.com/grammyjs/website/main/logos/grammY.png)](https://grammy.netlify.app)</h1>
+# <h1 align="center">[![grammY](https://raw.githubusercontent.com/grammyjs/website/main/logos/grammY.png)](https://grammy.dev)</h1>
+
+<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
+[![All Contributors](https://img.shields.io/badge/all_contributors-4-orange.svg?style=flat-square)](#contributors-)
+
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 _<h3 align="right">—The Telegram Bot Framework</h3>_
 
 ---
 
-_<h1 align="center">[Docs](https://grammy.netlify.app) | [API Reference](https://doc.deno.land/https/deno.land/x/grammy/mod.ts) | [Chat](https://telegram.me/grammyjs)</h1>_
+_<h1 align="center">[Docs](https://grammy.dev) | [API Reference](https://doc.deno.land/https/deno.land/x/grammy/mod.ts) | [Chat](https://telegram.me/grammyjs)</h1>_
 
 > This project has not reached 1.0. Please try it out and give some feedback before the release :)
 
@@ -51,7 +57,7 @@ Congrats! You just wrote a Telegram bot :)
 
 ## Going Further
 
-grammY has an excellent [documentation](https://grammy.netlify.app/). If you are using [VSCode](https://code.visualstudio.com/) as your code editor, you can hover over any element of grammY to get a detailed description of what that thing does or means.
+grammY has an excellent [documentation](https://grammy.dev/). If you are using [VSCode](https://code.visualstudio.com/) as your code editor, you can hover over any element of grammY to get a detailed description of what that thing does or means.
 
 If you are still stuck, just join the [Telegram chat](https://t.me/grammyjs) and ask for help. People are nice there and we appreciate your question, no matter what it is :)
 
@@ -59,7 +65,7 @@ Here are some more resources to support you:
 
 ## Resources
 
-### [grammY Website](https://grammy.netlify.app)
+### [grammY Website](https://grammy.dev)
 
 —main project website and documentation.
 
@@ -88,3 +94,67 @@ Here are some more resources to support you:
 All grammY packages published by [@grammyjs](https://github.com/grammyjs) run natively in Deno. We maintain our own backporting scripts to transform every codebase to still run on Node.
 
 However, given that most bot developers are still using Node, all documentation is written Node-first. We may migrate it if Deno overtakes Node. If you are already on Deno today, we expect you to know what you're doing. You mainly have to adjust the imports to URL imports, and use [`https://deno.land/x/grammy`](https://deno.land/x/grammy).
+
+## Contributors ✨
+
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tr>
+    <td align="center"><a href="https://github.com/KnorpelSenf"><img src="https://avatars.githubusercontent.com/u/12952387?v=4?s=100" width="100px;" alt=""/><br /><sub><b>KnorpelSenf</b></sub></a><br /><a href="#ideas-KnorpelSenf" title="Ideas, Planning, & Feedback">🤔</a> <a href="https://github.com/grammyjs/grammY/commits?author=KnorpelSenf" title="Code">💻</a> <a href="https://github.com/grammyjs/grammY/commits?author=KnorpelSenf" title="Documentation">📖</a> <a href="#design-KnorpelSenf" title="Design">🎨</a> <a href="#example-KnorpelSenf" title="Examples">💡</a> <a href="#question-KnorpelSenf" title="Answering Questions">💬</a> <a href="https://github.com/grammyjs/grammY/commits?author=KnorpelSenf" title="Tests">⚠️</a> <a href="#plugin-KnorpelSenf" title="Plugin/utility libraries">🔌</a> <a href="#platform-KnorpelSenf" title="Packaging/porting to new platform">📦</a></td>
+    <td align="center"><a href="https://github.com/Tecardo1"><img src="https://avatars.githubusercontent.com/u/42873000?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Tecardo1</b></sub></a><br /><a href="#plugin-Tecardo1" title="Plugin/utility libraries">🔌</a> <a href="#userTesting-Tecardo1" title="User Testing">📓</a></td>
+    <td align="center"><a href="https://github.com/wojpawlik"><img src="https://avatars.githubusercontent.com/u/23058303?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Wojciech Pawlik</b></sub></a><br /><a href="#ideas-wojpawlik" title="Ideas, Planning, & Feedback">🤔</a></td>
+    <td align="center"><a href="https://github.com/MegaITA"><img src="https://avatars.githubusercontent.com/u/32493080?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Alessandro Bertozzi</b></sub></a><br /><a href="https://github.com/grammyjs/grammY/commits?author=MegaITA" title="Documentation">📖</a></td>
+  </tr>
+</table>
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!
+
+## Contribution Guide
+
+> This section is intended for people who want to develop the grammY core package or one of its plugins. If you want to develop a Telegram bot, check out the [documentation](https://grammy.dev/).
+
+First of all, thanks for your interest in helping out!
+We appreciate any kind of support, be it small bug fixes, large feature contributions, or even just if you drop us a message with some constructive criticism how grammY can be improved for your use case.
+This library would not be possible without you.
+
+We believe it is a strength of grammY to provide an integrated experience to its users.
+Important plugins have a dedicated page right inside the main documentation, and they are published under @grammyjs both on GitHub and on npm.
+If you have a good idea, don't hesitate to tell us in the group chat!
+We can grant you access to the GitHub Organization, so you can get a dedicated repository under our name, and publish your code as an offcial plugin of grammY.
+You will be responsible for maintaining it.
+
+### A Few Words on Deno and Node
+
+**TL;DR** working on grammY means working on a Deno project, and that is a good thing.
+
+grammY started out as a hybrid project, targeting both Deno and Node.js as runtimes not long after the Deno 1.0 release.
+Naturally, this poses a challenge to grammY.
+So far, there are no sufficiently good tools to convert a codebase back and forth between the ecosystems.
+As a result, grammY maintains its own backporting script to convert Deno code (`deno/` subdirectory) for the Node.js platform (`node-backport/` subdirectoy), which is much simpler than doing it the other way around.
+
+The script is simple.
+There are three steps to do in order to obtain TypeScript code for Node from the grammY codebase that runs on Deno.
+
+1. Platform-specifics (`Deno.open`) etc are replaced by their equivalents (`fs.createReadStream`).
+2. Built-in functions in Deno (`fetch`) are replaced by equivalent dependencies (`node-fetch`)
+3. Explicit file extensions are stripped because Node uses implicit ones
+
+Steps 2. and 3. are achieved using regular coreutil operations on the codebase that replace file extensions in imports and inject polyfilling import calls for Node.js.
+Step 1. is achieved by having extracted all platform-specific code into a file called `platform.ts` that resides in the top level of the project.
+The backporting script's first operation (after duplicating the codebase into a fresh directory) is to replace the `platform.ts` file with a predefined second, Node-specific version of the same file that “coincidentally” exports exactly the same set of members with identical (or at least compatible) type signatures.
+Also, all dependencies of grammY are imported and re-exported here, as the import syntax for external modules differs between the platforms.
+
+Long story short: if you want to work on grammY, you effectively work on a Deno project.
+We use Deno testing, Deno linting, and the [Deno extension](https://marketplace.visualstudio.com/items?itemName=denoland.vscode-deno) for VSCode.
+We just make sure that _the code also runs on Node.js_, but this transpilation process is automated, and you usually don't even have to think about it.
+
+> Note that not all plugins of grammY have to have the same setup: many of them only integrate with grammY itself, and hence can be written for Node and automatically ported to Deno via <https://skypack.dev/> and similar services.

--- a/deno/README.md
+++ b/deno/README.md
@@ -1,15 +1,12 @@
 # grammY
 
-The grammY package lets you easily write Telegram bots. Here is a quickstart for
-you to get started, but note that a better explanation is
-[in our repo on GitHub](https://github.com/grammyjs/grammY).
+The grammY package lets you easily write Telegram bots. Here is a quickstart for you to get started, but note that a better explanation is [in our repo on GitHub](https://github.com/grammyjs/grammY).
 
-You may also want to check out the [docs](https://grammy.netlify.app).
+You may also want to check out the [docs](https://grammy.dev).
 
 ## Quickstart
 
-Talk to [@BotFather](https://t.me/BotFather) to create a new Telegram bot and
-obtain a _bot token_.
+Talk to [@BotFather](https://t.me/BotFather) to create a new Telegram bot and obtain a _bot token_.
 
 Paste the following code into a new file `bot.ts`.
 

--- a/deno/src/bot.ts
+++ b/deno/src/bot.ts
@@ -202,8 +202,8 @@ export class Bot<C extends Context = Context> extends Composer<C> {
      * your bot will handle.
      *
      * If you're writing a library on top of grammY, check out the
-     * [documentation](https://grammy.netlify.app/advanced/runner.html) to learn
-     * about how grammY receives updates.
+     * [documentation](https://grammy.dev/advanced/runner.html) to learn about
+     * how grammY receives updates.
      *
      * @param update An update from the Telegram Bot API
      * @param webhookReplyEnvelope An optional webhook reply envelope
@@ -258,8 +258,7 @@ export class Bot<C extends Context = Context> extends Composer<C> {
      * will impact the responsiveness negatively, so it makes sense to use the
      * `@grammyjs/runner` package even if you receive much fewer messages. If
      * you worry about how much load your bot can handle, check out the grammY
-     * [documentation](https://grammy.netlify.app/advanced/scaling.md) about
-     * scaling up.
+     * [documentation](https://grammy.dev/advanced/scaling.md) about scaling up.
      *
      * @param options Options to use for simple long polling
      */

--- a/deno/src/composer.ts
+++ b/deno/src/composer.ts
@@ -72,8 +72,7 @@ export interface MiddlewareObj<C extends Context = Context> {
  * Middleware is an extremely powerful concept and this short explanation only
  * scratched the surface of what is possible with grammY. If you want to know
  * more advanced things about middleware, check out the
- * [documentation](https://grammy.netlify.app/advanced/middleware.html) on the
- * website.
+ * [documentation](https://grammy.dev/advanced/middleware.html) on the website.
  */
 export type Middleware<C extends Context = Context> =
     | MiddlewareFn<C>
@@ -128,8 +127,7 @@ export async function run<C extends Context>(
  *
  * On the other hand, if you want to dig deeper into how grammY implements
  * middleware, check out the
- * [documentation](https://grammy.netlify.app/advanced/middleware.html) on the
- * website.
+ * [documentation](https://grammy.dev/advanced/middleware.html) on the website.
  */
 export class Composer<C extends Context> implements MiddlewareObj<C> {
     private handler: MiddlewareFn<C>
@@ -164,8 +162,8 @@ export class Composer<C extends Context> implements MiddlewareObj<C> {
      *
      * This method returns a new instance of composer. The returned instance can
      * be further extended, and all changes will be regarded here. Confer the
-     * [documentation](https://grammy.netlify.app/advanced/middleware.html) on
-     * the website if you want to know more about how the middleware system in
+     * [documentation](https://grammy.dev/advanced/middleware.html) on the
+     * website if you want to know more about how the middleware system in
      * grammY works, especially when it comes to chaining the method calls
      * (`use( ... ).use( ... ).use( ... )`).
      *
@@ -205,8 +203,8 @@ export class Composer<C extends Context> implements MiddlewareObj<C> {
      *
      * You can use autocomplete in VSCode to see all available filter queries.
      * Check out the
-     * [documentation](https://grammy.netlify.app/guide/filter-queries.html) on
-     * the website to learn more about filter queries in grammY.
+     * [documentation](https://grammy.dev/guide/filter-queries.html) on the
+     * website to learn more about filter queries in grammY.
      *
      * It is possible to pass multiple filter queries in an array, i.e.
      * ```ts
@@ -594,7 +592,8 @@ export class Composer<C extends Context> implements MiddlewareObj<C> {
      * You may generate this middleware in an `async` fashion.
      *
      * You can decide to return an empty array (`[]`) if you don't want to run
-     * any middleware for a given context object.
+     * any middleware for a given context object. This is equivalent to
+     * returning an empty instance of `Composer`.
      *
      * @param middlewareFactory The factory function creating the middleware
      */

--- a/deno/src/context.ts
+++ b/deno/src/context.ts
@@ -59,9 +59,9 @@ type RenamedUpdate = AliasProps<Omit<Update, 'update_id'>>
  * methods to keep information about how a regular expression was matched.
  *
  * Read up about middleware on the
- * [website](https://grammy.netlify.app/advanced/middleware.html) if you want to
- * know more about the powerful opportunities that lie in context objects, and
- * about how grammY implements them.
+ * [website](https://grammy.dev/advanced/middleware.html) if you want to know
+ * more about the powerful opportunities that lie in context objects, and about
+ * how grammY implements them.
  */
 export class Context implements RenamedUpdate {
     /**

--- a/deno/src/convenience/session.ts
+++ b/deno/src/convenience/session.ts
@@ -12,7 +12,7 @@ type MaybePromise<T> = Promise<T> | T
  * out the
  * [documentation](https://doc.deno.land/https/deno.land/x/grammy/mod.ts#session)
  * on session middleware to know more, and read the section about sessions on
- * the [website](https://grammy.netlify.app/guide/sessions.html).
+ * the [website](https://grammy.dev/guide/sessions.html).
  */
 export interface SessionContext<S> extends Context {
     /**
@@ -30,8 +30,7 @@ export interface SessionContext<S> extends Context {
  * same context object, the cached value will be used. Check out the
  * [documentation](https://doc.deno.land/https/deno.land/x/grammy/mod.ts#lazySession)
  * on lazy session middleware to know more, and read the section about lazy
- * sessions on the
- * [website](https://grammy.netlify.app/advanced/lazy-sessions.html).
+ * sessions on the [website](https://grammy.dev/advanced/lazy-sessions.html).
  */
 export interface LazySessionContext<S> extends Context {
     /**
@@ -70,8 +69,8 @@ export interface SessionOptions<S> {
      * This option lets you generate your own session keys per context object.
      * The session key determines how to map the different session objects to
      * your chats and users. Check out the
-     * [documentation](https://grammy.netlify.app/guide/sessions.html) on the
-     * website about session middleware to know how session keys are used.
+     * [documentation](https://grammy.dev/guide/sessions.html) on the website
+     * about session middleware to know how session keys are used.
      *
      * The default implementation will store sessions per user-chat combination.
      */
@@ -124,8 +123,8 @@ export interface SessionOptions<S> {
  * })
  * ```
  *
- * Check out the [documentation](https://grammy.netlify.app/guide/sessions.html)
- * on the website to know more about how sessions work in grammY.
+ * Check out the [documentation](https://grammy.dev/guide/sessions.html) on the
+ * website to know more about how sessions work in grammY.
  *
  * @param options Optional configuration to pass to the session middleware
  */
@@ -170,9 +169,8 @@ export function session<S>(
  * })
  * ```
  *
- * Check out the
- * [documentation](https://grammy.netlify.app/advanced/lazy-sessions.html) on
- * the website to know more about how lazy sessions work in grammY.
+ * Check out the [documentation](https://grammy.dev/advanced/lazy-sessions.html)
+ * on the website to know more about how lazy sessions work in grammY.
  *
  * @param options Optional configuration to pass to the session middleware
  */

--- a/deno/src/convenience/webhook.ts
+++ b/deno/src/convenience/webhook.ts
@@ -51,8 +51,8 @@ const frameworkAdapters: Record<SupportedFrameworks, FrameworkAdapter> = {
  * ```
  *
  * Confer the grammY
- * [documentation](https://grammy.netlify.app/guide/deployment-types.html) to
- * read more about how to run your bot with webhooks.
+ * [documentation](https://grammy.dev/guide/deployment-types.html) to read more
+ * about how to run your bot with webhooks.
  *
  * @param bot The bot for which to create a callback
  * @param framework An optional string identifying the framework (default:

--- a/deno/src/core/client.ts
+++ b/deno/src/core/client.ts
@@ -105,8 +105,7 @@ export interface ApiClientOptions {
      * URL builder function for API calls. Can be used to modify which API
      * server should be called.
      *
-     * @param root The root URL that was passed in `apiRoot`, or its default
-     * value
+     * @param root The URL that was passed in `apiRoot`, or its default value
      * @param token The bot's token that was passed when creating the bot
      * @param method The API method to be called, e.g. `getMe`
      * @returns The url that will be fetched during the API call

--- a/deno/src/core/client.ts
+++ b/deno/src/core/client.ts
@@ -54,8 +54,8 @@ export type ApiCallFn = <M extends keyof RawApi>(
  * implement rate limiting or other things against the Telegram Bot API.
  *
  * Confer the grammY
- * [documentation](https://grammy.netlify.app/advanced/transformers.html) to
- * read more about how to use transformers.
+ * [documentation](https://grammy.dev/advanced/transformers.html) to read more
+ * about how to use transformers.
  */
 export type Transformer = <M extends keyof RawApi>(
     prev: ApiCallFn,
@@ -97,14 +97,16 @@ const concatTransformer = (prev: ApiCallFn, trans: Transformer): ApiCallFn => (
  */
 export interface ApiClientOptions {
     /**
-     * Root URL of the Telegram Bot API server. Default: https://api.telegram.org
+     * Root URL of the Telegram Bot API server. Default:
+     * https://api.telegram.org
      */
     apiRoot?: string
     /**
-     * URL builder function for API calls. Can be used to modify which API server
-     * should be called.
+     * URL builder function for API calls. Can be used to modify which API
+     * server should be called.
      *
-     * @param root The root URL that was passed in `apiRoot`, or its default value
+     * @param root The root URL that was passed in `apiRoot`, or its default
+     * value
      * @param token The bot's token that was passed when creating the bot
      * @param method The API method to be called, e.g. `getMe`
      * @returns The url that will be fetched during the API call
@@ -146,9 +148,9 @@ export interface ApiClientOptions {
      */
     canUseWebhookReply?: (method: keyof RawApi) => boolean
     /**
-     * Base configuration for `fetch` calls. Specify any additional parameters to
-     * use when fetching a method of the Telegram Bot API. Default: `{ compress:
-     * true }` (Node), `{}` (Deno)
+     * Base configuration for `fetch` calls. Specify any additional parameters
+     * to use when fetching a method of the Telegram Bot API. Default: `{
+     * compress: true }` (Node), `{}` (Deno)
      */
     baseFetchConfig?: Omit<
         Exclude<Parameters<typeof fetch>[1], undefined>,

--- a/deno/src/filter.ts
+++ b/deno/src/filter.ts
@@ -23,7 +23,7 @@ type FilterFunction<C extends Context, D extends C> = (ctx: C) => ctx is D
  * Check out the
  * [documentation](https://doc.deno.land/https/deno.land/x/grammy/mod.ts#Composer)
  * of `bot.on` for examples. In addition, the
- * [website](https://grammy.netlify.app/guide/filter-queries.html) contains more
+ * [website](https://grammy.dev/guide/filter-queries.html) contains more
  * information about how filter queries work in grammY.
  *
  * @param filter A filter query or an array of filter queries
@@ -260,8 +260,8 @@ type AllValidFilterQueries = PermitL1Defaults
 /**
  * Represents a filter query that can be passed to `bot.on`. There are three
  * different kinds of filter queries: Level 1, Level 2, and Level 3. Check out
- * the [website](https://grammy.netlify.app/guide/filter-queries.html) to read
- * about how filter queries work in grammY, and how to use them.
+ * the [website](https://grammy.dev/guide/filter-queries.html) to read about how
+ * filter queries work in grammY, and how to use them.
  *
  * Here are three brief examples:
  * ```ts
@@ -288,7 +288,7 @@ type NotUndefined = string | number | boolean | SomeObject
 
 /**
  * Given a FilterQuery, returns an object that, when intersected with an Update,
- * marks those properties as required that are guaranteed to exist when.
+ * marks those properties as required that are guaranteed to exist.
  */
 type RunQuery<Q extends string> = L1Combinations<Q, L1Parts<Q>>
 

--- a/node-backport/README.md
+++ b/node-backport/README.md
@@ -2,7 +2,7 @@
 
 The grammY package lets you easily write Telegram bots. Here is a quickstart for you to get started, but note that a better explanation is [in our repo on GitHub](https://github.com/grammyjs/grammY).
 
-You may also want to check out the [docs](https://grammy.netlify.app).
+You may also want to check out the [docs](https://grammy.dev).
 
 ## Quickstart
 
@@ -11,23 +11,25 @@ Talk to [@BotFather](https://t.me/BotFather) to create a new Telegram bot and ob
 Paste the following code into a new file `bot.js`.
 
 ```js
-import { Bot } from 'grammy'
+import { Bot } from "grammy";
 // This works, too (CommonJS modules):
 // const { Bot } = require('grammy')
 
 // Create bot object
-const bot = new Bot('') // <-- place your bot token inside this string
+const bot = new Bot(""); // <-- place your bot token inside this string
 
 // Listen for messages
-bot.command('start', ctx => ctx.reply('Welcome! Send me a photo!'))
-bot.on('message:text', ctx => ctx.reply('That is text and not a photo!'))
-bot.on('message:photo', ctx => ctx.reply('Nice photo! Is that you?'))
-bot.on('edited_message', ctx => ctx.reply('Ha! Gotcha! You just edited this!', {
-    reply_to_message_id: ctx.editedMessage.message_id
-}))
+bot.command("start", (ctx) => ctx.reply("Welcome! Send me a photo!"));
+bot.on("message:text", (ctx) => ctx.reply("That is text and not a photo!"));
+bot.on("message:photo", (ctx) => ctx.reply("Nice photo! Is that you?"));
+bot.on("edited_message", (ctx) =>
+  ctx.reply("Ha! Gotcha! You just edited this!", {
+    reply_to_message_id: ctx.editedMessage.message_id,
+  })
+);
 
 // Launch!
-bot.start()
+bot.start();
 ```
 
 **Congratulations!** You have successfully created your first Telegram bot.

--- a/node-backport/package.json
+++ b/node-backport/package.json
@@ -7,6 +7,7 @@
   "engines": {
     "node": ">=12.0.0"
   },
+  "homepage": "https://grammy.dev/",
   "repository": {
     "type": "git",
     "url": "https://github.com/grammyjs/grammY"


### PR DESCRIPTION
Dedicated docs in the README for contributors.

Also begins following the specs of [allcontributors.com](https://allcontributors.com), and updates the URL in the JSDoc comments to point to [grammy.dev](https://grammy.dev)  instead of the old preview domain.
