### PR TITLE
fix: `ctx.match` being absent

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -238,7 +238,7 @@ export class Context implements RenamedUpdate {
      * Used by some middleware to store information about how a certain string
      * or regular expression was matched.
      */
-    public match: string | RegExpMatchArray | undefined = undefined;
+    public match: string | RegExpMatchArray | undefined;
 
     constructor(
         /**

--- a/src/context.ts
+++ b/src/context.ts
@@ -238,7 +238,7 @@ export class Context implements RenamedUpdate {
      * Used by some middleware to store information about how a certain string
      * or regular expression was matched.
      */
-    public match?: string | RegExpMatchArray;
+    public match: string | RegExpMatchArray | undefined = undefined;
 
     constructor(
         /**


### PR DESCRIPTION
As reported by @EdJoPaTo and discussed in https://t.me/grammyjs/65534