### PR TITLE
Fix dep versions

### DIFF
--- a/deno/src/core/client.ts
+++ b/deno/src/core/client.ts
@@ -242,8 +242,7 @@ class ApiClient<R extends RawApi> {
                 }
                 throw new HttpError(msg, err)
             }
-            // deno-lint-ignore no-explicit-any
-            return (await res.json()) as any // node-fetch returns `unknown`
+            return await res.json()
         }
     }
 

--- a/node-backport/package.json
+++ b/node-backport/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@types/debug": "^4.1.7",
-    "@types/node": "^16.10.2",
+    "@types/node": "^12.20.27",
     "@types/node-fetch": "^2.5.12",
     "typescript": "^4.4.3"
   },

--- a/node-backport/package.json
+++ b/node-backport/package.json
@@ -19,7 +19,7 @@
     "@grammyjs/types": "^2.2.6",
     "abort-controller": "^3.0.0",
     "debug": "^4.3.2",
-    "node-fetch": "^3.0.0"
+    "node-fetch": "^2.6.1"
   },
   "devDependencies": {
     "@types/debug": "^4.1.7",

--- a/node-backport/package.json
+++ b/node-backport/package.json
@@ -19,13 +19,14 @@
     "@grammyjs/types": "^2.2.6",
     "abort-controller": "^3.0.0",
     "debug": "^4.3.2",
-    "node-fetch": "^3.0.0"
+    "node-fetch": "^2.6.1"
   },
   "devDependencies": {
     "@types/debug": "^4.1.7",
-    "@types/node": "^16.9.1",
-    "ts-morph": "^12.0.0",
-    "typescript": "4.4.3"
+    "@types/node": "^16.7.1",
+    "@types/node-fetch": "^2.5.12",
+    "ts-morph": "^11.0.3",
+    "typescript": "4.3.5"
   },
   "files": [
     "out/"

--- a/node-backport/package.json
+++ b/node-backport/package.json
@@ -19,14 +19,13 @@
     "@grammyjs/types": "^2.2.6",
     "abort-controller": "^3.0.0",
     "debug": "^4.3.2",
-    "node-fetch": "^2.6.1"
+    "node-fetch": "^2.6.5"
   },
   "devDependencies": {
     "@types/debug": "^4.1.7",
-    "@types/node": "^16.7.1",
+    "@types/node": "^16.10.2",
     "@types/node-fetch": "^2.5.12",
-    "ts-morph": "^11.0.3",
-    "typescript": "4.3.5"
+    "typescript": "^4.4.3"
   },
   "files": [
     "out/"

--- a/node-backport/package.json
+++ b/node-backport/package.json
@@ -19,7 +19,7 @@
     "@grammyjs/types": "^2.2.6",
     "abort-controller": "^3.0.0",
     "debug": "^4.3.2",
-    "node-fetch": "^2.6.1"
+    "node-fetch": "^3.0.0"
   },
   "devDependencies": {
     "@types/debug": "^4.1.7",


### PR DESCRIPTION
Downgrades to `node-fetch@2` in order to fix module resolution.

Downgrades to `@types/node@12` because that is the minimum requirement for grammY.

Updates all other dependencies to their latest versions.