### PR TITLE
Require using InputFile class

### DIFF
--- a/deno/src/core/payload.ts
+++ b/deno/src/core/payload.ts
@@ -2,6 +2,7 @@ import {
     itrToStream,
     streamFile,
     InputFile,
+    inputFileData,
     InputMedia,
     debug as d,
 } from '../platform.ts'
@@ -170,14 +171,16 @@ async function* filePart(
     yield enc.encode(
         `content-disposition:form-data;name="${id}";filename=${filename}\r\n\r\n`
     )
-    if (input.file instanceof Uint8Array) {
-        // `input.file` is a buffer
-        yield input.file
+    const fileData = input[inputFileData]
+    if (fileData instanceof Uint8Array) {
+        // `fileData` is a buffer
+        yield fileData
     } else {
         const stream =
-            typeof input.file === 'string'
-                ? await streamFile(input.file) // `input.file` is a file path
-                : input.file // `input.file` is a stream
+            typeof fileData === 'string'
+                ? await streamFile(fileData) // `fileData` is a file path
+                : fileData // `fileData` is a stream
+
         yield* stream
     }
 }

--- a/deno/src/platform.ts
+++ b/deno/src/platform.ts
@@ -58,7 +58,11 @@ export class InputFile {
      * @param filename Optional name of the file
      */
     constructor(
-        file: string | Uint8Array | ReadableStream | AsyncGenerator<Uint8Array>,
+        file:
+            | string
+            | Uint8Array
+            | ReadableStream<Uint8Array>
+            | AsyncIterable<Uint8Array>,
         filename?: string
     ) {
         this[inputFileData] = file

--- a/deno/src/platform.ts
+++ b/deno/src/platform.ts
@@ -31,8 +31,25 @@ export const streamFile = isDeno
 // Base configuration for `fetch` calls
 export const baseFetchConfig = {}
 
-/** This object represents the contents of a file to be uploaded. Must be posted using multipart/form-data in the usual way that files are uploaded via the browser. */
+// Accessor for file data in `InputFile` instances
+export const inputFileData = Symbol('InputFile data')
+
+/**
+ * An `InputFile` wraps a number of different sources for [sending
+ * files](https://grammy.dev/guide/files.html#uploading-your-own-file).
+ *
+ * It corresponds to the `InputFile` type in the [Telegram Bot API
+ * Reference](https://core.telegram.org/bots/api#inputfile).
+ */
 export class InputFile {
+    public readonly [inputFileData]: ConstructorParameters<typeof InputFile>[0]
+    /**
+     * Optional name of the constructed `InputFile` instance.
+     *
+     * Check out the
+     * [documenation](https://grammy.dev/guide/files.html#uploading-your-own-file)
+     * on sending files with `InputFile`.
+     */
     public readonly filename?: string
     /**
      * Constructs an `InputFile` that can be used in the API to send files.
@@ -41,20 +58,17 @@ export class InputFile {
      * @param filename Optional name of the file
      */
     constructor(
-        public readonly file:
-            | string
-            | Uint8Array
-            | ReadableStream
-            | AsyncGenerator<Uint8Array>,
+        file: string | Uint8Array | ReadableStream | AsyncGenerator<Uint8Array>,
         filename?: string
     ) {
+        this[inputFileData] = file
         if (filename === undefined && typeof file === 'string')
             filename = basename(file)
         this.filename = filename
     }
 }
 
-// CUSTOM TYPEGRAM TYPES
+// CUSTOM INPUT FILE TYPES
 
 type GrammyTypes = InputFileProxy<InputFile>
 

--- a/node-backport/platform.ts
+++ b/node-backport/platform.ts
@@ -1,8 +1,8 @@
 import { InputFileProxy } from "@grammyjs/types";
-import { ReadStream } from "fs";
 import { Agent } from "https";
 import { basename } from "path";
 import { Readable } from "stream";
+import type { ReadStream } from "fs";
 
 export * from "@grammyjs/types";
 export { debug } from "debug";
@@ -19,8 +19,25 @@ export const baseFetchConfig = {
   agent: new Agent({ keepAlive: true }),
 };
 
-/** This object represents the contents of a file to be uploaded. Must be posted using multipart/form-data in the usual way that files are uploaded via the browser. */
+// Accessor for file data in `InputFile` instances
+export const inputFileData = Symbol("InputFile data");
+
+/**
+ * An `InputFile` wraps a number of different sources for [sending
+ * files](https://grammy.dev/guide/files.html#uploading-your-own-file).
+ *
+ * It corresponds to the `InputFile` type in the [Telegram Bot API
+ * Reference](https://core.telegram.org/bots/api#inputfile).
+ */
 export class InputFile {
+  public readonly [inputFileData]: ConstructorParameters<typeof InputFile>[0];
+  /**
+   * Optional name of the constructed `InputFile` instance.
+   *
+   * Check out the
+   * [documenation](https://grammy.dev/guide/files.html#uploading-your-own-file)
+   * on sending files with `InputFile`.
+   */
   public readonly filename?: string;
   /**
    * Constructs an `InputFile` that can be used in the API to send files.
@@ -29,13 +46,10 @@ export class InputFile {
    * @param filename Optional name of the file
    */
   constructor(
-    public readonly file:
-      | string
-      | Uint8Array
-      | ReadStream
-      | AsyncGenerator<Uint8Array>,
+    file: string | Uint8Array | ReadStream | AsyncGenerator<Uint8Array>,
     filename?: string
   ) {
+    this[inputFileData] = file;
     if (filename === undefined && typeof file === "string")
       filename = basename(file);
     this.filename = filename;

--- a/node-backport/platform.ts
+++ b/node-backport/platform.ts
@@ -46,7 +46,7 @@ export class InputFile {
    * @param filename Optional name of the file
    */
   constructor(
-    file: string | Uint8Array | ReadStream | AsyncGenerator<Uint8Array>,
+    file: string | Uint8Array | ReadStream | AsyncIterable<Uint8Array>,
     filename?: string
   ) {
     this[inputFileData] = file;


### PR DESCRIPTION
… by hiding the `file` property behind a symbol that is only exported internally.

This makes it much harder to accidentally avoid using `InputFile`
