### PR TITLE
fix: support numbers and symbols in `bot.route`

### DIFF
--- a/src/composer.ts
+++ b/src/composer.ts
@@ -703,7 +703,7 @@ export class Composer<C extends Context> implements MiddlewareObj<C> {
      * @param routeHandlers Handlers for every route
      * @param fallback Optional fallback middleware if no route matches
      */
-    route<R extends Record<string, Middleware<C>>>(
+    route<R extends Record<PropertyKey, Middleware<C>>>(
         router: (ctx: C) => MaybePromise<undefined | keyof R>,
         routeHandlers: R,
         fallback: Middleware<C> = pass,


### PR DESCRIPTION
Currently, routing can only be done with strings according to the type system. However, at runtime, we actually already support numbers and symbols as identifiers for the route handlers. This PQ adjusts the types to allow for all working values.

Note that this enables the following use case.

```ts
bot.route<Record<number, Middleware<C>>>((ctx) => ctx.session.step++, [
    (ctx) => ctx.reply("I am at 0"),
    (ctx) => ctx.reply("I am at 1"),
    (ctx) => ctx.reply("I am at 2"),
    (ctx) => ctx.reply("I am at 3"),
    (ctx) => ctx.reply("I am at 4"),
]);
```