### PR TITLE
Support file uploads via Deno.open()

### DIFF
--- a/src/platform.deno.ts
+++ b/src/platform.deno.ts
@@ -69,6 +69,7 @@ export class InputFile {
     constructor(
         file:
             | string
+            | Blob
             | URL
             | URLLike
             | Uint8Array
@@ -87,7 +88,7 @@ export class InputFile {
             throw new Error("Cannot reuse InputFile data source!");
         }
         const data = this.fileData;
-        // Handle file paths
+        // Handle local files
         if (typeof data === "string") {
             if (!isDeno) {
                 throw new Error(
@@ -97,6 +98,7 @@ export class InputFile {
             const file = await Deno.open(data);
             return iterateReader(file);
         }
+        if (data instanceof Blob) return data.stream();
         // Handle URL and URLLike
         if (data instanceof URL) return fetchFile(data);
         if ("url" in data) return fetchFile(data.url);

--- a/src/platform.deno.ts
+++ b/src/platform.deno.ts
@@ -71,6 +71,7 @@ export class InputFile {
         file: MaybePromise<
             | string
             | Blob
+            | Deno.File
             | URL
             | URLLike
             | Uint8Array
@@ -101,6 +102,7 @@ export class InputFile {
             return iterateReader(file);
         }
         if (data instanceof Blob) return data.stream();
+        if (isDenoFile(data)) return iterateReader(data);
         // Handle URL and URLLike
         if (data instanceof URL) return fetchFile(data);
         if ("url" in data) return fetchFile(data.url);
@@ -119,6 +121,9 @@ async function* fetchFile(url: string | URL): AsyncIterable<Uint8Array> {
         );
     }
     yield* body;
+}
+function isDenoFile(data: unknown): data is Deno.File {
+    return isDeno && data instanceof Deno.File;
 }
 
 // === Export InputFile types

--- a/src/platform.deno.ts
+++ b/src/platform.deno.ts
@@ -41,6 +41,7 @@ interface URLLike {
 // === InputFile handling and File augmenting
 // Accessor for file data in `InputFile` instances
 export const toRaw = Symbol("InputFile data");
+type MaybePromise<T> = T | Promise<T>;
 
 /**
  * An `InputFile` wraps a number of different sources for [sending
@@ -67,14 +68,15 @@ export class InputFile {
      * @param filename Optional name of the file
      */
     constructor(
-        file:
+        file: MaybePromise<
             | string
             | Blob
             | URL
             | URLLike
             | Uint8Array
             | ReadableStream<Uint8Array>
-            | AsyncIterable<Uint8Array>,
+            | AsyncIterable<Uint8Array>
+        >,
         filename?: string,
     ) {
         this.fileData = file;
@@ -87,7 +89,7 @@ export class InputFile {
         if (this.consumed) {
             throw new Error("Cannot reuse InputFile data source!");
         }
-        const data = this.fileData;
+        const data = await this.fileData;
         // Handle local files
         if (typeof data === "string") {
             if (!isDeno) {

--- a/src/platform.node.ts
+++ b/src/platform.node.ts
@@ -35,6 +35,7 @@ interface URLLike {
 // === InputFile handling and File augmenting
 // Accessor for file data in `InputFile` instances
 export const toRaw = Symbol("InputFile data");
+type MaybePromise<T> = T | Promise<T>;
 
 /**
  * An `InputFile` wraps a number of different sources for [sending
@@ -61,13 +62,14 @@ export class InputFile {
      * @param filename Optional name of the file
      */
     constructor(
-        file:
+        file: MaybePromise<
             | string
             | URL
             | URLLike
             | Uint8Array
             | ReadStream
-            | AsyncIterable<Uint8Array>,
+            | AsyncIterable<Uint8Array>
+        >,
         filename?: string,
     ) {
         this.fileData = file;
@@ -80,7 +82,7 @@ export class InputFile {
         if (this.consumed) {
             throw new Error("Cannot reuse InputFile data source!");
         }
-        const data = this.fileData;
+        const data = await this.fileData;
         // Handle file paths, URLs, and URLLike objects
         if (typeof data === "string") return createReadStream(data);
         if (data instanceof URL) return fetchFile(data);


### PR DESCRIPTION
Adds support for `Blob` under Deno.

Adds support for `Deno.File` under Deno. This allows for:
```ts
new InputFile(await Deno.open('/path/to/file'))
```

Also adds support for passing a `Promise` of any value under both Deno and Node.js. This allows for:
```ts
new InputFile(Deno.open('/path/to/file'))
```
under Deno, as well as
```ts
import { promises as fs } from "fs";
new InputFile(fs.readFile("asdf"));
```
under Node.

Note that this change will be integrated into #77 in order to prevent conflicts.