### PR TITLE
Improve error handling

### DIFF
--- a/deno/src/bot.ts
+++ b/deno/src/bot.ts
@@ -299,7 +299,13 @@ export class Bot<C extends Context = Context> extends Composer<C> {
                 try {
                     await this.handleUpdate(update)
                 } catch (err) {
-                    await this.errorHandler(err)
+                    // should always be true
+                    if (err instanceof BotError) {
+                        await this.errorHandler(err)
+                    } else {
+                        console.error('FATAL: grammY unable to handle:', err)
+                        throw err
+                    }
                 }
             }
             // Telegram uses the last setting if `allowed_updates` is omitted so

--- a/deno/src/composer.ts
+++ b/deno/src/composer.ts
@@ -86,8 +86,33 @@ export type Middleware<C extends Context = Context> =
  */
 export class BotError<C extends Context = Context> extends Error {
     constructor(public readonly error: unknown, public readonly ctx: C) {
-        super('Error in middleware!')
+        super(generateBotErrorMessage(error))
+        this.name = 'BotError'
     }
+}
+function generateBotErrorMessage(error: unknown) {
+    let msg: string
+    if (error instanceof Error) {
+        msg = `${error.name} in middleware: ${error.message}`
+    } else {
+        const type = typeof error
+        msg = `Non-error value of type ${type} thrown in middleware`
+        switch (type) {
+            case 'bigint':
+            case 'boolean':
+            case 'number':
+            case 'symbol':
+                msg += `: ${error}`
+                break
+            case 'string':
+                msg += `: ${String(error).substr(0, 50)}`
+                break
+            default:
+                msg += '!'
+                break
+        }
+    }
+    return msg
 }
 
 // === Middleware base functions
@@ -762,7 +787,7 @@ export class Composer<C extends Context> implements MiddlewareObj<C> {
                 await bound(ctx, cont)
             } catch (err) {
                 nextCalled = false
-                await errorHandler(new BotError<C>(ctx, err), cont)
+                await errorHandler(new BotError<C>(err, ctx), cont)
             }
             if (nextCalled) await next()
         })

--- a/deno/src/core/error.ts
+++ b/deno/src/core/error.ts
@@ -29,6 +29,7 @@ export class GrammyError extends Error implements ApiError {
         public readonly payload: Record<string, unknown>
     ) {
         super(`${message} (${err.error_code}: ${err.description})`)
+        this.name = 'GrammyError'
         this.error_code = err.error_code
         this.description = err.description
         this.parameters = err.parameters ?? {}
@@ -55,5 +56,6 @@ export class HttpError extends Error {
         public readonly error: unknown
     ) {
         super(message)
+        this.name = 'HttpError'
     }
 }


### PR DESCRIPTION
Fixes a bug in error boundaries.

Makes grammY ready for error handling in TypeScript 4.4 where errors in `catch` blocks will be of type `unknown` by default.

Improves the default error message that is printed if `BotError` is logged instead of properly inspecting the thrown error object.

Adds an option to print sensitive information to the logs, called `sensitiveLogs`. This will make the API client include the bot token in error messages, but as an advantage, more detailed system information become available when network requests fail. This option will be recommended to set to `true` for production scale bots in the deployment checklist.