### PR TITLE
Deduplicate concurrent calls to `bot.init`

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -239,8 +239,12 @@ export class Bot<
         if (!this.isInited()) {
             debug("Initializing bot");
             this.mePromise ??= withRetries(() => this.api.getMe());
-            const me = await this.mePromise;
-            this.mePromise = undefined;
+            let me: UserFromGetMe;
+            try {
+                me = await this.mePromise;
+            } finally {
+                this.mePromise = undefined;
+            }
             if (this.me === undefined) this.me = me;
             else debug("Bot info was set manually by now, will not overwrite");
         }


### PR DESCRIPTION
If one does
```ts
bot.start()
await bot.init()
```
then this would make grammY perform two identical calls to `getMe`.

This PQ optimizes the above scenario. Any number of calls will be deduplicated automatically, so that all promises resolve at the same time when the first `getMe` call completes.

In addition, the initialization via `bot.init` is made more robust by automatically retrying the API call if there are network issues. Previously, this was only the case for init calls done via `bot.start`.