### PR TITLE
Add types property to package.json

### DIFF
--- a/node-backport/package.json
+++ b/node-backport/package.json
@@ -32,6 +32,7 @@
     "out/"
   ],
   "main": "./out/mod.js",
+  "types": "./out/mod.d.ts",
   "keywords": [
     "telegram",
     "bot",


### PR DESCRIPTION
This makes npm display a TypeScript badge on the package site.