### PR TITLE
Extend default keepalive on Node to 10 s

### DIFF
--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -273,7 +273,7 @@ class ApiClient<R extends RawApi> {
         const options = { ...opts.baseFetchConfig, signal: sig, ...config };
         // Perform fetch call, and handle networking errors
         const successPromise = fetch(
-            url instanceof URL ? url.href : url,
+            url instanceof URL ? url : new URL(url),
             options,
         ).catch(toHttpError(method, opts.sensitiveLogs));
         // Those are the three possible outcomes of the fetch call:

--- a/src/platform.node.ts
+++ b/src/platform.node.ts
@@ -24,11 +24,14 @@ export const itrToStream = (itr: AsyncIterable<Uint8Array>) =>
 
 // === Base configuration for `fetch` calls
 export function baseFetchConfig(apiRoot: string) {
+    const agentConfig = { keepAlive: true, keepAliveMsecs: 10_000 };
     if (apiRoot.startsWith("https:")) {
-        return { compress: true, agent: new HttpsAgent({ keepAlive: true }) };
+        return { compress: true, agent: new HttpsAgent(agentConfig) };
     } else if (apiRoot.startsWith("http:")) {
-        return { agent: new HttpAgent({ keepAlive: true }) };
-    } else return {};
+        return { agent: new HttpAgent(agentConfig) };
+    } else {
+        return {};
+    }
 }
 
 /** Something that looks like a URL. */


### PR DESCRIPTION
There are two differences between how grammY and Telegraf perform requests. The keepalive time is 1 second on grammY and 10 seconds on Telegraf. The fetched URL is a string on grammY and a `URL` object on Telegraf. `node-fetch` normalises the URL internally.

This sets the default keepalive time for grammY on Node to 10 seconds.

Towards #200.