### PR TITLE
feat: built-in web bundle

### DIFF
--- a/bundling/bundle-all.sh
+++ b/bundling/bundle-all.sh
@@ -12,6 +12,11 @@ echo "Cached ../src/mod.ts"
 deno run --unstable --quiet --allow-net --allow-read=../src/ --allow-write=bundles/ \
     bundle-es.ts dev ../src/mod.ts
 
+mkdir -p ../out
+deno run --unstable --quiet --allow-net --allow-read \
+    --allow-env=DENO_DIR,XDG_CACHE_HOME,HOME,DENO_AUTH_TOKENS \
+    --allow-write=../out bundle-web.ts dev ../src/mod.ts
+
 cores=$(grep -c ^processor /proc/cpuinfo)
 echo "Caching and bundling releases using $cores cores"
 curl --silent https://cdn.deno.land/grammy/meta/versions.json |

--- a/bundling/bundle-web.ts
+++ b/bundling/bundle-web.ts
@@ -1,0 +1,24 @@
+import { bundle } from "https://deno.land/x/emit@0.12.0/mod.ts";
+
+// Parse args
+const [release, source = `https://deno.land/x/grammy@${release}/mod.ts`] =
+    Deno.args;
+if (!release) throw new Error("No release specified!");
+
+// Bundle code
+const { code: bundledCode } = await bundle(source, {
+    compilerOptions: {
+        sourceMap: false,
+        inlineSources: false,
+        inlineSourceMap: false,
+    },
+});
+
+await Deno.writeTextFile(
+    "../out/web.js",
+    bundledCode.replace(/\/\/# sourceMappingURL=.*\n/, ""),
+);
+await Deno.writeTextFile(
+    "../out/web.d.ts",
+    'export * from "./mod"',
+);

--- a/bundling/bundle-web.ts
+++ b/bundling/bundle-web.ts
@@ -13,10 +13,10 @@ const load = (specifier: string) => {
         const baseLength = specifier.length - ".deno.ts".length;
         specifier = specifier.substring(0, baseLength) + ".web.ts";
     }
-    console.log(specifier); // TODO: remove
     return cache.load(specifier);
 };
 
+console.log(`Bundling version '${release}' from ${source} ...`);
 // Bundle code
 const { code: bundledCode } = await bundle(source, {
     load,
@@ -27,12 +27,15 @@ const { code: bundledCode } = await bundle(source, {
     },
 });
 
+console.log("Emitting ...");
 // Strip the huge inline source map which is somehow generated anyway
 await Deno.writeTextFile(
-    "../out/web.js",
+    "../out/web.mjs",
     bundledCode.replace(/\/\/# sourceMappingURL=.*\n/, ""),
 );
 await Deno.writeTextFile(
     "../out/web.d.ts",
     'export * from "./mod";\n',
 );
+
+console.log("Done.");

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -7,7 +7,8 @@
         "dev": "deno fmt && deno lint && deno task test && deno task check",
         "coverage": "deno task test --coverage=./test/cov_profile && deno coverage --lcov --output=./coverage.lcov ./test/cov_profile",
         "report": "genhtml ./coverage.lcov --output-directory ./test/coverage/ && echo 'Point your browser to test/coverage/index.html to see the test coverage report.'",
-        "bundle": "cd bundling && ./bundle-all.sh"
+        "bundle": "cd bundling && ./bundle-all.sh",
+        "bundle-web": "mkdir -p out && cd bundling && deno run --unstable --quiet --allow-net --allow-read --allow-env=DENO_DIR,XDG_CACHE_HOME,HOME,DENO_AUTH_TOKENS --allow-write=../out bundle-web.ts dev ../src/mod.ts"
     },
     "fmt": {
         "options": {

--- a/package.json
+++ b/package.json
@@ -36,12 +36,23 @@
     "main": "./out/mod.js",
     "types": "./out/mod.d.ts",
     "exports": {
-        "./types": {
-            "types": "./out/types.d.ts"
-        },
         ".": {
             "types": "./out/mod.d.ts",
             "default": "./out/mod.js"
+        },
+        "./types": {
+            "types": "./out/types.d.ts"
+        },
+        "./web": {
+            "types": "./out/web.d.ts",
+            "default": "./out/web.js"
+        }
+    },
+    "typesVersions": {
+        "*": {
+            "web": [
+                "out/web"
+            ]
         }
     },
     "keywords": [

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         },
         "./web": {
             "types": "./out/web.d.ts",
-            "default": "./out/web.js"
+            "default": "./out/web.mjs"
         }
     },
     "typesVersions": {

--- a/src/platform.deno.ts
+++ b/src/platform.deno.ts
@@ -1,5 +1,5 @@
 /** Are we running on Deno or in a web browser? */
-export const isDeno = typeof Deno !== "undefined"; // TODO: remove for next major
+export const isDeno = typeof Deno !== "undefined";
 
 // === Export debug
 import d from "https://cdn.skypack.dev/debug@4.3.4";

--- a/src/platform.web.ts
+++ b/src/platform.web.ts
@@ -1,4 +1,5 @@
-export { d as debug } from "https://cdn.skypack.dev/debug@4.3.4";
+import d from "https://cdn.skypack.dev/debug@4.3.4";
+export { d as debug };
 
 // === Export system-specific operations
 // Turn an AsyncIterable<Uint8Array> into a stream

--- a/src/types.web.ts
+++ b/src/types.web.ts
@@ -37,7 +37,7 @@ export class InputFile {
     /**
      * Constructs an `InputFile` that can be used in the API to send files.
      *
-     * @param file A path to a local file or a `Buffer` or a `ReadableStream` that specifies the file data
+     * @param file A URL to a file or a `Blob` or any form of `Uint8Array` that specifies the file data
      * @param filename Optional name of the file
      */
     constructor(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,12 @@
         "skipLibCheck": true,
         "target": "es2019"
     },
-    "include": ["src/"],
+    "include": [
+        "src/"
+    ],
+    "exclude": [
+        "src/*.web.ts"
+    ],
     "deno2node": {
         "shim": "./src/shim.node.ts"
     }


### PR DESCRIPTION
Besided being called inside `bundle-all.sh`, `deno task bundle-web` can also be used to create the new bundle.
Two files will be created inside the `out` folder: web.js and web.d.ts

The `web.d.ts` file only re-exports everything from `out/mod.d.ts`. This
file is needed because typescript refuses to search for types for the
`web.js` file in anywhere other than a `web.d.ts` placed next to it.
That behavior should be overriden by the `typesVersions` property in
`package.json`, but for some reason it's not. The `typesVersions`
property is necessary to make typescript detect the `/web` entrypoint,
though.
