### PR TITLE
Remove broken ES3 and ES5 bundles

### DIFF
--- a/bundling/bundle-es.ts
+++ b/bundling/bundle-es.ts
@@ -7,7 +7,7 @@ const bundled = await Deno.emit(source, { bundle: "module" });
 const bundledCode = bundled.files["deno:///bundle.js"];
 console.log("Bundled", release);
 // Transpile code
-for (const target of ["es3", "es5", "es6", "esnext"] as const) {
+for (const target of ["es6", "esnext"] as const) {
     const transpiled = await Deno.emit("/src.ts", {
         sources: { "/src.ts": bundledCode },
         compilerOptions: { target },


### PR DESCRIPTION
Fixes up on #116 by removing ES3 and ES5 bundles. See https://github.com/grammyjs/grammY/pull/116#issuecomment-997482092 for why this is done.

The versions are also going to be removed from the CDN. They are broken and cannot possibly work, so they have zero purpose and should have zero usage.