### PR TITLE
Catch throwing iterators

### DIFF
--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -221,7 +221,11 @@ class ApiClient<R extends RawApi> {
         }
     }
 
-    private call: ApiCallFn<R> = async (method, payload, signal) => {
+    private call: ApiCallFn<R> = async <M extends Methods<R>>(
+        method: M,
+        payload: Payload<M, R>,
+        signal?: AbortSignal,
+    ) => {
         debug("Calling", method);
         const url = this.options.buildUrl(
             this.options.apiRoot,
@@ -248,7 +252,7 @@ class ApiClient<R extends RawApi> {
                 ? () => abortController.abort()
                 : combineAborts(abortController, signal);
 
-            const res = await new Promise(
+            const res = await new Promise<ApiResponse<ApiCallResult<M, R>>>(
                 (resolve, reject) => {
                     function onStreamError(err: unknown) {
                         abort();

--- a/src/platform.deno.ts
+++ b/src/platform.deno.ts
@@ -3,7 +3,7 @@ const isDeno = typeof Deno !== "undefined";
 // === Needed imports
 import { InputFileProxy } from "https://cdn.skypack.dev/@grammyjs/types@v2.3.1?dts";
 import { basename } from "https://deno.land/std@0.113.0/path/mod.ts";
-import { iterateReader } from "https://deno.land/std@0.113.0/io/mod.ts";
+import { iterateReader } from "https://deno.land/std@0.113.0/streams/mod.ts";
 
 // === Export all API types
 export * from "https://cdn.skypack.dev/@grammyjs/types@v2.3.1?dts";
@@ -23,7 +23,7 @@ if (isDeno) {
 
 // === Export system-specific operations
 // Turn an AsyncIterable<Uint8Array> into a stream
-export { readableStreamFromIterable as itrToStream } from "https://deno.land/std@0.113.0/io/mod.ts";
+export { readableStreamFromIterable as itrToStream } from "https://deno.land/std@0.113.0/streams/mod.ts";
 // Turn a file path into an AsyncIterable<Uint8Array>
 export const streamFile = isDeno
     ? (path: string) => Deno.open(path).then(iterateReader)


### PR DESCRIPTION
If an iterator throws, the corresponding stream causes an unhandled promise rejection. This is an ugly specification, and this PR work around it by wrapping the iterator and cancelling the request upon error.

Closes #34.

Uses ideas from https://github.com/denoland/deno_std/issues/1214.