### PR TITLE
Skip typechecks while bundling old versions

### DIFF
--- a/bundling/bundle-all.sh
+++ b/bundling/bundle-all.sh
@@ -17,7 +17,7 @@ echo "Caching and bundling releases using $cores cores"
 curl --silent https://cdn.deno.land/grammy/meta/versions.json |
     jq --raw-output '.versions | .[] | select(startswith("v1"))' |
     xargs -P$cores -I% bash -c \
-        'deno cache --quiet https://deno.land/x/grammy@%/mod.ts &&
+        'deno cache --quiet --no-check https://deno.land/x/grammy@%/mod.ts &&
             echo "Cached %" &&
             deno run --unstable --allow-net --allow-write=bundles/ bundle-es.ts %'
 echo 'Done.'


### PR DESCRIPTION
When Deno (and thus TS) upgrades, this can make already released versions stop compiling. That just happened with TS 4.5. Such a case breaks our bundling script. This PR applies `--no-check` to all bundling operations, and it does so with the following reasons:
- All versions typecheck when released. This is enough safety.
- Bundles do not contain types, and since tsc transpilation JS output is stable over versions due to regression tests, we can safely ignore the types in the code.
- It takes a lot of time to check the same stuff over and over again, which slows down CI by a large factor.
- Bundling is broken and there are no other solutions that take this little effort and work that well.