### PR TITLE
Support synchronous iterables

### DIFF
--- a/src/platform.deno.ts
+++ b/src/platform.deno.ts
@@ -76,6 +76,7 @@ export class InputFile {
             | URLLike
             | Uint8Array
             | ReadableStream<Uint8Array>
+            | Iterable<Uint8Array>
             | AsyncIterable<Uint8Array>,
         filename?: string,
     ) {
@@ -100,7 +101,9 @@ export class InputFile {
         if (!(file instanceof URL)) return undefined;
         return basename(file.pathname) || basename(file.hostname);
     }
-    async [toRaw](): Promise<Uint8Array | AsyncIterable<Uint8Array>> {
+    async [toRaw](): Promise<
+        Uint8Array | Iterable<Uint8Array> | AsyncIterable<Uint8Array>
+    > {
         if (this.consumed) {
             throw new Error("Cannot reuse InputFile data source!");
         }

--- a/src/platform.node.ts
+++ b/src/platform.node.ts
@@ -74,6 +74,7 @@ export class InputFile {
             | URLLike
             | Uint8Array
             | ReadStream
+            | Iterable<Uint8Array>
             | AsyncIterable<Uint8Array>,
         filename?: string,
     ) {
@@ -98,7 +99,7 @@ export class InputFile {
         if (!(file instanceof URL)) return undefined;
         return basename(file.pathname) || basename(file.hostname);
     }
-    [toRaw](): Uint8Array | AsyncIterable<Uint8Array> {
+    [toRaw](): Uint8Array | Iterable<Uint8Array> | AsyncIterable<Uint8Array> {
         if (this.consumed) {
             throw new Error("Cannot reuse InputFile data source!");
         }


### PR DESCRIPTION
This is already working, all we need to do is to permit it in the type annotations.

What's more, we're already expecting this to work in the docs: https://grammy.dev/guide/files.html#uploading-your-own-files