### PR TITLE
Improve error message for when undefined is passed as token

### DIFF
--- a/deno/src/bot.ts
+++ b/deno/src/bot.ts
@@ -174,7 +174,7 @@ export class Bot<
      */
     constructor(public readonly token: string, config?: BotConfig<C>) {
         super()
-        if (token.length === 0) throw new Error('Empty token!')
+        if (!token) throw new Error('Empty token!')
         this.me = config?.botInfo
         this.clientConfig = config?.client
         this.ContextConstructor =

--- a/deno/test/bot.test.ts
+++ b/deno/test/bot.test.ts
@@ -4,7 +4,7 @@ import {
     assertEquals,
 } from 'https://deno.land/std@0.97.0/testing/asserts.ts'
 
-function createBot(token = 'fake-token') {
+function createBot(token: string) {
     return new Bot(token)
 }
 
@@ -14,5 +14,6 @@ Deno.test('should take a token', () => {
 })
 
 Deno.test('should not take an empty token', () => {
+    assertThrows(() => createBot(undefined as unknown as string))
     assertThrows(() => createBot(''))
 })


### PR DESCRIPTION
Title says it all.

Also adds a test case for this.