### PR TITLE
Migrate from `Deno.File` to `Deno.FsFile` and merge #173

### DIFF
--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -128,11 +128,7 @@ export interface ApiClientOptions {
      * @param method The API method to be called, e.g. `getMe`
      * @returns The URL that will be fetched during the API call
      */
-    buildUrl?: (
-        root: string,
-        token: string,
-        method: string,
-    ) => Parameters<typeof fetch>[0];
+    buildUrl?: (root: string, token: string, method: string) => string | URL;
     /**
      * Maximum number of seconds that a request to the Bot API server may take.
      * If a request has not completed before this time has elapsed, grammY
@@ -279,7 +275,10 @@ class ApiClient<R extends RawApi> {
         const sig = controller.signal;
         const options = { ...opts.baseFetchConfig, signal: sig, ...config };
         // Perform fetch call, and handle networking errors
-        const successPromise = fetch(url, options)
+        const successPromise = fetch(
+            url instanceof URL ? url.href : url,
+            options,
+        )
             .catch(toHttpError(method, opts.sensitiveLogs));
         // Those are the three possible outcomes of the fetch call:
         const operations = [successPromise, streamErr.promise, timeout.promise];

--- a/src/platform.deno.ts
+++ b/src/platform.deno.ts
@@ -131,7 +131,7 @@ export class InputFile {
 }
 
 async function* fetchFile(url: string | URL): AsyncIterable<Uint8Array> {
-    const { body } = await fetch(url);
+    const { body } = await fetch(url instanceof URL ? url.href : url);
     if (body === null) {
         throw new Error(`Download failed, no response body from '${url}'`);
     }

--- a/src/platform.deno.ts
+++ b/src/platform.deno.ts
@@ -71,7 +71,7 @@ export class InputFile {
         file:
             | string
             | Blob
-            | Deno.File
+            | Deno.FsFile
             | URL
             | URLLike
             | Uint8Array
@@ -137,8 +137,8 @@ async function* fetchFile(url: string | URL): AsyncIterable<Uint8Array> {
     }
     yield* body;
 }
-function isDenoFile(data: unknown): data is Deno.File {
-    return isDeno && data instanceof Deno.File;
+function isDenoFile(data: unknown): data is Deno.FsFile {
+    return isDeno && data instanceof Deno.FsFile;
 }
 
 // === Export InputFile types


### PR DESCRIPTION
This is breaking, but only for Deno users who do an update of Deno which deprecates `Deno.File` and makes their linting fail.

Fixes CI.

Includes #173.