### PR TITLE
Allow session to work with callbackQuery and inlineQuery

### DIFF
--- a/src/convenience/session.ts
+++ b/src/convenience/session.ts
@@ -315,7 +315,10 @@ export function lazySession<S, C extends Context>(
 }
 
 function defaultGetSessionKey(ctx: Context): string | undefined {
-    return ctx.chat?.id.toString();
+    const chatInstance = ctx.chat?.id ??
+        ctx.callbackQuery?.chat_instance ??
+        ctx.from.id;
+    return chatInstance?.toString();
 }
 
 /**

--- a/src/convenience/session.ts
+++ b/src/convenience/session.ts
@@ -317,7 +317,7 @@ export function lazySession<S, C extends Context>(
 function defaultGetSessionKey(ctx: Context): string | undefined {
     const chatInstance = ctx.chat?.id ??
         ctx.callbackQuery?.chat_instance ??
-        ctx.from.id;
+        ctx.from?.id;
     return chatInstance?.toString();
 }
 


### PR DESCRIPTION
When using the session on inline queries or on inline buttons sent from inline queries the `defaultGetSessionKey` was useless and errored: `Cannot access session data because the session key was undefined!`

With this change both `inlineQuery` (which has `from`) and `callbackQuery` (which has either `chat` or `chat_instance`) work out of the box.
