### PR TITLE
feat: protect against lazy multi sessions mistake

### DIFF
--- a/src/convenience/session.ts
+++ b/src/convenience/session.ts
@@ -275,6 +275,9 @@ function strictMultiSession<S, C extends Context>(
 export function lazySession<S, C extends Context>(
     options: SessionOptions<S> = {},
 ): MiddlewareFn<C & LazySessionFlavor<S>> {
+    if (options.type !== undefined && options.type !== "single") {
+        throw new Error("Cannot use lazy multi sessions!");
+    }
     const { initial, storage, getSessionKey, custom } = fillDefaults(options);
     return async (ctx, next) => {
         const propSession = new PropertySession(

--- a/test/convenience/session.test.ts
+++ b/test/convenience/session.test.ts
@@ -432,6 +432,13 @@ describe("multi session", () => {
 describe("lazy session", () => {
     const next = () => Promise.resolve();
 
+    it("should throw when used with multi sessions", () => {
+        assertThrows(
+            () => lazySession({ type: "multi" as unknown as "single" }),
+            "Cannot use lazy multi sessions",
+        );
+    });
+
     it("should pass through updates", async () => {
         type C = Context & SessionFlavor<never>;
         const composer = new Composer<C>();


### PR DESCRIPTION
Prevents non-TS people from making the same mistake as reported in #345.