### PR TITLE
Worktop adapter

### DIFF
--- a/deno/src/convenience/webhook.ts
+++ b/deno/src/convenience/webhook.ts
@@ -16,6 +16,7 @@ type SupportedFrameworks =
     | 'koa'
     | 'oak'
     | 'fastify'
+    | 'worktop'
 
 /**
  * Abstraction over a request-response cycle, provding access to the update, as
@@ -72,6 +73,11 @@ const frameworkAdapters: Record<SupportedFrameworks, FrameworkAdapter> = {
         update: Promise.resolve(req.body),
         respond: json => reply.send(json),
     }),
+    worktop: (req, res) => ({
+        update: Promise.resolve(req.body.json()),
+        end: () => res.end(),
+        respond: json => res.send(200, json)
+    })
     // please open a PR if you want to add another
 }
 


### PR DESCRIPTION
[Worktop](https://github.com/lukeed/worktop) is a framework to write serverless workers on Cloudflare Workers.

As of the APIs:
* update's [`req.body.json()`](https://github.com/lukeed/worktop/blob/e3a44ba8cd34d7fa6849f98d4fb8dae37afdb404/src/request.ts#L27)
* end's [`res.end()`](https://github.com/lukeed/worktop/blob/master/src/response.d.ts#L26)
* respond's [`res.send()`](https://github.com/lukeed/worktop/blob/e3a44ba8cd34d7fa6849f98d4fb8dae37afdb404/src/response.d.ts#L28)