### PR TITLE
Check API root for trailing slash

### DIFF
--- a/deno/src/core/client.ts
+++ b/deno/src/core/client.ts
@@ -206,6 +206,12 @@ class ApiClient<R extends RawApi> {
         private readonly webhookReplyEnvelope: WebhookReplyEnvelope = {}
     ) {
         this.options = { ...DEFAULT_OPTIONS, ...options }
+        if (this.options.apiRoot.endsWith('/'))
+            throw new Error(
+                `Remove the trailing '/' from the 'apiRoot' option! (Use '${this.options.apiRoot.substr(
+                    this.options.apiRoot.length - 1
+                )}' instead of '${this.options.apiRoot}'.)`
+            )
     }
 
     private call: ApiCallFn<R> = async (method, payload, signal) => {

--- a/deno/src/core/client.ts
+++ b/deno/src/core/client.ts
@@ -241,11 +241,10 @@ class ApiClient<R extends RawApi> {
                 })
             } catch (err) {
                 let msg = `Network request for '${method}' failed!`
-                if (isTelegramError(err)) {
+                if (isTelegramError(err))
                     msg += ` (${err.status}: ${err.statusText})`
-                } else if (this.options.sensitiveLogs && err instanceof Error) {
+                if (this.options.sensitiveLogs && err instanceof Error)
                     msg += ` ${err.message}`
-                }
                 throw new HttpError(msg, err)
             }
             return await res.json()


### PR DESCRIPTION
This will throw an error upon bot creation of the `client.apiRoot` option contains a trailing slash. The kind of configuration is hard to debug, because Telegram simply returns a 404.

This PR also gives away more info in case Telegram returns errors that are hard to understand. It does this by printing sensitive logs (if enabled) also in case the error is returned by Telegram.
