### PR TITLE
chore: add github action to publish to npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Main
 on:
     push:
         tags:
-            - "*"
+            - "v1.*"
 
 jobs:
     build:
@@ -12,6 +12,13 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v3
+
+            - name: Publish to npm
+              run: |
+                npm config set //registry.npmjs.org/:_authToken '${NPM_TOKEN}'
+                npm publish
+              env :
+                NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
             - name: Release
               uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,14 +13,14 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v3
 
-            - name: Backport
-              run: npm ci --ignore-scripts && npm run backport
+            - run: npm ci --ignore-scripts
+            - run: npm run backport
 
             - name: Publish to npm
               run: |
                 npm config set //registry.npmjs.org/:_authToken '${NPM_TOKEN}'
-                npm publish
-              env :
+                npm publish --ignore-scripts
+              env:
                 NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
             - name: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,9 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v3
 
+            - name: Backport
+              run: npm run backport
+
             - name: Publish to npm
               run: |
                 npm config set //registry.npmjs.org/:_authToken '${NPM_TOKEN}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
               uses: actions/checkout@v3
 
             - name: Backport
-              run: npm run backport
+              run: npm ci --ignore-scripts && npm run backport
 
             - name: Publish to npm
               run: |


### PR DESCRIPTION
The action will run whenever a `v1.*` tag is created pointing to `main`.
It will call `npm publish`, which will run `npm run backport`
because of the `prepare` npm script.
