### PR TITLE
feat: add delete_webhook_on_polling start option

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -46,7 +46,7 @@ export interface PollingOptions {
     /**
      * Pass False to prevent webhook deletion on the start of long polling.
      * Note that this will result in immediate error response from Telegram
-     * server is webhook is set somewhere else.
+     * server if webhook is set somewhere else.
      */
     delete_webhook_on_polling?: boolean;
     /**


### PR DESCRIPTION
I want to propose a new option `delete_webhook_on_polling` for the `PollingOptions`.

If this options is set to False, Bot.start() method will skip call to `deleteWebhook` forbidding long polling to start if somewhere webhook is set.