### PR TITLE
`ctx.match` cannot be `null`

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -74,7 +74,7 @@ export class Context implements RenamedUpdate {
      * Used by some middleware to store information about how a certain string
      * or regular expression was matched.
      */
-    public match?: string | RegExpMatchArray | null;
+    public match?: string | RegExpMatchArray;
 
     constructor(
         /**


### PR DESCRIPTION
If there is not match, then `ctx.match` will be `undefined`. If a match is found, it will be either a string or a match array. Either way, `null` is not a possible type.

This PR removes `null` from the `ctx.match` type.

Follow-up for #81, see https://github.com/grammyjs/grammY/pull/81#discussion_r744256477