### PR TITLE
Check for Deno api property not exposed by Deno deploy

### DIFF
--- a/deno/src/platform.ts
+++ b/deno/src/platform.ts
@@ -11,12 +11,12 @@ const isDeno = typeof Deno !== 'undefined'
 if (isDeno) {
     debug.useColors = () => !Deno.noColor
     const env = { name: 'env', variable: 'DEBUG' } as const
-    let res = await Deno.permissions.query(env)
-    if (res.state === 'prompt') res = await Deno.permissions.request(env)
-    if (res.state === 'granted') {
-        const val = Deno.env.get(env.variable)
-        if (val) debug.enable(val)
-    }
+    
+    const val = await Deno.permissions.request(env)
+        .finally(() => Deno.env.get(env.variable))
+        .catch(() => null)
+ 
+    if (val) debug.enable(val)
 }
 
 import { iter } from 'https://deno.land/std@0.97.0/io/mod.ts'


### PR DESCRIPTION
This might not be the most 'gentle' way to check for permissions. :D