### PR TITLE
Fix: responsing via webhooks missed header.

### DIFF
--- a/src/convenience/webhook.ts
+++ b/src/convenience/webhook.ts
@@ -50,7 +50,10 @@ type FrameworkAdapter = (...args: any[]) => ReqResHandler;
 const standard: FrameworkAdapter = (req, res) => ({
     update: Promise.resolve(req.body),
     end: () => res.end(),
-    respond: (json) => res.send(json),
+    respond: (json) => {
+        res.set("Content-Type", "application/json");
+        res.send(json);
+    },
 });
 
 // Integrations with popular frameworks
@@ -61,7 +64,10 @@ const frameworkAdapters: Record<SupportedFrameworks, FrameworkAdapter> = {
     koa: (ctx) => ({
         update: Promise.resolve(ctx.request.body),
         end: () => (ctx.body = ""),
-        respond: (json) => (ctx.response.body = json),
+        respond: (json) => {
+            ctx.set("Content-Type", "application/json");
+            ctx.response.body = json;
+        },
     }),
     oak: (ctx) => ({
         update: ctx.request.body({ type: "json" }).value,


### PR DESCRIPTION
Telegram only processes methods returned as json to a webhook call if
the Content-Type header is set to "application/json".

This did not happen with express and koa, as grammy just wrote the json
stringified to the body instead of directly passing the json object,
causing the frameworks to not set the json Content-Type header.

This fix is only for express-like and koa frameworks, others might still
have this bug.

Fixes #69 