### PR TITLE
Add support for Bot API 5.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ _<h2 align="center"> [:mag: Documentation](https://grammy.dev) | [:page_with_cur
 
 <!-- deno-fmt-ignore-start -->
 
-[![Bot API](https://img.shields.io/badge/Bot%20API-5.4-blue?logo=telegram&style=flat-square)](https://core.telegram.org/bots/api)
+[![Bot API](https://img.shields.io/badge/Bot%20API-5.5-blue?logo=telegram&style=flat-square)](https://core.telegram.org/bots/api)
 [![npm](https://img.shields.io/npm/v/grammy?logo=npm&style=flat-square)](https://www.npmjs.org/package/grammy) <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-44-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "contribs": "all-contributors"
     },
     "dependencies": {
-        "@grammyjs/types": "^2.3.1",
+        "@grammyjs/types": "^2.4.0",
         "abort-controller": "^3.0.0",
         "debug": "^4.3.3",
         "node-fetch": "^2.6.5"

--- a/src/context.ts
+++ b/src/context.ts
@@ -957,7 +957,7 @@ export class Context implements RenamedUpdate {
      */
     banChatSenderChat(
         sender_chat_id: number,
-        other?: Other<"banChatSenderChat", "user_id">,
+        other?: Other<"banChatSenderChat", "sender_chat_id">,
         signal?: AbortSignal,
     ) {
         return this.api.banChatSenderChat(

--- a/src/context.ts
+++ b/src/context.ts
@@ -950,17 +950,20 @@ export class Context implements RenamedUpdate {
      * Context-aware alias for `api.banChatSenderChat`. Use this method to ban a channel chat in a supergroup or a channel. The owner of the chat will not be able to send messages and join live streams on behalf of the chat, unless it is unbanned first. The bot must be an administrator in the supergroup or channel for this to work and must have the appropriate administrator rights. Returns True on success.
      *
      * @param sender_chat_id Unique identifier of the target sender chat
+     * @param other Optional remaining parameters, confer the official reference below
      * @param signal Optional `AbortSignal` to cancel the request
      *
      * **Official reference:** https://core.telegram.org/bots/api#banchatsenderchat
      */
     banChatSenderChat(
         sender_chat_id: number,
+        other?: Other<"promoteChatMember", "user_id">,
         signal?: AbortSignal,
     ) {
         return this.api.banChatSenderChat(
             orThrow(this.chat, "banChatSenderChat").id,
             sender_chat_id,
+            other,
             signal,
         );
     }

--- a/src/context.ts
+++ b/src/context.ts
@@ -957,7 +957,7 @@ export class Context implements RenamedUpdate {
      */
     banChatSenderChat(
         sender_chat_id: number,
-        other?: Other<"promoteChatMember", "user_id">,
+        other?: Other<"banChatSenderChat", "user_id">,
         signal?: AbortSignal,
     ) {
         return this.api.banChatSenderChat(

--- a/src/context.ts
+++ b/src/context.ts
@@ -947,6 +947,44 @@ export class Context implements RenamedUpdate {
     }
 
     /**
+     * Context-aware alias for `api.banChatSenderChat`. Use this method to ban a channel chat in a supergroup or a channel. The owner of the chat will not be able to send messages and join live streams on behalf of the chat, unless it is unbanned first. The bot must be an administrator in the supergroup or channel for this to work and must have the appropriate administrator rights. Returns True on success.
+     *
+     * @param sender_chat_id Unique identifier of the target sender chat
+     * @param signal Optional `AbortSignal` to cancel the request
+     *
+     * **Official reference:** https://core.telegram.org/bots/api#banchatsenderchat
+     */
+    banChatSenderChat(
+        sender_chat_id: number,
+        signal?: AbortSignal,
+    ) {
+        return this.api.banChatSenderChat(
+            orThrow(this.chat, "banChatSenderChat").id,
+            sender_chat_id,
+            signal,
+        );
+    }
+
+    /**
+     * Context-aware alias for `api.unbanChatSenderChat`. Use this method to unban a previously banned channel chat in a supergroup or channel. The bot must be an administrator for this to work and must have the appropriate administrator rights. Returns True on success.
+     *
+     * @param sender_chat_id Unique identifier of the target sender chat
+     * @param signal Optional `AbortSignal` to cancel the request
+     *
+     * **Official reference:** https://core.telegram.org/bots/api#unbanchatsenderchat
+     */
+    unbanChatSenderChat(
+        sender_chat_id: number,
+        signal?: AbortSignal,
+    ) {
+        return this.api.unbanChatSenderChat(
+            orThrow(this.chat, "unbanChatSenderChat").id,
+            sender_chat_id,
+            signal,
+        );
+    }
+
+    /**
      * Context-aware alias for `api.setChatPermissions`. Use this method to set default chat permissions for all members. The bot must be an administrator in the group or a supergroup for this to work and must have the can_restrict_members administrator rights. Returns True on success.
      *
      * @param permissions New default chat permissions

--- a/src/convenience/keyboard.ts
+++ b/src/convenience/keyboard.ts
@@ -168,7 +168,7 @@ export class InlineKeyboard {
      * the button is pressed.
      *
      * @param text The text to display
-     * @param url HTTP or tg:// url to be opened when button is pressed
+     * @param url HTTP or tg:// url to be opened when the button is pressed. Links tg://user?id=<user_id> can be used to mention a user by their ID without using a username, if this is allowed by their privacy settings.
      */
     url(text: string, url: string) {
         return this.add({ text, url });
@@ -258,7 +258,7 @@ export class InlineKeyboard {
     /**
      * Adds a new payment button, confer https://core.telegram.org/bots/api#payments
      *
-     * This type of button must always be the first button in the first row.
+     * This type of button must always be the first button in the first row and can only be used in invoice messages.
      *
      * @param text The text to display
      */

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -242,12 +242,7 @@ export class Api<R extends RawApi = RawApi> {
         signal?: AbortSignal,
     ) {
         return this.raw.forwardMessage(
-            {
-                chat_id,
-                from_chat_id,
-                message_id,
-                ...other,
-            },
+            { chat_id, from_chat_id, message_id, ...other },
             signal,
         );
     }
@@ -271,12 +266,7 @@ export class Api<R extends RawApi = RawApi> {
         signal?: AbortSignal,
     ) {
         return this.raw.copyMessage(
-            {
-                chat_id,
-                from_chat_id,
-                message_id,
-                ...other,
-            },
+            { chat_id, from_chat_id, message_id, ...other },
             signal,
         );
     }
@@ -493,13 +483,7 @@ export class Api<R extends RawApi = RawApi> {
         signal?: AbortSignal,
     ) {
         return this.raw.editMessageLiveLocation(
-            {
-                chat_id,
-                message_id,
-                latitude,
-                longitude,
-                ...other,
-            },
+            { chat_id, message_id, latitude, longitude, ...other },
             signal,
         );
     }
@@ -527,12 +511,7 @@ export class Api<R extends RawApi = RawApi> {
         signal?: AbortSignal,
     ) {
         return this.raw.editMessageLiveLocation(
-            {
-                inline_message_id,
-                latitude,
-                longitude,
-                ...other,
-            },
+            { inline_message_id, latitude, longitude, ...other },
             signal,
         );
     }
@@ -558,11 +537,7 @@ export class Api<R extends RawApi = RawApi> {
         signal?: AbortSignal,
     ) {
         return this.raw.stopMessageLiveLocation(
-            {
-                chat_id,
-                message_id,
-                ...other,
-            },
+            { chat_id, message_id, ...other },
             signal,
         );
     }
@@ -618,14 +593,7 @@ export class Api<R extends RawApi = RawApi> {
         signal?: AbortSignal,
     ) {
         return this.raw.sendVenue(
-            {
-                chat_id,
-                latitude,
-                longitude,
-                title,
-                address,
-                ...other,
-            },
+            { chat_id, latitude, longitude, title, address, ...other },
             signal,
         );
     }
@@ -649,12 +617,7 @@ export class Api<R extends RawApi = RawApi> {
         signal?: AbortSignal,
     ) {
         return this.raw.sendContact(
-            {
-                chat_id,
-                phone_number,
-                first_name,
-                ...other,
-            },
+            { chat_id, phone_number, first_name, ...other },
             signal,
         );
     }
@@ -826,12 +789,7 @@ export class Api<R extends RawApi = RawApi> {
         signal?: AbortSignal,
     ) {
         return this.raw.restrictChatMember(
-            {
-                chat_id,
-                user_id,
-                permissions,
-                ...other,
-            },
+            { chat_id, user_id, permissions, ...other },
             signal,
         );
     }
@@ -875,11 +833,7 @@ export class Api<R extends RawApi = RawApi> {
         signal?: AbortSignal,
     ) {
         return this.raw.setChatAdministratorCustomTitle(
-            {
-                chat_id,
-                user_id,
-                custom_title,
-            },
+            { chat_id, user_id, custom_title },
             signal,
         );
     }
@@ -1247,10 +1201,7 @@ export class Api<R extends RawApi = RawApi> {
         signal?: AbortSignal,
     ) {
         return this.raw.setChatStickerSet(
-            {
-                chat_id,
-                sticker_set_name,
-            },
+            { chat_id, sticker_set_name },
             signal,
         );
     }
@@ -1439,12 +1390,7 @@ export class Api<R extends RawApi = RawApi> {
         signal?: AbortSignal,
     ) {
         return this.raw.editMessageMedia(
-            {
-                chat_id,
-                message_id,
-                media,
-                ...other,
-            },
+            { chat_id, message_id, media, ...other },
             signal,
         );
     }
@@ -1488,11 +1434,7 @@ export class Api<R extends RawApi = RawApi> {
         signal?: AbortSignal,
     ) {
         return this.raw.editMessageReplyMarkup(
-            {
-                chat_id,
-                message_id,
-                ...other,
-            },
+            { chat_id, message_id, ...other },
             signal,
         );
     }
@@ -1634,13 +1576,7 @@ export class Api<R extends RawApi = RawApi> {
         signal?: AbortSignal,
     ) {
         return this.raw.createNewStickerSet(
-            {
-                user_id,
-                name,
-                title,
-                emojis,
-                ...other,
-            },
+            { user_id, name, title, emojis, ...other },
             signal,
         );
     }
@@ -1737,11 +1673,7 @@ export class Api<R extends RawApi = RawApi> {
         signal?: AbortSignal,
     ) {
         return this.raw.answerInlineQuery(
-            {
-                inline_query_id,
-                results,
-                ...other,
-            },
+            { inline_query_id, results, ...other },
             signal,
         );
     }
@@ -1840,11 +1772,7 @@ export class Api<R extends RawApi = RawApi> {
         signal?: AbortSignal,
     ) {
         return this.raw.answerPreCheckoutQuery(
-            {
-                pre_checkout_query_id,
-                ok,
-                ...other,
-            },
+            { pre_checkout_query_id, ok, ...other },
             signal,
         );
     }
@@ -1911,13 +1839,7 @@ export class Api<R extends RawApi = RawApi> {
         signal?: AbortSignal,
     ) {
         return this.raw.setGameScore(
-            {
-                chat_id,
-                message_id,
-                user_id,
-                score,
-                ...other,
-            },
+            { chat_id, message_id, user_id, score, ...other },
             signal,
         );
     }
@@ -1945,12 +1867,7 @@ export class Api<R extends RawApi = RawApi> {
         signal?: AbortSignal,
     ) {
         return this.raw.setGameScore(
-            {
-                inline_message_id,
-                user_id,
-                score,
-                ...other,
-            },
+            { inline_message_id, user_id, score, ...other },
             signal,
         );
     }
@@ -1974,11 +1891,7 @@ export class Api<R extends RawApi = RawApi> {
         signal?: AbortSignal,
     ) {
         return this.raw.getGameHighScores(
-            {
-                chat_id,
-                message_id,
-                user_id,
-            },
+            { chat_id, message_id, user_id },
             signal,
         );
     }
@@ -2000,10 +1913,7 @@ export class Api<R extends RawApi = RawApi> {
         signal?: AbortSignal,
     ) {
         return this.raw.getGameHighScores(
-            {
-                inline_message_id,
-                user_id,
-            },
+            { inline_message_id, user_id },
             signal,
         );
     }

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -885,6 +885,43 @@ export class Api<R extends RawApi = RawApi> {
     }
 
     /**
+     * Use this method to ban a channel chat in a supergroup or a channel. The owner of the chat will not be able to send messages and join live streams on behalf of the chat, unless it is unbanned first. The bot must be an administrator in the supergroup or channel for this to work and must have the appropriate administrator rights. Returns True on success.
+     *
+     * @param chat_id Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+     * @param sender_chat_id Unique identifier of the target sender chat
+     * @param signal Optional `AbortSignal` to cancel the request
+     *
+     * **Official reference:** https://core.telegram.org/bots/api#banchatsenderchat
+     */
+    banChatSenderChat(
+        chat_id: number | string,
+        sender_chat_id: number,
+        signal?: AbortSignal,
+    ) {
+        return this.raw.banChatSenderChat({ chat_id, sender_chat_id }, signal);
+    }
+
+    /**
+     * Use this method to unban a previously banned channel chat in a supergroup or channel. The bot must be an administrator for this to work and must have the appropriate administrator rights. Returns True on success.
+     *
+     * @param chat_id Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+     * @param sender_chat_id Unique identifier of the target sender chat
+     * @param signal Optional `AbortSignal` to cancel the request
+     *
+     * **Official reference:** https://core.telegram.org/bots/api#unbanchatsenderchat
+     */
+    unbanChatSenderChat(
+        chat_id: number | string,
+        sender_chat_id: number,
+        signal?: AbortSignal,
+    ) {
+        return this.raw.unbanChatSenderChat(
+            { chat_id, sender_chat_id },
+            signal,
+        );
+    }
+
+    /**
      * Use this method to set default chat permissions for all members. The bot must be an administrator in the group or a supergroup for this to work and must have the can_restrict_members administrator rights. Returns True on success.
      *
      * @param chat_id Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -889,6 +889,7 @@ export class Api<R extends RawApi = RawApi> {
      *
      * @param chat_id Unique identifier for the target chat or username of the target channel (in the format @channelusername)
      * @param sender_chat_id Unique identifier of the target sender chat
+     * @param other Optional remaining parameters, confer the official reference below
      * @param signal Optional `AbortSignal` to cancel the request
      *
      * **Official reference:** https://core.telegram.org/bots/api#banchatsenderchat
@@ -896,9 +897,13 @@ export class Api<R extends RawApi = RawApi> {
     banChatSenderChat(
         chat_id: number | string,
         sender_chat_id: number,
+        other?: Other<R, "banChatSenderChat", "sender_chat_id">,
         signal?: AbortSignal,
     ) {
-        return this.raw.banChatSenderChat({ chat_id, sender_chat_id }, signal);
+        return this.raw.banChatSenderChat(
+            { chat_id, sender_chat_id, ...other },
+            signal,
+        );
     }
 
     /**

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -280,6 +280,7 @@ const COMMON_MESSAGE_KEYS = {
     voice_chat_participants_invited: {},
 
     forward_date: {},
+    is_automatic_forward: {},
 } as const;
 const MESSAGE_KEYS = {
     ...COMMON_MESSAGE_KEYS,

--- a/src/platform.deno.ts
+++ b/src/platform.deno.ts
@@ -2,12 +2,12 @@
 const isDeno = typeof Deno !== "undefined";
 
 // === Needed imports
-import { InputFileProxy } from "https://cdn.skypack.dev/@grammyjs/types@v2.3.1?dts";
+import { InputFileProxy } from "https://cdn.skypack.dev/@grammyjs/types@v2.4.0?dts";
 import { basename } from "https://deno.land/std@0.116.0/path/mod.ts";
 import { iterateReader } from "https://deno.land/std@0.116.0/streams/mod.ts";
 
 // === Export all API types
-export * from "https://cdn.skypack.dev/@grammyjs/types@v2.3.1?dts";
+export * from "https://cdn.skypack.dev/@grammyjs/types@v2.4.0?dts";
 
 // === Export debug
 import d from "https://cdn.skypack.dev/debug@^4.3.3";


### PR DESCRIPTION
Adds support for Bot API 5.5.

The only _interesting_ grammy-specific change is that we can now do:
```ts
bot.on('message:is_automatic_forward')
```
and it will trigger for all messages in a group that were posted in the attached channel.