### PR TITLE
Fix error for command with a leading slash

### DIFF
--- a/src/composer.ts
+++ b/src/composer.ts
@@ -384,10 +384,7 @@ export class Composer<C extends Context> implements MiddlewareObj<C> {
             if (cmd.startsWith("/")) {
                 throw new Error(
                     `Do not include '/' when registering command handlers (use '${
-                        cmd.substr(
-                            0,
-                            1,
-                        )
+                        cmd.substr(1)
                     }' not '${cmd}')`,
                 );
             }


### PR DESCRIPTION
With `composer.command('/start')`, the expected error message is:
```Do not include '/' when registering command handlers (use 'start' not '/start')```
but instead I received
```Do not include '/' when registering command handlers (use '/' not '/start')```