### PR TITLE
Support custom API types

### DIFF
--- a/deno/src/bot.ts
+++ b/deno/src/bot.ts
@@ -99,7 +99,10 @@ export interface BotConfig<C extends Context> {
  * bot.start()
  * ```
  */
-export class Bot<C extends Context = Context> extends Composer<C> {
+export class Bot<
+    C extends Context = Context,
+    A extends Api = Api
+> extends Composer<C> {
     private pollingRunning = false
     private pollingAbortController: AbortController | undefined
     private lastTriedUpdateId = 0
@@ -114,7 +117,7 @@ export class Bot<C extends Context = Context> extends Composer<C> {
      * Use this only outside of your middleware. If you have access to `ctx`,
      * then using `ctx.api` instead of `bot.api` is preferred.
      */
-    public readonly api: Api
+    public readonly api: A
 
     private botInfo: UserFromGetMe | undefined
     private readonly clientConfig: ApiClientOptions | undefined
@@ -170,7 +173,7 @@ export class Bot<C extends Context = Context> extends Composer<C> {
             (Context as new (
                 ...args: ConstructorParameters<typeof Context>
             ) => C)
-        this.api = new Api(token, this.clientConfig)
+        this.api = new Api(token, this.clientConfig) as A
     }
 
     /**

--- a/deno/src/context.ts
+++ b/deno/src/context.ts
@@ -1,5 +1,6 @@
 // deno-lint-ignore-file camelcase
-import { Api, Other } from './core/api.ts'
+import { Api, Other as OtherApi } from './core/api.ts'
+import { Methods, RawApi } from './core/client.ts'
 import {
     Chat,
     ChatPermissions,
@@ -18,6 +19,11 @@ import {
     UserFromGetMe,
 } from './platform.ts'
 
+type Other<M extends Methods<RawApi>, X extends string = never> = OtherApi<
+    RawApi,
+    M,
+    X
+>
 type SnakeToCamelCase<S extends string> = S extends `${infer L}_${infer R}`
     ? `${L}${Capitalize<SnakeToCamelCase<R>>}`
     : S

--- a/deno/src/core/api.ts
+++ b/deno/src/core/api.ts
@@ -20,6 +20,8 @@ import {
     TransformerConsumer,
     WebhookReplyEnvelope,
     Transformer,
+    Payload,
+    Methods,
 } from './client.ts'
 
 type AlwaysOmittedInOther = 'chat_id'
@@ -28,9 +30,10 @@ type AlwaysOmittedInOther = 'chat_id'
  * given that some properties X have already been specified.
  */
 export type Other<
-    M extends keyof RawApi,
-    X extends keyof Omit<Opts<M>, AlwaysOmittedInOther> = never
-> = Omit<Opts<M>, AlwaysOmittedInOther | X>
+    R extends RawApi,
+    M extends Methods<R>,
+    X extends string = never
+> = Omit<Payload<M, R>, X | AlwaysOmittedInOther>
 
 /**
  * This class provides access to the full Telegram Bot API. All methods of the
@@ -49,7 +52,7 @@ export type Other<
  * modify the method and payload on the fly before sending it to the Telegram
  * servers. Confer the `config` property for this.
  */
-export class Api {
+export class Api<R extends RawApi = RawApi> {
     /**
      * Provides access to all methods of the Telegram Bot API exactly as
      * documented on the website (https://core.telegram.org/bots/api). No
@@ -59,7 +62,7 @@ export class Api {
      * undocumented methods with arbitrary parameters—use only if you know what
      * you are doing.
      */
-    public readonly raw: RawApi
+    public readonly raw: R
 
     /**
      * Configuration object for the API instance, used as a namespace to
@@ -76,7 +79,7 @@ export class Api {
          * _Note that using transformer functions is an advanced feature of
          * grammY that most bots will not need to make use of._
          */
-        readonly use: TransformerConsumer
+        readonly use: TransformerConsumer<R>
         /**
          * Provides read access to all currently installed transformers (those
          * that have previously been passed to `config.use`).
@@ -84,7 +87,7 @@ export class Api {
          * _Note that using transformer functions is an advanced feature of
          * grammY that most bots will not need to make use of._
          */
-        readonly installedTransformers: () => Transformer[]
+        readonly installedTransformers: () => Transformer<R>[]
     }
 
     constructor(
@@ -92,7 +95,7 @@ export class Api {
         config?: ApiClientOptions,
         webhookReplyEnvelope?: WebhookReplyEnvelope
     ) {
-        const { raw, use, installedTransformers } = createRawApi(
+        const { raw, use, installedTransformers } = createRawApi<R>(
             token,
             config,
             webhookReplyEnvelope
@@ -116,7 +119,7 @@ export class Api {
      *
      * **Official reference:** https://core.telegram.org/bots/api#getupdates
      */
-    getUpdates(other?: Other<'getUpdates'>, signal?: AbortSignal) {
+    getUpdates(other?: Other<R, 'getUpdates'>, signal?: AbortSignal) {
         return this.raw.getUpdates({ ...other }, signal)
     }
 
@@ -140,7 +143,7 @@ export class Api {
      */
     setWebhook(
         url: string,
-        other?: Other<'setWebhook', 'url'>,
+        other?: Other<R, 'setWebhook', 'url'>,
         signal?: AbortSignal
     ) {
         return this.raw.setWebhook({ url, ...other }, signal)
@@ -154,7 +157,7 @@ export class Api {
      *
      * **Official reference:** https://core.telegram.org/bots/api#deletewebhook
      */
-    deleteWebhook(other?: Other<'deleteWebhook'>, signal?: AbortSignal) {
+    deleteWebhook(other?: Other<R, 'deleteWebhook'>, signal?: AbortSignal) {
         return this.raw.deleteWebhook({ ...other }, signal)
     }
 
@@ -215,7 +218,7 @@ export class Api {
     sendMessage(
         chat_id: number | string,
         text: string,
-        other?: Other<'sendMessage', 'text'>,
+        other?: Other<R, 'sendMessage', 'text'>,
         signal?: AbortSignal
     ) {
         return this.raw.sendMessage({ chat_id, text, ...other }, signal)
@@ -236,7 +239,7 @@ export class Api {
         chat_id: number | string,
         from_chat_id: number | string,
         message_id: number,
-        other?: Other<'forwardMessage', 'from_chat_id' | 'message_id'>,
+        other?: Other<R, 'forwardMessage', 'from_chat_id' | 'message_id'>,
         signal?: AbortSignal
     ) {
         return this.raw.forwardMessage(
@@ -265,7 +268,7 @@ export class Api {
         chat_id: number | string,
         from_chat_id: number | string,
         message_id: number,
-        other?: Other<'copyMessage', 'from_chat_id' | 'message_id'>,
+        other?: Other<R, 'copyMessage', 'from_chat_id' | 'message_id'>,
         signal?: AbortSignal
     ) {
         return this.raw.copyMessage(
@@ -292,7 +295,7 @@ export class Api {
     sendPhoto(
         chat_id: number | string,
         photo: InputFile | string,
-        other?: Other<'sendPhoto', 'photo'>,
+        other?: Other<R, 'sendPhoto', 'photo'>,
         signal?: AbortSignal
     ) {
         return this.raw.sendPhoto({ chat_id, photo, ...other }, signal)
@@ -313,7 +316,7 @@ export class Api {
     sendAudio(
         chat_id: number | string,
         audio: InputFile | string,
-        other?: Other<'sendAudio', 'audio'>,
+        other?: Other<R, 'sendAudio', 'audio'>,
         signal?: AbortSignal
     ) {
         return this.raw.sendAudio({ chat_id, audio, ...other }, signal)
@@ -332,7 +335,7 @@ export class Api {
     sendDocument(
         chat_id: number | string,
         document: InputFile | string,
-        other?: Other<'sendDocument', 'document'>,
+        other?: Other<R, 'sendDocument', 'document'>,
         signal?: AbortSignal
     ) {
         return this.raw.sendDocument({ chat_id, document, ...other }, signal)
@@ -351,7 +354,7 @@ export class Api {
     sendVideo(
         chat_id: number | string,
         video: InputFile | string,
-        other?: Other<'sendVideo', 'video'>,
+        other?: Other<R, 'sendVideo', 'video'>,
         signal?: AbortSignal
     ) {
         return this.raw.sendVideo({ chat_id, video, ...other }, signal)
@@ -370,7 +373,7 @@ export class Api {
     sendAnimation(
         chat_id: number | string,
         animation: InputFile | string,
-        other?: Other<'sendAnimation', 'animation'>,
+        other?: Other<R, 'sendAnimation', 'animation'>,
         signal?: AbortSignal
     ) {
         return this.raw.sendAnimation({ chat_id, animation, ...other }, signal)
@@ -389,7 +392,7 @@ export class Api {
     sendVoice(
         chat_id: number | string,
         voice: InputFile | string,
-        other?: Other<'sendVoice', 'voice'>,
+        other?: Other<R, 'sendVoice', 'voice'>,
         signal?: AbortSignal
     ) {
         return this.raw.sendVoice({ chat_id, voice, ...other }, signal)
@@ -409,7 +412,7 @@ export class Api {
     sendVideoNote(
         chat_id: number | string,
         video_note: InputFile | string,
-        other?: Other<'sendVideoNote', 'video_note'>,
+        other?: Other<R, 'sendVideoNote', 'video_note'>,
         signal?: AbortSignal
     ) {
         return this.raw.sendVideoNote({ chat_id, video_note, ...other }, signal)
@@ -433,7 +436,7 @@ export class Api {
             | InputMediaPhoto
             | InputMediaVideo
         >,
-        other?: Other<'sendMediaGroup', 'media'>,
+        other?: Other<R, 'sendMediaGroup', 'media'>,
         signal?: AbortSignal
     ) {
         return this.raw.sendMediaGroup({ chat_id, media, ...other }, signal)
@@ -454,7 +457,7 @@ export class Api {
         chat_id: number | string,
         latitude: number,
         longitude: number,
-        other?: Other<'sendLocation', 'latitude' | 'longitude'>,
+        other?: Other<R, 'sendLocation', 'latitude' | 'longitude'>,
         signal?: AbortSignal
     ) {
         return this.raw.sendLocation(
@@ -481,6 +484,7 @@ export class Api {
         latitude: number,
         longitude: number,
         other?: Other<
+            R,
             'editMessageLiveLocation',
             'message_id' | 'inline_message_id' | 'latitude' | 'longitude'
         >,
@@ -514,6 +518,7 @@ export class Api {
         latitude: number,
         longitude: number,
         other?: Other<
+            R,
             'editMessageLiveLocation',
             'message_id' | 'inline_message_id' | 'latitude' | 'longitude'
         >,
@@ -544,6 +549,7 @@ export class Api {
         chat_id: number | string,
         message_id: number,
         other?: Other<
+            R,
             'stopMessageLiveLocation',
             'message_id' | 'inline_message_id'
         >,
@@ -571,6 +577,7 @@ export class Api {
     stopMessageLiveLocationInline(
         inline_message_id: string,
         other?: Other<
+            R,
             'stopMessageLiveLocation',
             'message_id' | 'inline_message_id'
         >,
@@ -602,6 +609,7 @@ export class Api {
         title: string,
         address: string,
         other?: Other<
+            R,
             'sendVenue',
             'latitude' | 'longitude' | 'title' | 'address'
         >,
@@ -635,7 +643,7 @@ export class Api {
         chat_id: number | string,
         phone_number: string,
         first_name: string,
-        other?: Other<'sendContact', 'phone_number' | 'first_name'>,
+        other?: Other<R, 'sendContact', 'phone_number' | 'first_name'>,
         signal?: AbortSignal
     ) {
         return this.raw.sendContact(
@@ -664,7 +672,7 @@ export class Api {
         chat_id: number | string,
         question: string,
         options: readonly string[],
-        other?: Other<'sendPoll', 'question' | 'options'>,
+        other?: Other<R, 'sendPoll', 'question' | 'options'>,
         signal?: AbortSignal
     ) {
         return this.raw.sendPoll(
@@ -686,7 +694,7 @@ export class Api {
     sendDice(
         chat_id: number | string,
         emoji: string,
-        other?: Other<'sendDice', 'emoji'>,
+        other?: Other<R, 'sendDice', 'emoji'>,
         signal?: AbortSignal
     ) {
         return this.raw.sendDice({ chat_id, emoji, ...other }, signal)
@@ -734,7 +742,7 @@ export class Api {
      */
     getUserProfilePhotos(
         user_id: number,
-        other?: Other<'getUserProfilePhotos', 'user_id'>,
+        other?: Other<R, 'getUserProfilePhotos', 'user_id'>,
         signal?: AbortSignal
     ) {
         return this.raw.getUserProfilePhotos({ user_id, ...other }, signal)
@@ -772,7 +780,7 @@ export class Api {
     banChatMember(
         chat_id: number | string,
         user_id: number,
-        other?: Other<'banChatMember', 'user_id'>,
+        other?: Other<R, 'banChatMember', 'user_id'>,
         signal?: AbortSignal
     ) {
         return this.raw.banChatMember({ chat_id, user_id, ...other }, signal)
@@ -791,7 +799,7 @@ export class Api {
     unbanChatMember(
         chat_id: number | string,
         user_id: number,
-        other?: Other<'unbanChatMember', 'user_id'>,
+        other?: Other<R, 'unbanChatMember', 'user_id'>,
         signal?: AbortSignal
     ) {
         return this.raw.unbanChatMember({ chat_id, user_id, ...other }, signal)
@@ -812,7 +820,7 @@ export class Api {
         chat_id: number | string,
         user_id: number,
         permissions: ChatPermissions,
-        other?: Other<'restrictChatMember', 'user_id' | 'permissions'>,
+        other?: Other<R, 'restrictChatMember', 'user_id' | 'permissions'>,
         signal?: AbortSignal
     ) {
         return this.raw.restrictChatMember(
@@ -839,7 +847,7 @@ export class Api {
     promoteChatMember(
         chat_id: number | string,
         user_id: number,
-        other?: Other<'promoteChatMember', 'user_id'>,
+        other?: Other<R, 'promoteChatMember', 'user_id'>,
         signal?: AbortSignal
     ) {
         return this.raw.promoteChatMember(
@@ -916,7 +924,7 @@ export class Api {
      */
     createChatInviteLink(
         chat_id: number | string,
-        other?: Other<'createChatInviteLink'>,
+        other?: Other<R, 'createChatInviteLink'>,
         signal?: AbortSignal
     ) {
         return this.raw.createChatInviteLink({ chat_id, ...other }, signal)
@@ -935,7 +943,7 @@ export class Api {
     editChatInviteLink(
         chat_id: number | string,
         invite_link: string,
-        other?: Other<'editChatInviteLink', 'invite_link'>,
+        other?: Other<R, 'editChatInviteLink', 'invite_link'>,
         signal?: AbortSignal
     ) {
         return this.raw.editChatInviteLink(
@@ -1037,7 +1045,7 @@ export class Api {
     pinChatMessage(
         chat_id: number | string,
         message_id: number,
-        other?: Other<'pinChatMessage', 'message_id'>,
+        other?: Other<R, 'pinChatMessage', 'message_id'>,
         signal?: AbortSignal
     ) {
         return this.raw.pinChatMessage(
@@ -1194,7 +1202,7 @@ export class Api {
      */
     answerCallbackQuery(
         callback_query_id: string,
-        other?: Other<'answerCallbackQuery', 'callback_query_id'>,
+        other?: Other<R, 'answerCallbackQuery', 'callback_query_id'>,
         signal?: AbortSignal
     ) {
         return this.raw.answerCallbackQuery(
@@ -1214,7 +1222,7 @@ export class Api {
      */
     setMyCommands(
         commands: readonly BotCommand[],
-        other?: Other<'setMyCommands', 'commands'>,
+        other?: Other<R, 'setMyCommands', 'commands'>,
         signal?: AbortSignal
     ) {
         return this.raw.setMyCommands({ commands, ...other }, signal)
@@ -1228,7 +1236,10 @@ export class Api {
      *
      * **Official reference:** https://core.telegram.org/bots/api#deletemycommands
      */
-    deleteMyCommands(other?: Other<'deleteMyCommands'>, signal?: AbortSignal) {
+    deleteMyCommands(
+        other?: Other<R, 'deleteMyCommands'>,
+        signal?: AbortSignal
+    ) {
         return this.raw.deleteMyCommands({ ...other }, signal)
     }
 
@@ -1240,7 +1251,7 @@ export class Api {
      *
      * **Official reference:** https://core.telegram.org/bots/api#getmycommands
      */
-    getMyCommands(other?: Other<'getMyCommands'>, signal?: AbortSignal) {
+    getMyCommands(other?: Other<R, 'getMyCommands'>, signal?: AbortSignal) {
         return this.raw.getMyCommands({ ...other }, signal)
     }
 
@@ -1259,7 +1270,7 @@ export class Api {
         chat_id: number | string,
         message_id: number,
         text: string,
-        other?: Other<'editMessageText', 'message_id' | 'text'>,
+        other?: Other<R, 'editMessageText', 'message_id' | 'text'>,
         signal?: AbortSignal
     ) {
         return this.raw.editMessageText(
@@ -1280,7 +1291,7 @@ export class Api {
     editMessageTextInline(
         inline_message_id: string,
         text: string,
-        other?: Other<'editMessageText', 'inline_message_id' | 'text'>,
+        other?: Other<R, 'editMessageText', 'inline_message_id' | 'text'>,
         signal?: AbortSignal
     ) {
         return this.raw.editMessageText(
@@ -1302,7 +1313,7 @@ export class Api {
     editMessageCaption(
         chat_id: number | string,
         message_id: number,
-        other?: Other<'editMessageCaption', 'message_id'>,
+        other?: Other<R, 'editMessageCaption', 'message_id'>,
         signal?: AbortSignal
     ) {
         return this.raw.editMessageCaption(
@@ -1322,7 +1333,7 @@ export class Api {
      */
     editMessageCaptionInline(
         inline_message_id: string,
-        other?: Other<'editMessageCaption', 'inline_message_id'>,
+        other?: Other<R, 'editMessageCaption', 'inline_message_id'>,
         signal?: AbortSignal
     ) {
         return this.raw.editMessageCaption(
@@ -1346,7 +1357,7 @@ export class Api {
         chat_id: number | string,
         message_id: number,
         media: InputMedia,
-        other?: Other<'editMessageMedia', 'message_id' | 'media'>,
+        other?: Other<R, 'editMessageMedia', 'message_id' | 'media'>,
         signal?: AbortSignal
     ) {
         return this.raw.editMessageMedia(
@@ -1373,7 +1384,7 @@ export class Api {
     editMessageMediaInline(
         inline_message_id: string,
         media: InputMedia,
-        other?: Other<'editMessageMedia', 'inline_message_id' | 'media'>,
+        other?: Other<R, 'editMessageMedia', 'inline_message_id' | 'media'>,
         signal?: AbortSignal
     ) {
         return this.raw.editMessageMedia(
@@ -1395,7 +1406,7 @@ export class Api {
     editMessageReplyMarkup(
         chat_id: number | string,
         message_id: number,
-        other?: Other<'editMessageReplyMarkup', 'message_id'>,
+        other?: Other<R, 'editMessageReplyMarkup', 'message_id'>,
         signal?: AbortSignal
     ) {
         return this.raw.editMessageReplyMarkup(
@@ -1419,7 +1430,7 @@ export class Api {
      */
     editMessageReplyMarkupInline(
         inline_message_id: string,
-        other?: Other<'editMessageReplyMarkup', 'inline_message_id'>,
+        other?: Other<R, 'editMessageReplyMarkup', 'inline_message_id'>,
         signal?: AbortSignal
     ) {
         return this.raw.editMessageReplyMarkup(
@@ -1441,7 +1452,7 @@ export class Api {
     stopPoll(
         chat_id: number | string,
         message_id: number,
-        other?: Other<'stopPoll', 'message_id'>,
+        other?: Other<R, 'stopPoll', 'message_id'>,
         signal?: AbortSignal
     ) {
         return this.raw.stopPoll({ chat_id, message_id, ...other }, signal)
@@ -1485,7 +1496,7 @@ export class Api {
     sendSticker(
         chat_id: number | string,
         sticker: InputFile | string,
-        other?: Other<'sendSticker', 'sticker'>,
+        other?: Other<R, 'sendSticker', 'sticker'>,
         signal?: AbortSignal
     ) {
         return this.raw.sendSticker({ chat_id, sticker, ...other }, signal)
@@ -1538,6 +1549,7 @@ export class Api {
         title: string,
         emojis: string,
         other?: Other<
+            R,
             'createNewStickerSet',
             'user_id' | 'name' | 'title' | 'emojis'
         >,
@@ -1570,7 +1582,7 @@ export class Api {
         user_id: number,
         name: string,
         emojis: string,
-        other?: Other<'addStickerToSet', 'user_id' | 'name' | 'emojis'>,
+        other?: Other<R, 'addStickerToSet', 'user_id' | 'name' | 'emojis'>,
         signal?: AbortSignal
     ) {
         return this.raw.addStickerToSet(
@@ -1643,7 +1655,7 @@ export class Api {
     answerInlineQuery(
         inline_query_id: string,
         results: readonly InlineQueryResult[],
-        other?: Other<'answerInlineQuery', 'inline_query_id' | 'results'>,
+        other?: Other<R, 'answerInlineQuery', 'inline_query_id' | 'results'>,
         signal?: AbortSignal
     ) {
         return this.raw.answerInlineQuery(
@@ -1680,6 +1692,7 @@ export class Api {
         currency: string,
         prices: readonly LabeledPrice[],
         other?: Other<
+            R,
             'sendInvoice',
             | 'title'
             | 'description'
@@ -1719,7 +1732,7 @@ export class Api {
     answerShippingQuery(
         shipping_query_id: string,
         ok: boolean,
-        other?: Other<'answerShippingQuery', 'shipping_query_id' | 'ok'>,
+        other?: Other<R, 'answerShippingQuery', 'shipping_query_id' | 'ok'>,
         signal?: AbortSignal
     ) {
         return this.raw.answerShippingQuery(
@@ -1741,7 +1754,11 @@ export class Api {
     answerPreCheckoutQuery(
         pre_checkout_query_id: string,
         ok: boolean,
-        other?: Other<'answerPreCheckoutQuery', 'pre_checkout_query_id' | 'ok'>,
+        other?: Other<
+            R,
+            'answerPreCheckoutQuery',
+            'pre_checkout_query_id' | 'ok'
+        >,
         signal?: AbortSignal
     ) {
         return this.raw.answerPreCheckoutQuery(
@@ -1786,7 +1803,7 @@ export class Api {
     sendGame(
         chat_id: number,
         game_short_name: string,
-        other?: Other<'sendGame', 'game_short_name'>,
+        other?: Other<R, 'sendGame', 'game_short_name'>,
         signal?: AbortSignal
     ) {
         return this.raw.sendGame({ chat_id, game_short_name, ...other }, signal)
@@ -1809,7 +1826,7 @@ export class Api {
         message_id: number,
         user_id: number,
         score: number,
-        other?: Other<'setGameScore', 'message_id' | 'user_id' | 'score'>,
+        other?: Other<R, 'setGameScore', 'message_id' | 'user_id' | 'score'>,
         signal?: AbortSignal
     ) {
         return this.raw.setGameScore(
@@ -1840,6 +1857,7 @@ export class Api {
         user_id: number,
         score: number,
         other?: Other<
+            R,
             'setGameScore',
             'inline_message_id' | 'user_id' | 'score'
         >,

--- a/deno/src/core/api.ts
+++ b/deno/src/core/api.ts
@@ -10,7 +10,6 @@ import {
     InputMediaPhoto,
     InputMediaVideo,
     LabeledPrice,
-    Opts,
     PassportElementError,
 } from '../platform.ts'
 import {

--- a/deno/src/core/client.ts
+++ b/deno/src/core/client.ts
@@ -36,9 +36,9 @@ export type RawApi = {
 export type Payload<M extends Methods<R>, R extends RawApi> = R[M] extends (
     ...args: [Record<string, unknown>, ...unknown[]]
 ) => unknown
-    ? Parameters<R[M]>[0] extends undefined
+    ? Parameters<R[M]>[0] extends undefined // deno-lint-ignore ban-types
         ? {}
-        : NonNullable<Parameters<R[M]>[0]>
+        : NonNullable<Parameters<R[M]>[0]> // deno-lint-ignore ban-types
     : {}
 
 /**

--- a/deno/src/core/client.ts
+++ b/deno/src/core/client.ts
@@ -34,7 +34,7 @@ export type RawApi = {
 }
 
 export type Payload<M extends Methods<R>, R extends RawApi> = R[M] extends (
-    ...args: unknown[]
+    ...args: [Record<string, unknown>, ...unknown[]]
 ) => unknown
     ? Parameters<R[M]>[0] extends undefined
         ? {}

--- a/deno/src/mod.ts
+++ b/deno/src/mod.ts
@@ -34,3 +34,4 @@ export type {
     ApiClientOptions,
 } from './core/client.ts'
 export { GrammyError, HttpError } from './core/error.ts'
+

--- a/deno/src/mod.ts
+++ b/deno/src/mod.ts
@@ -34,4 +34,3 @@ export type {
     ApiClientOptions,
 } from './core/client.ts'
 export { GrammyError, HttpError } from './core/error.ts'
-

--- a/deno/src/platform.ts
+++ b/deno/src/platform.ts
@@ -3,10 +3,7 @@ const isDeno = typeof Deno !== 'undefined'
 // === Needed imports
 import { InputFileProxy } from 'https://cdn.skypack.dev/@grammyjs/types@v2.2.2?dts'
 import { basename } from 'https://deno.land/std@0.100.0/path/mod.ts'
-import {
-    iter,
-    readerFromIterable,
-} from 'https://deno.land/std@0.100.0/io/mod.ts'
+import { iter } from 'https://deno.land/std@0.100.0/io/mod.ts'
 
 // === Export all API types
 export * from 'https://cdn.skypack.dev/@grammyjs/types@v2.2.2?dts'
@@ -33,35 +30,6 @@ export const streamFile = isDeno
     : () => {
           throw new Error('Reading files by path requires a Deno environment')
       }
-export {
-    // Determine whether a file path is absolute
-    isAbsolute as isAbsolutePath,
-    // Turn a file path into a URL object
-    toFileUrl as pathToUrl,
-} from 'https://deno.land/std@0.100.0/path/mod.ts'
-// Turn a link into a URL object
-export const linkToUrl = (link: string) => new URL(link)
-// Define URL type
-export type URL = globalThis.URL
-// Create a temporary file
-export const createTempFile = () => Deno.makeTempFile()
-// Copy a file from a URL to a file path
-export const transferFile = async (url: URL, dest: string) => {
-    if (url.protocol === 'file') {
-        const src = url.pathname
-        await Deno.copyFile(src, dest)
-    } else {
-        const { body } = await fetch(url)
-        if (body === null) throw new Error('Download failed, no response body!')
-        const reader = readerFromIterable(body)
-        const writer = await Deno.open(dest, { write: true })
-        try {
-            await Deno.copy(reader, writer)
-        } finally {
-            writer.close()
-        }
-    }
-}
 
 // === Base configuration for `fetch` calls
 export const baseFetchConfig = {}

--- a/node-backport/package.json
+++ b/node-backport/package.json
@@ -16,7 +16,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@grammyjs/types": "^2.2.1",
+    "@grammyjs/types": "^2.2.2",
     "abort-controller": "^3.0.0",
     "debug": "^4.3.1",
     "node-fetch": "^2.6.1"

--- a/node-backport/platform.ts
+++ b/node-backport/platform.ts
@@ -1,24 +1,53 @@
+// === Needed imports
 import { InputFileProxy } from "@grammyjs/types";
 import { Agent } from "https";
 import { basename } from "path";
+import { URL } from "url";
 import { Readable } from "stream";
-import type { ReadStream } from "fs";
+import fs, { ReadStream } from "fs";
+import os from "os";
+import path from "path";
 
+// === Export all API types
 export * from "@grammyjs/types";
-export { debug } from "debug";
-// Turn a file path into an AsyncIterable<Uint8Array>
-export { createReadStream as streamFile } from "fs";
 
+// === Export debug
+export { debug } from "debug";
+
+// === Export system-specific operations
 // Turn an AsyncIterable<Uint8Array> into a stream
 export const itrToStream = (itr: AsyncIterable<Uint8Array>) =>
   Readable.from(itr, { objectMode: false });
+// Turn a file path into an AsyncIterable<Uint8Array>
+export { createReadStream as streamFile } from "fs";
+// Determine wether a file path is absolute
+export { isAbsolute as isAbsolutePath } from "path";
+export {
+  // Turn a file path into a URL object
+  pathToFileURL as pathToUrl,
+  // Define URL type
+  URL,
+} from "url";
+// Turn a link into a URL object
+export const linkToUrl = (link: string) => new URL(link);
+// Create a temporary file
+export const createTempFile = async () =>
+  path.join(
+    await fs.promises.mkdtemp(
+      (await fs.promises.realpath(os.tmpdir())) + path.sep
+    ),
+    "filedata"
+  );
+// Copy a file from a URL to a file path
+// TODO: implement transferFile
 
-// Base configuration for `fetch` calls
+// === Base configuration for `fetch` calls
 export const baseFetchConfig = {
   compress: true,
   agent: new Agent({ keepAlive: true }),
 };
 
+// === InputFile handling and File augmenting
 // Accessor for file data in `InputFile` instances
 export const inputFileData = Symbol("InputFile data");
 
@@ -56,17 +85,15 @@ export class InputFile {
   }
 }
 
-// CUSTOM INPUT FILE TYPES
-
+// === Export InputFile types
 type GrammyTypes = InputFileProxy<InputFile>;
 
 /** Wrapper type to bundle all methods of the Telegram API */
 export type Telegram = GrammyTypes["Telegram"];
 
 /** Utility type providing the argument type for the given method name or `{}` if the method does not take any parameters */
-export type Opts<
-  M extends keyof GrammyTypes["Telegram"]
-> = GrammyTypes["Opts"][M];
+export type Opts<M extends keyof GrammyTypes["Telegram"]> =
+  GrammyTypes["Opts"][M];
 
 /** This object represents the content of a media message to be sent. It should be one of
 - InputMediaAnimation

--- a/node-backport/platform.ts
+++ b/node-backport/platform.ts
@@ -2,11 +2,8 @@
 import { InputFileProxy } from "@grammyjs/types";
 import { Agent } from "https";
 import { basename } from "path";
-import { URL } from "url";
 import { Readable } from "stream";
-import fs, { ReadStream } from "fs";
-import os from "os";
-import path from "path";
+import type { ReadStream } from "fs";
 
 // === Export all API types
 export * from "@grammyjs/types";
@@ -20,26 +17,6 @@ export const itrToStream = (itr: AsyncIterable<Uint8Array>) =>
   Readable.from(itr, { objectMode: false });
 // Turn a file path into an AsyncIterable<Uint8Array>
 export { createReadStream as streamFile } from "fs";
-// Determine wether a file path is absolute
-export { isAbsolute as isAbsolutePath } from "path";
-export {
-  // Turn a file path into a URL object
-  pathToFileURL as pathToUrl,
-  // Define URL type
-  URL,
-} from "url";
-// Turn a link into a URL object
-export const linkToUrl = (link: string) => new URL(link);
-// Create a temporary file
-export const createTempFile = async () =>
-  path.join(
-    await fs.promises.mkdtemp(
-      (await fs.promises.realpath(os.tmpdir())) + path.sep
-    ),
-    "filedata"
-  );
-// Copy a file from a URL to a file path
-// TODO: implement transferFile
 
 // === Base configuration for `fetch` calls
 export const baseFetchConfig = {


### PR DESCRIPTION
Just as the context type can be adjusted, this PR introduces a type parameter for the API type.

It is used only for `bot.api` because `ctx.api` can already be adjusted via the context type. Also, we do not want to make a mess by having the context type depend on the API type.

This PR is required for a future implementation of a hydration plugin.

This PR is required by the code in the files plugin repository: https://github.com/grammyjs/files