### PR TITLE
Add support for Web File on Deno

### DIFF
--- a/deno/src/platform.ts
+++ b/deno/src/platform.ts
@@ -51,7 +51,7 @@ export class InputFile {
     private [internalInputFileData]: ConstructorParameters<typeof InputFile>[0]
     public get [inputFileData]() {
         const file = this[internalInputFileData]
-        return file instanceof File ? file.stream() : file
+        return file instanceof Blob ? file.stream() : file
     }
     /**
      * Optional name of the constructed `InputFile` instance.
@@ -73,7 +73,7 @@ export class InputFile {
             | Uint8Array
             | ReadableStream<Uint8Array>
             | AsyncIterable<Uint8Array>
-            | File,
+            | Blob,
         filename?: string
     ) {
         this[internalInputFileData] = file


### PR DESCRIPTION
Allows `File` objects to be passed to `InputFile` (on Deno only). The file will be streamed via `file.stream()`. The filename will be taken from the supplied file object. Retrying API calls is possible. This change is non-breaking.

@wojpawlik is this possible to port to Node, preferably without raising the minimum Node version?
If no, this will simply be merged, and Node users will not get support for web files.