### PR TITLE
Ignore deno.lock file from source control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,8 @@ pids
 # Dependency directories
 node_modules/
 
-# package-lock.json will not be published, so no need to store it
+# lock files will not be published, so no need to store it
+deno.lock
 package-lock.json
 
 # Output of 'npm pack'

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "contribs": "all-contributors"
     },
     "dependencies": {
-        "@grammyjs/types": "^2.10.0",
+        "@grammyjs/types": "^2.10.2",
         "abort-controller": "^3.0.0",
         "debug": "^4.3.4",
         "node-fetch": "^2.6.7"
@@ -28,7 +28,7 @@
         "@types/node": "^12.20.55",
         "@types/node-fetch": "^2.6.2",
         "all-contributors-cli": "^6.24.0",
-        "deno2node": "^1.4.0"
+        "deno2node": "^1.5.1"
     },
     "files": [
         "out/"

--- a/src/types.deno.ts
+++ b/src/types.deno.ts
@@ -1,13 +1,13 @@
 // === Needed imports
 import { basename } from "https://deno.land/std@0.162.0/path/mod.ts";
 import { iterateReader } from "https://deno.land/std@0.162.0/streams/mod.ts";
-import { type InputFileProxy } from "https://esm.sh/@grammyjs/types@2.10.0";
+import { type InputFileProxy } from "https://esm.sh/@grammyjs/types@2.10.2";
 import { debug as d, isDeno, toRaw } from "./platform.deno.ts";
 
 const debug = d("grammy:warn");
 
 // === Export all API types
-export * from "https://esm.sh/@grammyjs/types@2.10.0";
+export * from "https://esm.sh/@grammyjs/types@2.10.2";
 
 /** Something that looks like a URL. */
 interface URLLike {


### PR DESCRIPTION
Necessary after Deno 1.28 was released which started generating this file automatically: https://deno.com/blog/v1.28#auto-discovery-of-the-lock-file