### PR TITLE
Add `method` property to webhook reply response

### DIFF
--- a/src/core/payload.ts
+++ b/src/core/payload.ts
@@ -7,25 +7,13 @@ import {
 
 // === Payload types (JSON vs. form data)
 /**
- * Turns a payload into an options object that can be passed to a `fetch` call.
- * Automatically switches between JSON payloads and form-data payloads as
- * needed.
- *
- * @param payload The payload to use
- */
-export function createRequestConfig(payload: Record<string, unknown>) {
-    return requiresFormDataUpload(payload)
-        ? createFormDataPayload(payload)
-        : createJsonPayload(payload);
-}
-/**
  * Determines for a given payload if it may be sent as JSON, or if it has to be
  * uploaded via multipart/form-data. Returns `true` in the latter case and
  * `false` in the former.
  *
  * @param payload The payload to analyse
  */
-function requiresFormDataUpload(payload: unknown): boolean {
+export function requiresFormDataUpload(payload: unknown): boolean {
     return (
         typeof payload === "object" &&
         payload !== null &&
@@ -53,7 +41,7 @@ function str(value: unknown) {
  *
  * @param payload The payload to wrap
  */
-function createJsonPayload(payload: Record<string, unknown>) {
+export function createJsonPayload(payload: Record<string, unknown>) {
     return {
         method: "POST",
         headers: {
@@ -71,7 +59,7 @@ function createJsonPayload(payload: Record<string, unknown>) {
  *
  * @param payload The payload to wrap
  */
-function createFormDataPayload(payload: Record<string, unknown>) {
+export function createFormDataPayload(payload: Record<string, unknown>) {
     const boundary = createBoundary();
 
     return {


### PR DESCRIPTION
According to the [doc](https://core.telegram.org/bots/api#making-requests-when-getting-updates), when responding to webhook call, the `method` field must be specified in the json.