### PR TITLE
Fix double deduping

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -246,7 +246,7 @@ export class Bot<
                 this.mePromise = undefined;
             }
             if (this.me === undefined) this.me = me;
-            else debug("Bot info was set manually by now, will not overwrite");
+            else debug("Bot info was set by now, will not overwrite");
         }
         debug(`I am ${this.me!.username}!`);
     }


### PR DESCRIPTION
Follow-up for #182.

The webhook callback now makes use of the introduced deduplication of init calls. Previously, it had its own way to making sure that only one update would load to the call.