### PR TITLE
Fix fastify webhook updates when secretToken given

### DIFF
--- a/src/convenience/frameworks.node.ts
+++ b/src/convenience/frameworks.node.ts
@@ -52,7 +52,7 @@ const koa = (ctx: any) => ({
 /** fastify web framework */
 const fastify = (req: any, reply: any) => ({
     update: Promise.resolve(req.body),
-    header: req.headers[SECRET_HEADER],
+    header: req.headers[SECRET_HEADER.toLowerCase()],
     end: () => reply.status(200).send(),
     respond: (json: string) => reply.send(json),
     unauthorized: () => reply.code(401).send("secret token is wrong"),


### PR DESCRIPTION
Fastify will normalize all headers to lower case form, so we always get `undefined` by using `req.headers[SECRET_HEADER]`.

This PR fixes that by using `toLowerCase` to transform the given header key.

Not sure If CloudFlare or AWS Lambda will do that too, so they are leaved unmodified.