### PR TITLE
chore: run web bundle before npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,14 @@ jobs:
 
             - run: npm ci --ignore-scripts
             - run: npm run backport
-            - run: npm run bundle-web
+            
+            # Setup deno so we can bundle for the web
+            
+            - uses: denoland/setup-deno@main
+              with:
+                  deno-version: v1.x
+            
+            - run: deno task bundle-web
 
             - name: Publish to npm
               run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
 
             - run: npm ci --ignore-scripts
             - run: npm run backport
+            - run: npm run bundle-web
 
             - name: Publish to npm
               run: |

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "scripts": {
         "prepare": "npm run backport",
         "backport": "deno2node tsconfig.json",
-        "contribs": "all-contributors"
+        "contribs": "all-contributors",
+        "bundle-web": "mkdir -p out && cd bundling && deno run --unstable --quiet --allow-net --allow-read --allow-env=DENO_DIR,XDG_CACHE_HOME,HOME,DENO_AUTH_TOKENS --allow-write=../out bundle-web.ts dev ../src/mod.ts"
     },
     "dependencies": {
         "@grammyjs/types": "^2.10.3",


### PR DESCRIPTION
We need to create the web version before publishing the package so the web.mjs and web.d.ts files exist when we `npm publish`