### PR TITLE
Fix throwing error upon `bot.stop()`

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -425,14 +425,10 @@ you can circumvent this protection against memory leaks.`);
     async stop() {
         if (this.pollingRunning) {
             debug("Stopping bot, saving update offset");
-            debug("+++++++++++++++++++++ aborting ");
             this.pollingAbortController?.abort();
             this.pollingRunning = false;
-            debug("+++++++++++++++++++++ incrementing ");
             const offset = this.lastTriedUpdateId + 1;
-            debug("+++++++++++++++++++++ syncing offset ");
             await this.api.getUpdates({ offset, limit: 1 });
-            debug("+++++++++++++++++++++ clearing ");
             this.pollingAbortController = undefined;
         } else {
             debug("Bot is not running!");

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -377,7 +377,8 @@ you can circumvent this protection against memory leaks.`);
                         this.pollingAbortController.signal,
                     );
                 } catch (error) {
-                    await handleErr(error);
+                    if (this.pollingRunning) await handleErr(error);
+                    else debug("Pending `getUpdates` request cancelled");
                 }
             } while (updates === undefined && this.pollingRunning);
             if (updates === undefined) break;
@@ -424,10 +425,14 @@ you can circumvent this protection against memory leaks.`);
     async stop() {
         if (this.pollingRunning) {
             debug("Stopping bot, saving update offset");
-            this.pollingRunning = false;
+            debug("+++++++++++++++++++++ aborting ");
             this.pollingAbortController?.abort();
+            this.pollingRunning = false;
+            debug("+++++++++++++++++++++ incrementing ");
             const offset = this.lastTriedUpdateId + 1;
+            debug("+++++++++++++++++++++ syncing offset ");
             await this.api.getUpdates({ offset, limit: 1 });
+            debug("+++++++++++++++++++++ clearing ");
             this.pollingAbortController = undefined;
         } else {
             debug("Bot is not running!");

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -425,8 +425,8 @@ you can circumvent this protection against memory leaks.`);
     async stop() {
         if (this.pollingRunning) {
             debug("Stopping bot, saving update offset");
-            this.pollingAbortController?.abort();
             this.pollingRunning = false;
+            this.pollingAbortController?.abort();
             const offset = this.lastTriedUpdateId + 1;
             await this.api.getUpdates({ offset, limit: 1 });
             this.pollingAbortController = undefined;

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -362,7 +362,7 @@ you can circumvent this protection against memory leaks.`);
                     throw error;
                 }
             } else debugErr(error);
-            debugErr("Call to `getUpdates` failed, retrying in 3 seconds ...");
+            debugErr("Call to getUpdates failed, retrying in 3 seconds ...");
             await new Promise((r) => setTimeout(r, 3000));
         };
 
@@ -378,7 +378,7 @@ you can circumvent this protection against memory leaks.`);
                     );
                 } catch (error) {
                     if (this.pollingRunning) await handleErr(error);
-                    else debug("Pending `getUpdates` request cancelled");
+                    else debug("Pending getUpdates request cancelled");
                 }
             } while (updates === undefined && this.pollingRunning);
             if (updates === undefined) break;

--- a/src/convenience/session.ts
+++ b/src/convenience/session.ts
@@ -358,6 +358,17 @@ export class MemorySessionStorage<S> implements StorageAdapter<S> {
         return value.session;
     }
 
+    /**
+     * Reads the values for all keys of the session storage, and returns them as
+     * an array.
+     */
+    readAll() {
+        return Array
+            .from(this.storage.keys())
+            .map((key) => this.read(key))
+            .filter((value): value is S => value !== undefined);
+    }
+
     write(key: string, value: S) {
         this.storage.set(key, this.addExpiryDate(value));
     }

--- a/src/convenience/session.ts
+++ b/src/convenience/session.ts
@@ -358,17 +358,6 @@ export class MemorySessionStorage<S> implements StorageAdapter<S> {
         return value.session;
     }
 
-    /**
-     * Reads the values for all keys of the session storage, and returns them as
-     * an array.
-     */
-    readAll() {
-        return Array
-            .from(this.storage.keys())
-            .map((key) => this.read(key))
-            .filter((value): value is S => value !== undefined);
-    }
-
     write(key: string, value: S) {
         this.storage.set(key, this.addExpiryDate(value));
     }


### PR DESCRIPTION
Fixes errors reported in https://t.me/grammyjs/16197 and https://t.me/grammyjs/28217, namely that `bot.stop()` caused the built-in polling to throw an error.