### PR TITLE
Improve webhooks support for fastify

### DIFF
--- a/src/convenience/webhook.ts
+++ b/src/convenience/webhook.ts
@@ -71,6 +71,7 @@ const frameworkAdapters: Record<SupportedFrameworks, FrameworkAdapter> = {
     }),
     fastify: (req, reply) => ({
         update: Promise.resolve(req.body),
+        end: () => reply.send({}),
         respond: (json) => reply.send(json),
     }),
     worktop: (req, res) => ({


### PR DESCRIPTION
Current version of fastify is stuck on never ending request when using `webhookCallback` and the update is handled without an error and without a reply as well (which matters only when using webhook replies anyway).

This fixes that.

This problem happens on fastify v1 and v3 (latest versions for each major version). 
Fastify v2 works without the fix but the fix won't break it.
