### PR TITLE
feat: webhook adapter for next.js api routes

### DIFF
--- a/src/convenience/frameworks.node.ts
+++ b/src/convenience/frameworks.node.ts
@@ -69,7 +69,7 @@ const azure = (context: any, req: any) => ({
 /** Vercel/Next.js Serverless Functions */
 const vercel = (req: any, res: any) => ({
     update: Promise.resolve(req.body),
-    header: req.headers[SECRET_HEADER] as string,
+    header: req.headers[SECRET_HEADER],
     end: () => res.end(),
     respond: (json: string) => res.status(200).json(json),
     unauthorized: () => res.status(401).send("secret token is wrong"),

--- a/src/convenience/frameworks.node.ts
+++ b/src/convenience/frameworks.node.ts
@@ -53,11 +53,10 @@ const awsLambda = (event: any, _context: any, callback: any) => ({
 const azure = (context: any, req: any) => ({
     update: Promise.resolve(req.body),
     header: context.res.headers[SECRET_HEADER],
-    end: () =>
-        context.res = {
-            status: 200,
-            body: "",
-        },
+    end: () => (context.res = {
+        status: 200,
+        body: "",
+    }),
     respond: (json: string) => {
         context.res.set("Content-Type", "application/json");
         context.res.send(json);
@@ -67,6 +66,15 @@ const azure = (context: any, req: any) => ({
     },
 });
 
+/** Vercel/Next.js Serverless Functions */
+const vercel = (req: any, res: any) => ({
+    update: Promise.resolve(req.body),
+    header: req.headers[SECRET_HEADER] as string,
+    end: () => res.end(),
+    respond: (json: string) => res.status(200).json(json),
+    unauthorized: () => res.status(401).send("secret token is wrong"),
+});
+
 // please open a PR if you want to add another
 export const adapters = {
     http,
@@ -74,6 +82,7 @@ export const adapters = {
     worktop,
     "aws-lambda": awsLambda,
     azure,
+    vercel,
     ...sharedAdapters,
 };
 export const defaultAdapter = "express";

--- a/src/convenience/frameworks.node.ts
+++ b/src/convenience/frameworks.node.ts
@@ -53,11 +53,10 @@ const awsLambda = (event: any, _context: any, callback: any) => ({
 const azure = (context: any, req: any) => ({
     update: Promise.resolve(req.body),
     header: context.res.headers[SECRET_HEADER],
-    end: () =>
-        (context.res = {
-            status: 200,
-            body: "",
-        }),
+    end: () => (context.res = {
+        status: 200,
+        body: "",
+    }),
     respond: (json: string) => {
         context.res.set("Content-Type", "application/json");
         context.res.send(json);

--- a/src/convenience/frameworks.node.ts
+++ b/src/convenience/frameworks.node.ts
@@ -53,10 +53,11 @@ const awsLambda = (event: any, _context: any, callback: any) => ({
 const azure = (context: any, req: any) => ({
     update: Promise.resolve(req.body),
     header: context.res.headers[SECRET_HEADER],
-    end: () => (context.res = {
-        status: 200,
-        body: "",
-    }),
+    end: () =>
+        (context.res = {
+            status: 200,
+            body: "",
+        }),
     respond: (json: string) => {
         context.res.set("Content-Type", "application/json");
         context.res.send(json);
@@ -66,8 +67,8 @@ const azure = (context: any, req: any) => ({
     },
 });
 
-/** Vercel/Next.js Serverless Functions */
-const vercel = (req: any, res: any) => ({
+/** Next.js Serverless Functions */
+const nextJs = (req: any, res: any) => ({
     update: Promise.resolve(req.body),
     header: req.headers[SECRET_HEADER],
     end: () => res.end(),
@@ -82,7 +83,7 @@ export const adapters = {
     worktop,
     "aws-lambda": awsLambda,
     azure,
-    vercel,
+    "next-js": nextJs,
     ...sharedAdapters,
 };
 export const defaultAdapter = "express";


### PR DESCRIPTION
This adapter will enable bots to work smoothly when using next.js api routes as webhook endpoint. See https://t.me/grammyjs/86659 for how it started.