### PR TITLE
Avoid prompting for DEBUG env var access

### DIFF
--- a/src/platform.deno.ts
+++ b/src/platform.deno.ts
@@ -14,11 +14,11 @@ import d from "https://cdn.skypack.dev/debug@4.3.4";
 export { d as debug };
 if (isDeno) {
     d.useColors = () => !Deno.noColor;
-    try {
+    const env = { name: "env", variable: "DEBUG" } as const;
+    const res = await Deno.permissions.query(env);
+    if (res.state === "granted") {
         const val = Deno.env.get("DEBUG");
         if (val) d.enable(val);
-    } catch {
-        // cannot access env var, treat as if it is not set
     }
 }
 const debug = d("grammy:warn");

--- a/src/platform.deno.ts
+++ b/src/platform.deno.ts
@@ -12,12 +12,13 @@ export * from "https://esm.sh/@grammyjs/types@v2.7.0";
 // === Export debug
 import d from "https://cdn.skypack.dev/debug@4.3.4";
 export { d as debug };
+const DEBUG = "DEBUG";
 if (isDeno) {
     d.useColors = () => !Deno.noColor;
-    const env = { name: "env", variable: "DEBUG" } as const;
+    const env = { name: "env", variable: DEBUG } as const;
     const res = await Deno.permissions.query(env);
     if (res.state === "granted") {
-        const val = Deno.env.get("DEBUG");
+        const val = Deno.env.get(DEBUG);
         if (val) d.enable(val);
     }
 }


### PR DESCRIPTION
That's how it was before Deno decided to always prompt by default. This PQ restores the old behaviour.