### PR TITLE
Support creating InputFile instances from URLs

### DIFF
--- a/src/platform.deno.ts
+++ b/src/platform.deno.ts
@@ -95,16 +95,7 @@ export class InputFile {
         if (
             typeof data === "object" && ("url" in data || data instanceof URL)
         ) {
-            data = (async function* () {
-                let url = data instanceof URL ? data : data.url;
-                const { body } = await fetch(url);
-                if (body === null) {
-                    throw new Error(
-                        `Download failed, no response body from '${url}'`,
-                    );
-                }
-                yield* body;
-            })();
+            data = fetchFile(data instanceof URL ? data : data.url);
         } else if (
             typeof data !== "string" && (!(data instanceof Uint8Array))
         ) {
@@ -112,6 +103,16 @@ export class InputFile {
         }
         return data;
     }
+}
+
+async function* fetchFile(url: string | URL): AsyncIterable<Uint8Array> {
+    const { body } = await fetch(url);
+    if (body === null) {
+        throw new Error(
+            `Download failed, no response body from '${url}'`,
+        );
+    }
+    yield* body;
 }
 
 // === Export InputFile types

--- a/src/platform.deno.ts
+++ b/src/platform.deno.ts
@@ -46,7 +46,8 @@ export const inputFileData = Symbol("InputFile data");
  * Reference](https://core.telegram.org/bots/api#inputfile).
  */
 export class InputFile {
-    public readonly [inputFileData]: ConstructorParameters<typeof InputFile>[0];
+    private consumed = false;
+    private readonly fileData: ConstructorParameters<typeof InputFile>[0];
     /**
      * Optional name of the constructed `InputFile` instance.
      *
@@ -69,11 +70,21 @@ export class InputFile {
             | AsyncIterable<Uint8Array>,
         filename?: string,
     ) {
-        this[inputFileData] = file;
+        this.fileData = file;
         if (filename === undefined && typeof file === "string") {
             filename = basename(file);
         }
         this.filename = filename;
+    }
+    get [inputFileData]() {
+        if (this.consumed) {
+            throw new Error("Cannot reuse InputFile data source!");
+        }
+        const data = this.fileData;
+        if (typeof data !== "string" && (!(data instanceof Uint8Array))) {
+            this.consumed = false;
+        }
+        return data;
     }
 }
 

--- a/src/platform.node.ts
+++ b/src/platform.node.ts
@@ -4,6 +4,7 @@ import { Agent } from "https";
 import { basename } from "path";
 import { Readable } from "stream";
 import type { ReadStream } from "fs";
+import { URL } from "url";
 
 // === Export all API types
 export * from "@grammyjs/types";
@@ -24,6 +25,14 @@ export const baseFetchConfig = {
     agent: new Agent({ keepAlive: true }),
 };
 
+/** Something that looks like a URL. */
+interface URLLike {
+    /**
+     * Identifier of the resouce. Must be in a format that can be parsed by the
+     * URL constructor.
+     */
+    url: string;
+}
 // === InputFile handling and File augmenting
 // Accessor for file data in `InputFile` instances
 export const inputFileData = Symbol("InputFile data");
@@ -53,7 +62,13 @@ export class InputFile {
      * @param filename Optional name of the file
      */
     constructor(
-        file: string | Uint8Array | ReadStream | AsyncIterable<Uint8Array>,
+        file:
+            | string
+            | URL
+            | URLLike
+            | Uint8Array
+            | ReadStream
+            | AsyncIterable<Uint8Array>,
         filename?: string,
     ) {
         this.fileData = file;
@@ -66,8 +81,23 @@ export class InputFile {
         if (this.consumed) {
             throw new Error("Cannot reuse InputFile data source!");
         }
-        const data = this.fileData;
-        if (typeof data !== "string" && (!(data instanceof Uint8Array))) {
+        let data = this.fileData;
+        if (
+            typeof data === "object" && ("url" in data || data instanceof URL)
+        ) {
+            data = (async function* () {
+                let url = data instanceof URL ? data : data.url;
+                const { body } = await fetch(url);
+                if (body === null) {
+                    throw new Error(
+                        `Download failed, no response body from '${url}'`,
+                    );
+                }
+                yield* body;
+            })();
+        } else if (
+            typeof data !== "string" && (!(data instanceof Uint8Array))
+        ) {
             this.consumed = false;
         }
         return data;

--- a/src/platform.node.ts
+++ b/src/platform.node.ts
@@ -105,7 +105,7 @@ async function* fetchFile(url: string | URL): AsyncIterable<Uint8Array> {
     for await (const chunk of body) {
         if (typeof chunk === "string") {
             throw new Error(
-                `Could not transfer file, received string data instead of bytes from ${url}`,
+                `Could not transfer file, received string data instead of bytes from '${url}'`,
             );
         }
         yield chunk;

--- a/src/platform.node.ts
+++ b/src/platform.node.ts
@@ -36,7 +36,8 @@ export const inputFileData = Symbol("InputFile data");
  * Reference](https://core.telegram.org/bots/api#inputfile).
  */
 export class InputFile {
-    public readonly [inputFileData]: ConstructorParameters<typeof InputFile>[0];
+    private consumed = false;
+    private readonly fileData: ConstructorParameters<typeof InputFile>[0];
     /**
      * Optional name of the constructed `InputFile` instance.
      *
@@ -55,11 +56,21 @@ export class InputFile {
         file: string | Uint8Array | ReadStream | AsyncIterable<Uint8Array>,
         filename?: string,
     ) {
-        this[inputFileData] = file;
+        this.fileData = file;
         if (filename === undefined && typeof file === "string") {
             filename = basename(file);
         }
         this.filename = filename;
+    }
+    get [inputFileData]() {
+        if (this.consumed) {
+            throw new Error("Cannot reuse InputFile data source!");
+        }
+        const data = this.fileData;
+        if (typeof data !== "string" && (!(data instanceof Uint8Array))) {
+            this.consumed = false;
+        }
+        return data;
     }
 }
 

--- a/src/platform.node.ts
+++ b/src/platform.node.ts
@@ -102,7 +102,14 @@ async function* fetchFile(url: string | URL): AsyncIterable<Uint8Array> {
             `Download failed, no response body from '${url}'`,
         );
     }
-    for await (const chunk of body) yield JSON.parse(chunk.toString());
+    for await (const chunk of body) {
+        if (typeof chunk === "string") {
+            throw new Error(
+                `Could not transfer file, received string data instead of bytes from ${url}`,
+            );
+        }
+        yield chunk;
+    }
 }
 
 // === Export InputFile types

--- a/src/platform.node.ts
+++ b/src/platform.node.ts
@@ -85,16 +85,7 @@ export class InputFile {
         if (
             typeof data === "object" && ("url" in data || data instanceof URL)
         ) {
-            data = (async function* () {
-                let url = data instanceof URL ? data : data.url;
-                const { body } = await fetch(url);
-                if (body === null) {
-                    throw new Error(
-                        `Download failed, no response body from '${url}'`,
-                    );
-                }
-                yield* body;
-            })();
+            data = fetchFile(data instanceof URL ? data : data.url);
         } else if (
             typeof data !== "string" && (!(data instanceof Uint8Array))
         ) {
@@ -102,6 +93,16 @@ export class InputFile {
         }
         return data;
     }
+}
+
+async function* fetchFile(url: string | URL): AsyncIterable<Uint8Array> {
+    const { body } = await fetch(url);
+    if (body === null) {
+        throw new Error(
+            `Download failed, no response body from '${url}'`,
+        );
+    }
+    for await (const chunk of body) yield JSON.parse(chunk.toString());
 }
 
 // === Export InputFile types


### PR DESCRIPTION
Adds the following syntax for constructing `InputFile`s based on remote data.

```ts
const url = 'https://raw.githubusercontent.com/grammyjs/website/main/logos/grammY.png'

// both work
new InputFile({ url })
new InputFile(new URL(url))
```

The data will be fetched lazily from the specified URL as soon as the `InputFile` is sent. The file contents are streamed, so only a small portion of the data is kept in memory at all times. When several files are sent in an album, they are piped though one by one, such that only a single outgoing request is open at all times.

Currently does not support more advanced configuration options. Note that it's already possible to do this:

```ts
const { body } = await fetch(url, opts)
if (body === null) throw new Error('No data')
const inputFile = new InputFile(body)
```

This allows you to pass any configuration to `fetch`.

Currently does not support caching files on disk. This is very hard to get right, and it is questionable if it has any advantages. Confer the discussion at #33 for more information about caching.

Based off of #77. Please review and merge #77 first.

Closes #33.

