### PR TITLE
Improved building config of ApiClient

### DIFF
--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -206,8 +206,10 @@ class ApiClient<R extends RawApi> {
             apiRoot,
             buildUrl: options.buildUrl ??
                 ((root, token, method) => `${root}/bot${token}/${method}`),
-            baseFetchConfig: options.baseFetchConfig ??
-                baseFetchConfig(apiRoot),
+            baseFetchConfig: {
+                ...baseFetchConfig(apiRoot),
+                ...options.baseFetchConfig,
+            },
             canUseWebhookReply: options.canUseWebhookReply ?? (() => false),
             sensitiveLogs: options.sensitiveLogs ?? false,
         };


### PR DESCRIPTION
This little change allows user to control `compress` property (as well as the other possible options) without need to manually specify `agent`. In example I want to disable compression (it's enabled by default for `https` apiRoot) with default bot API server. With this change I can use:

```javascript
const bot = new Bot(TOKEN, {
  client: {
    baseFetchConfig: {
      compress: false,
    },
  },
});
```

instead of:

```javascript
import { Agent as HttpsAgent } from "https";

const bot = new Bot(TOKEN, {
  client: {
    baseFetchConfig: {
      compress: false,
      agent: new HttpsAgent({ keepAlive: true })
    },
  },
});
```

Or when I want compression with local bot api server (it's disabled by default for http) I can use:

```javascript
const bot = new Bot(TOKEN, {
  client: {
    apiRoot: "http://local.server.lan:12345/",
    baseFetchConfig: {
      compress: false,
    },
  },
});
```

instead of:

```javascript
import { Agent as HttpAgent } from "http";

const bot = new Bot(TOKEN, {
  client: {
    apiRoot: "http://local.server.lan:12345/",
    baseFetchConfig: {
      compress: true,
      agent: new HttpAgent({ keepAlive: true })
    },
  },
});
```

I see no negative impacts of this change.