### PR TITLE
Update to Bot API 5.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "contribs": "all-contributors"
     },
     "dependencies": {
-        "@grammyjs/types": "^2.4.5",
+        "@grammyjs/types": "^2.5.0",
         "abort-controller": "^3.0.0",
         "debug": "^4.3.3",
         "node-fetch": "^2.6.5"

--- a/src/platform.deno.ts
+++ b/src/platform.deno.ts
@@ -2,12 +2,12 @@
 const isDeno = typeof Deno !== "undefined";
 
 // === Needed imports
-import { InputFileProxy } from "https://cdn.skypack.dev/@grammyjs/types@v2.4.5?dts";
-import { basename } from "https://deno.land/std@0.118.0/path/mod.ts";
-import { iterateReader } from "https://deno.land/std@0.118.0/streams/mod.ts";
+import { InputFileProxy } from "https://cdn.skypack.dev/@grammyjs/types@v2.5.0?dts";
+import { basename } from "https://deno.land/std@0.119.0/path/mod.ts";
+import { iterateReader } from "https://deno.land/std@0.119.0/streams/mod.ts";
 
 // === Export all API types
-export * from "https://cdn.skypack.dev/@grammyjs/types@v2.4.5?dts";
+export * from "https://cdn.skypack.dev/@grammyjs/types@v2.5.0?dts";
 
 // === Export debug
 import d from "https://cdn.skypack.dev/debug@^4.3.3";
@@ -25,7 +25,7 @@ const debug = d("grammy:warn");
 
 // === Export system-specific operations
 // Turn an AsyncIterable<Uint8Array> into a stream
-export { readableStreamFromIterable as itrToStream } from "https://deno.land/std@0.118.0/streams/mod.ts";
+export { readableStreamFromIterable as itrToStream } from "https://deno.land/std@0.119.0/streams/mod.ts";
 
 // === Base configuration for `fetch` calls
 export const baseFetchConfig = (_apiRoot: string) => ({});

--- a/test/bot.test.ts
+++ b/test/bot.test.ts
@@ -2,7 +2,7 @@ import { Bot } from "../src/bot.ts";
 import {
     assertEquals,
     assertThrows,
-} from "https://deno.land/std@0.118.0/testing/asserts.ts";
+} from "https://deno.land/std@0.119.0/testing/asserts.ts";
 
 function createBot(token: string) {
     return new Bot(token);

--- a/test/filter.test.ts
+++ b/test/filter.test.ts
@@ -2,7 +2,7 @@ import { FilterQuery, matchFilter } from "../src/filter.ts";
 import {
     assert,
     assertThrows,
-} from "https://deno.land/std@0.118.0/testing/asserts.ts";
+} from "https://deno.land/std@0.119.0/testing/asserts.ts";
 import { Context } from "../src/context.ts";
 
 Deno.test("should reject empty filters", () => {


### PR DESCRIPTION
Title says it all. Achieved by updating type deps. No code changes required.

Related: https://github.com/grammyjs/types/commit/17c50c4b5eaab5e407e90ab46e91cc497ede58e7