### PR TITLE
Update to Bot API 5.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ _<h2 align="center"> [:mag: Documentation](https://grammy.dev) | [:page_with_cur
 
 <!-- deno-fmt-ignore-start -->
 
-[![Bot API](https://img.shields.io/badge/Bot%20API-5.6-blue?logo=telegram&style=flat-square)](https://core.telegram.org/bots/api)
+[![Bot API](https://img.shields.io/badge/Bot%20API-5.7-blue?logo=telegram&style=flat-square)](https://core.telegram.org/bots/api)
 [![npm](https://img.shields.io/npm/v/grammy?logo=npm&style=flat-square)](https://www.npmjs.org/package/grammy) <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-50-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "contribs": "all-contributors"
     },
     "dependencies": {
-        "@grammyjs/types": "^2.5.1",
+        "@grammyjs/types": "^2.6.0",
         "abort-controller": "^3.0.0",
         "debug": "^4.3.3",
         "node-fetch": "^2.6.5"

--- a/src/context.ts
+++ b/src/context.ts
@@ -1507,7 +1507,7 @@ export class Context implements RenamedUpdate {
     }
 
     /**
-     * Context-aware alias for `api.sendSticker`. Use this method to send static .WEBP or animated .TGS stickers. On success, the sent Message is returned.
+     * Context-aware alias for `api.sendSticker`. Use this method to send static .WEBP, animated .TGS, or video .WEBM stickers. On success, the sent Message is returned.
      *
      * @param sticker Sticker to send. Pass a file_id as String to send a file that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a .WEBP file from the Internet, or upload a new one using multipart/form-data.
      * @param other Optional remaining parameters, confer the official reference below

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -1499,7 +1499,7 @@ export class Api<R extends RawApi = RawApi> {
     }
 
     /**
-     * Use this method to send static .WEBP or animated .TGS stickers. On success, the sent Message is returned.
+     * Use this method to send static .WEBP, animated .TGS, or video .WEBM stickers. On success, the sent Message is returned.
      *
      * @param chat_id Unique identifier for the target chat or username of the target channel (in the format @channelusername)
      * @param sticker Sticker to send. Pass a file_id as String to send a file that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a .WEBP file from the Internet, or upload a new one using multipart/form-data.
@@ -1547,7 +1547,7 @@ export class Api<R extends RawApi = RawApi> {
     }
 
     /**
-     * Use this method to create a new sticker set owned by a user. The bot will be able to edit the sticker set thus created. You must use exactly one of the fields png_sticker or tgs_sticker. Returns True on success.
+     * Use this method to create a new sticker set owned by a user. The bot will be able to edit the sticker set thus created. You must use exactly one of the fields png_sticker, tgs_sticker, or webm_sticker. Returns True on success.
      *
      * @param user_id User identifier of created sticker set owner
      * @param name Short name of sticker set, to be used in t.me/addstickers/ URLs (e.g., animals). Can contain only english letters, digits and underscores. Must begin with a letter, can't contain consecutive underscores and must end in “_by_<bot username>”. <bot_username> is case insensitive. 1-64 characters.
@@ -1577,7 +1577,7 @@ export class Api<R extends RawApi = RawApi> {
     }
 
     /**
-     * Use this method to add a new sticker to a set created by the bot. You must use exactly one of the fields png_sticker or tgs_sticker. Animated stickers can be added to animated sticker sets and only to them. Animated sticker sets can have up to 50 stickers. Static sticker sets can have up to 120 stickers. Returns True on success.
+     * Use this method to add a new sticker to a set created by the bot. You must use exactly one of the fields png_sticker, tgs_sticker, or webm_sticker. Animated stickers can be added to animated sticker sets and only to them. Animated sticker sets can have up to 50 stickers. Static sticker sets can have up to 120 stickers. Returns True on success.
      *
      * @param user_id User identifier of sticker set owner
      * @param name Sticker set name
@@ -1630,11 +1630,11 @@ export class Api<R extends RawApi = RawApi> {
     }
 
     /**
-     * Use this method to set the thumbnail of a sticker set. Animated thumbnails can be set for animated sticker sets only. Returns True on success.
+     * Use this method to set the thumbnail of a sticker set. Animated thumbnails can be set for animated sticker sets only. Video thumbnails can be set only for video sticker sets only. Returns True on success.
      *
      * @param name Sticker set name
      * @param user_id User identifier of the sticker set owner
-     * @param thumb A PNG image with the thumbnail, must be up to 128 kilobytes in size and have width and height exactly 100px, or a TGS animation with the thumbnail up to 32 kilobytes in size; see https://core.telegram.org/animated_stickers#technical-requirements for animated sticker technical requirements. Pass a file_id as a String to send a file that already exists on the Telegram servers, pass an HTTP URL as a String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data.. Animated sticker set thumbnail can't be uploaded via HTTP URL.
+     * @param thumb A PNG image with the thumbnail, must be up to 128 kilobytes in size and have width and height exactly 100px, or a TGS animation with the thumbnail up to 32 kilobytes in size; see https://core.telegram.org/stickers#animated-sticker-requirements for animated sticker technical requirements, or a WEBM video with the thumbnail up to 32 kilobytes in size; see https://core.telegram.org/stickers#video-sticker-requirements for video sticker technical requirements. Pass a file_id as a String to send a file that already exists on the Telegram servers, pass an HTTP URL as a String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data. More info on Sending Files ». Animated sticker set thumbnails can't be uploaded via HTTP URL.
      * @param signal Optional `AbortSignal` to cancel the request
      *
      * **Official reference:** https://core.telegram.org/bots/api#setstickersetthumb
@@ -1642,7 +1642,7 @@ export class Api<R extends RawApi = RawApi> {
     setStickerSetThumb(
         name: string,
         user_id: number,
-        thumb: InputFile | string,
+        thumb?: InputFile | string,
         signal?: AbortSignal,
     ) {
         return this.raw.setStickerSetThumb({ name, user_id, thumb }, signal);

--- a/src/platform.deno.ts
+++ b/src/platform.deno.ts
@@ -3,8 +3,8 @@ const isDeno = typeof Deno !== "undefined";
 
 // === Needed imports
 import { type InputFileProxy } from "https://cdn.skypack.dev/@grammyjs/types@v2.6.0?dts";
-import { basename } from "https://deno.land/std@0.119.0/path/mod.ts";
-import { iterateReader } from "https://deno.land/std@0.119.0/streams/mod.ts";
+import { basename } from "https://deno.land/std@0.123.0/path/mod.ts";
+import { iterateReader } from "https://deno.land/std@0.123.0/streams/mod.ts";
 
 // === Export all API types
 export * from "https://cdn.skypack.dev/@grammyjs/types@v2.6.0?dts";
@@ -25,7 +25,7 @@ const debug = d("grammy:warn");
 
 // === Export system-specific operations
 // Turn an AsyncIterable<Uint8Array> into a stream
-export { readableStreamFromIterable as itrToStream } from "https://deno.land/std@0.119.0/streams/mod.ts";
+export { readableStreamFromIterable as itrToStream } from "https://deno.land/std@0.123.0/streams/mod.ts";
 
 // === Base configuration for `fetch` calls
 export const baseFetchConfig = (_apiRoot: string) => ({});

--- a/src/platform.deno.ts
+++ b/src/platform.deno.ts
@@ -2,12 +2,12 @@
 const isDeno = typeof Deno !== "undefined";
 
 // === Needed imports
-import { type InputFileProxy } from "https://cdn.skypack.dev/@grammyjs/types@v2.5.1?dts";
+import { type InputFileProxy } from "https://cdn.skypack.dev/@grammyjs/types@v2.6.0?dts";
 import { basename } from "https://deno.land/std@0.119.0/path/mod.ts";
 import { iterateReader } from "https://deno.land/std@0.119.0/streams/mod.ts";
 
 // === Export all API types
-export * from "https://cdn.skypack.dev/@grammyjs/types@v2.5.1?dts";
+export * from "https://cdn.skypack.dev/@grammyjs/types@v2.6.0?dts";
 
 // === Export debug
 import d from "https://cdn.skypack.dev/debug@^4.3.3";

--- a/test/bot.test.ts
+++ b/test/bot.test.ts
@@ -2,7 +2,7 @@ import { Bot } from "../src/bot.ts";
 import {
     assertEquals,
     assertThrows,
-} from "https://deno.land/std@0.119.0/testing/asserts.ts";
+} from "https://deno.land/std@0.123.0/testing/asserts.ts";
 
 function createBot(token: string) {
     return new Bot(token);

--- a/test/filter.test.ts
+++ b/test/filter.test.ts
@@ -2,7 +2,7 @@ import { FilterQuery, matchFilter } from "../src/filter.ts";
 import {
     assert,
     assertThrows,
-} from "https://deno.land/std@0.119.0/testing/asserts.ts";
+} from "https://deno.land/std@0.123.0/testing/asserts.ts";
 import { Context } from "../src/context.ts";
 
 Deno.test("should reject empty filters", () => {


### PR DESCRIPTION
Updates grammY to Bot API 5.7.

Blocked by https://github.com/grammyjs/types/pull/5.

Pending tasks:
- [x] Update dependencies