### PR TITLE
Added missing pre, text_link, text_mention entity types to filters

### DIFF
--- a/src/filter.ts
+++ b/src/filter.ts
@@ -231,6 +231,9 @@ const ENTITY_KEYS = {
     underline: {},
     strikethrough: {},
     code: {},
+    pre: {},
+    text_link: {},
+    text_mention: {},
 } as const;
 const USER_KEYS = {
     me: {},


### PR DESCRIPTION
There was 3 message entity types missing (https://core.telegram.org/bots/api#messageentity) in src/filters.ts. `pre`, `text_link`, `text_mention`. Added those.