### PR TITLE
chore: make deno the default formatter for VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,8 @@
     "editor.codeActionsOnSave": { "source.fixAll": true },
     "deno.enable": true,
     "deno.lint": true,
-    "deno.config": "./deno.jsonc"
+    "deno.config": "./deno.jsonc",
+    "[typescript]": {
+        "editor.defaultFormatter": "denoland.vscode-deno"
+    }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,5 @@
     "deno.enable": true,
     "deno.lint": true,
     "deno.config": "./deno.jsonc",
-    "[typescript]": {
-        "editor.defaultFormatter": "denoland.vscode-deno"
-    }
+    "editor.defaultFormatter": "denoland.vscode-deno"
 }


### PR DESCRIPTION
as discussed in https://grammyjs.t.me/73886
