### PR TITLE
chore: revert "chore: add github action to publish to npm (#338)"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Main
 on:
     push:
         tags:
-            - "v1.*"
+            - "*"
 
 jobs:
     build:
@@ -12,22 +12,6 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v3
-
-            # Setup deno so we can bundle for the web
-
-            - uses: denoland/setup-deno@main
-              with:
-                  deno-version: v1.x
-
-            - run: npm install
-            - run: deno task bundle-web
-
-            - name: Publish to npm
-              run: |
-                  npm config set //registry.npmjs.org/:_authToken '${NPM_TOKEN}'
-                  npm publish --ignore-scripts
-              env:
-                  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
             - name: Release
               uses: softprops/action-gh-release@v1

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -9,7 +9,7 @@
         "report": "genhtml ./coverage.lcov --output-directory ./test/coverage/ && echo 'Point your browser to test/coverage/index.html to see the test coverage report.'",
         "bundle": "cd bundling && ./bundle-all.sh",
         "bundle-web": "mkdir -p out && cd bundling && deno run --unstable --quiet --allow-net --allow-read --allow-env=DENO_DIR,XDG_CACHE_HOME,HOME,DENO_AUTH_TOKENS --allow-write=../out bundle-web.ts dev ../src/mod.ts",
-        "release": "deno task dev && deon task backport && deno task bundle-web"
+        "release": "deno task dev && deno task backport && deno task bundle-web"
     },
     "fmt": {
         "options": {

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -8,7 +8,8 @@
         "coverage": "deno task test --coverage=./test/cov_profile && deno coverage --lcov --output=./coverage.lcov ./test/cov_profile",
         "report": "genhtml ./coverage.lcov --output-directory ./test/coverage/ && echo 'Point your browser to test/coverage/index.html to see the test coverage report.'",
         "bundle": "cd bundling && ./bundle-all.sh",
-        "bundle-web": "mkdir -p out && cd bundling && deno run --unstable --quiet --allow-net --allow-read --allow-env=DENO_DIR,XDG_CACHE_HOME,HOME,DENO_AUTH_TOKENS --allow-write=../out bundle-web.ts dev ../src/mod.ts"
+        "bundle-web": "mkdir -p out && cd bundling && deno run --unstable --quiet --allow-net --allow-read --allow-env=DENO_DIR,XDG_CACHE_HOME,HOME,DENO_AUTH_TOKENS --allow-write=../out bundle-web.ts dev ../src/mod.ts",
+        "release": "deno task dev && deon task backport && deno task bundle-web"
     },
     "fmt": {
         "options": {


### PR DESCRIPTION
This reverts commit f1a6e1c.

It also adds a `release` script to simplify the manual task that we failed to automate.