### PR TITLE
feat: add support for Bot API 6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "contribs": "all-contributors"
     },
     "dependencies": {
-        "@grammyjs/types": "^2.10.3",
+        "@grammyjs/types": "^2.11.0",
         "abort-controller": "^3.0.0",
         "debug": "^4.3.4",
         "node-fetch": "^2.6.7"

--- a/src/context.ts
+++ b/src/context.ts
@@ -957,6 +957,7 @@ export class Context implements RenamedUpdate {
      * We only recommend using this method when a response from the bot will take a noticeable amount of time to arrive.
      *
      * @param action Type of action to broadcast. Choose one, depending on what the user is about to receive: typing for text messages, upload_photo for photos, record_video or upload_video for videos, record_voice or upload_voice for voice notes, upload_document for general files, choose_sticker for stickers, find_location for location data, record_video_note or upload_video_note for video notes.
+     * @param other Optional remaining parameters, confer the official reference below
      * @param signal Optional `AbortSignal` to cancel the request
      *
      * **Official reference:** https://core.telegram.org/bots/api#sendchataction
@@ -974,11 +975,13 @@ export class Context implements RenamedUpdate {
             | "find_location"
             | "record_video_note"
             | "upload_video_note",
+        other?: Other<"sendChatAction", "chat_id" | "action">,
         signal?: AbortSignal,
     ) {
         return this.api.sendChatAction(
             orThrow(this.chat, "sendChatAction").id,
             action,
+            other,
             signal,
         );
     }
@@ -1569,7 +1572,7 @@ export class Context implements RenamedUpdate {
     }
 
     /**
-     * Context-aware alias for `api.getChatMember`. Use this method to get information about a member of a chat. Returns a ChatMember object on success.
+     * Context-aware alias for `api.getChatMember`. Use this method to get information about a member of a chat. The method is guaranteed to work only if the bot is an administrator in the chat. Returns a ChatMember object on success.
      *
      * @param signal Optional `AbortSignal` to cancel the request
      *
@@ -1584,7 +1587,7 @@ export class Context implements RenamedUpdate {
     }
 
     /**
-     * Context-aware alias for `api.getChatMember`. Use this method to get information about a member of a chat. Returns a ChatMember object on success.
+     * Context-aware alias for `api.getChatMember`. Use this method to get information about a member of a chat. The method is guaranteed to work only if the bot is an administrator in the chat. Returns a ChatMember object on success.
      *
      * @param user_id Unique identifier of the target user
      * @param signal Optional `AbortSignal` to cancel the request
@@ -1654,26 +1657,18 @@ export class Context implements RenamedUpdate {
     /**
      * Context-aware alias for `api.editForumTopic`. Use this method to edit name and icon of a topic in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have can_manage_topics administrator rights, unless it is the creator of the topic. Returns True on success.
      *
-     * @param name New topic name, 1-128 characters
-     * @param icon_custom_emoji_id New unique identifier of the custom emoji shown as the topic icon. Use getForumTopicIconStickers to get all allowed custom emoji identifiers.
+     * @param other Optional remaining parameters, confer the official reference below
      * @param signal Optional `AbortSignal` to cancel the request
      *
      * **Official reference:** https://core.telegram.org/bots/api#editforumtopic
      */
     editForumTopic(
-        name: string,
-        icon_custom_emoji_id: string,
+        other?: Other<"editForumTopic", "chat_id" | "message_thread_id">,
         signal?: AbortSignal,
     ) {
         const message = orThrow(this.msg, "editForumTopic");
         const thread = orThrow(message.message_thread_id, "editForumTopic");
-        return this.api.editForumTopic(
-            message.chat.id,
-            thread,
-            name,
-            icon_custom_emoji_id,
-            signal,
-        );
+        return this.api.editForumTopic(message.chat.id, thread, other, signal);
     }
 
     /**
@@ -1731,6 +1726,78 @@ export class Context implements RenamedUpdate {
         return this.api.unpinAllForumTopicMessages(
             message.chat.id,
             thread,
+            signal,
+        );
+    }
+
+    /**
+     * Context-aware alias for `api.editGeneralForumTopic`. Use this method to edit the name of the 'General' topic in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have can_manage_topics administrator rights. Returns True on success.
+     *
+     * @param name New topic name, 1-128 characters
+     * @param signal Optional `AbortSignal` to cancel the request
+     *
+     * **Official reference:** https://core.telegram.org/bots/api#editgeneralforumtopic
+     */
+    editGeneralForumTopic(name: string, signal?: AbortSignal) {
+        return this.api.editGeneralForumTopic(
+            orThrow(this.chat, "editGeneralForumTopic").id,
+            name,
+            signal,
+        );
+    }
+
+    /**
+     * Context-aware alias for `api.closeGeneralForumTopic`. Use this method to close an open 'General' topic in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights. Returns True on success.
+     *
+     * @param signal Optional `AbortSignal` to cancel the request
+     *
+     * **Official reference:** https://core.telegram.org/bots/api#closegeneralforumtopic
+     */
+    closeGeneralForumTopic(signal?: AbortSignal) {
+        return this.api.closeGeneralForumTopic(
+            orThrow(this.chat, "closeGeneralForumTopic").id,
+            signal,
+        );
+    }
+
+    /**
+     * Context-aware alias for `api.reopenGeneralForumTopic`. Use this method to reopen a closed 'General' topic in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights. The topic will be automatically unhidden if it was hidden. Returns True on success.     *
+     *
+     * @param signal Optional `AbortSignal` to cancel the request
+     *
+     * **Official reference:** https://core.telegram.org/bots/api#reopengeneralforumtopic
+     */
+    reopenGeneralForumTopic(signal?: AbortSignal) {
+        return this.api.reopenGeneralForumTopic(
+            orThrow(this.chat, "reopenGeneralForumTopic").id,
+            signal,
+        );
+    }
+
+    /**
+     * Context-aware alias for `api.hideGeneralForumTopic`. Use this method to hide the 'General' topic in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights. The topic will be automatically closed if it was open. Returns True on success.
+     *
+     * @param signal Optional `AbortSignal` to cancel the request
+     *
+     * **Official reference:** https://core.telegram.org/bots/api#hidegeneralforumtopic
+     */
+    hideGeneralForumTopic(signal?: AbortSignal) {
+        return this.api.hideGeneralForumTopic(
+            orThrow(this.chat, "hideGeneralForumTopic").id,
+            signal,
+        );
+    }
+
+    /**
+     * Context-aware alias for `api.unhideGeneralForumTopic`. Use this method to unhide the 'General' topic in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights. Returns True on success.
+     *
+     * @param signal Optional `AbortSignal` to cancel the request
+     *
+     * **Official reference:** https://core.telegram.org/bots/api#unhidegeneralforumtopic
+     */
+    unhideGeneralForumTopic(signal?: AbortSignal) {
+        return this.api.unhideGeneralForumTopic(
+            orThrow(this.chat, "unhideGeneralForumTopic").id,
             signal,
         );
     }

--- a/src/convenience/keyboard.ts
+++ b/src/convenience/keyboard.ts
@@ -33,6 +33,12 @@ import {
  */
 export class Keyboard {
     /**
+     * Requests clients to always show the keyboard when the regular keyboard is
+     * hidden. Defaults to false, in which case the custom keyboard can be
+     * hidden and opened with a keyboard icon.
+     */
+    public is_persistent?: boolean;
+    /**
      * Show the current keyboard only to those users that are mentioned in the
      * text of the message object.
      */
@@ -134,6 +140,21 @@ export class Keyboard {
      */
     webApp(text: string, url: string) {
         return this.add({ text, web_app: { url } });
+    }
+    /**
+     * Make the current keyboard persistent. See
+     * https://grammy.dev/plugins/keyboard.html#persistent-keyboards for more
+     * details.
+     *
+     * Keyboards are not persistent by default, use this function to enable it
+     * (without any parameters or pass `true`). Pass `false` to force the
+     * keyboard to not persist.
+     *
+     * @param isEnabled `true` if the keyboard should persist, and `false` otherwise
+     */
+    persistent(isEnabled = true) {
+        this.is_persistent = isEnabled;
+        return this;
     }
     /**
      * Make the current keyboard selective. See

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -692,6 +692,7 @@ export class Api<R extends RawApi = RawApi> {
      *
      * @param chat_id Unique identifier for the target chat or username of the target channel (in the format @channelusername)
      * @param action Type of action to broadcast. Choose one, depending on what the user is about to receive: typing for text messages, upload_photo for photos, record_video or upload_video for videos, record_voice or upload_voice for voice notes, upload_document for general files, choose_sticker for stickers, find_location for location data, record_video_note or upload_video_note for video notes.
+     * @param other Optional remaining parameters, confer the official reference below
      * @param signal Optional `AbortSignal` to cancel the request
      *
      * **Official reference:** https://core.telegram.org/bots/api#sendchataction
@@ -710,9 +711,10 @@ export class Api<R extends RawApi = RawApi> {
             | "find_location"
             | "record_video_note"
             | "upload_video_note",
+        other?: Other<R, "sendChatAction", "chat_id" | "action">,
         signal?: AbortSignal,
     ) {
-        return this.raw.sendChatAction({ chat_id, action }, signal);
+        return this.raw.sendChatAction({ chat_id, action, ...other }, signal);
     }
 
     /**
@@ -1188,7 +1190,7 @@ export class Api<R extends RawApi = RawApi> {
     }
 
     /**
-     * Use this method to get information about a member of a chat. Returns a ChatMember object on success.
+     * Use this method to get information about a member of a chat. The method is guaranteed to work only if the bot is an administrator in the chat. Returns a ChatMember object on success.
      *
      * @param chat_id Unique identifier for the target chat or username of the target supergroup or channel (in the format @channelusername)
      * @param user_id Unique identifier of the target user
@@ -1271,8 +1273,7 @@ export class Api<R extends RawApi = RawApi> {
      *
      * @param chat_id Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
      * @param message_thread_id Unique identifier for the target message thread of the forum topic
-     * @param name New topic name, 1-128 characters
-     * @param icon_custom_emoji_id New unique identifier of the custom emoji shown as the topic icon. Use getForumTopicIconStickers to get all allowed custom emoji identifiers.
+     * @param other Optional remaining parameters, confer the official reference below
      * @param signal Optional `AbortSignal` to cancel the request
      *
      * **Official reference:** https://core.telegram.org/bots/api#editforumtopic
@@ -1280,16 +1281,13 @@ export class Api<R extends RawApi = RawApi> {
     editForumTopic(
         chat_id: number | string,
         message_thread_id: number,
-        name: string,
-        icon_custom_emoji_id: string,
+        other?: Other<R, "editForumTopic", "chat_id" | "message_thread_id">,
         signal?: AbortSignal,
     ) {
-        return this.raw.editForumTopic({
-            chat_id,
-            message_thread_id,
-            name,
-            icon_custom_emoji_id,
-        }, signal);
+        return this.raw.editForumTopic(
+            { chat_id, message_thread_id, ...other },
+            signal,
+        );
     }
 
     /**
@@ -1367,6 +1365,71 @@ export class Api<R extends RawApi = RawApi> {
             { chat_id, message_thread_id },
             signal,
         );
+    }
+
+    /**
+     * Use this method to edit the name of the 'General' topic in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have can_manage_topics administrator rights. Returns True on success.
+     *
+     * @param chat_id Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
+     * @param name New topic name, 1-128 characters
+     * @param signal Optional `AbortSignal` to cancel the request
+     *
+     * **Official reference:** https://core.telegram.org/bots/api#editgeneralforumtopic
+     */
+    editGeneralForumTopic(
+        chat_id: number | string,
+        name: string,
+        signal?: AbortSignal,
+    ) {
+        return this.raw.editGeneralForumTopic({ chat_id, name }, signal);
+    }
+
+    /**
+     * Use this method to close an open 'General' topic in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights. Returns True on success.
+     *
+     * @param chat_id Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
+     * @param signal Optional `AbortSignal` to cancel the request
+     *
+     * **Official reference:** https://core.telegram.org/bots/api#closegeneralforumtopic
+     */
+    closeGeneralForumTopic(chat_id: number | string, signal?: AbortSignal) {
+        return this.raw.closeGeneralForumTopic({ chat_id }, signal);
+    }
+
+    /**
+     * Use this method to reopen a closed 'General' topic in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights. The topic will be automatically unhidden if it was hidden. Returns True on success.     *
+     *
+     * @param chat_id Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
+     * @param signal Optional `AbortSignal` to cancel the request
+     *
+     * **Official reference:** https://core.telegram.org/bots/api#reopengeneralforumtopic
+     */
+    reopenGeneralForumTopic(chat_id: number | string, signal?: AbortSignal) {
+        return this.raw.reopenGeneralForumTopic({ chat_id }, signal);
+    }
+
+    /**
+     * Use this method to hide the 'General' topic in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights. The topic will be automatically closed if it was open. Returns True on success.
+     *
+     * @param chat_id Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
+     * @param signal Optional `AbortSignal` to cancel the request
+     *
+     * **Official reference:** https://core.telegram.org/bots/api#hidegeneralforumtopic
+     */
+    hideGeneralForumTopic(chat_id: number | string, signal?: AbortSignal) {
+        return this.raw.hideGeneralForumTopic({ chat_id }, signal);
+    }
+
+    /**
+     * Use this method to unhide the 'General' topic in a forum supergroup chat. The bot must be an administrator in the chat for this to work and must have the can_manage_topics administrator rights. Returns True on success.
+     *
+     * @param chat_id Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
+     * @param signal Optional `AbortSignal` to cancel the request
+     *
+     * **Official reference:** https://core.telegram.org/bots/api#unhidegeneralforumtopic
+     */
+    unhideGeneralForumTopic(chat_id: number | string, signal?: AbortSignal) {
+        return this.raw.unhideGeneralForumTopic({ chat_id }, signal);
     }
 
     /**

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -252,6 +252,8 @@ const EDITABLE_MESSAGE_KEYS = {
     entities: ENTITY_KEYS,
     caption_entities: ENTITY_KEYS,
 
+    has_media_spoiler: {},
+
     caption: {},
 } as const;
 const COMMON_MESSAGE_KEYS = {
@@ -272,9 +274,6 @@ const COMMON_MESSAGE_KEYS = {
     pinned_message: {},
     invoice: {},
     proximity_alert_triggered: {},
-    forum_topic_created: {},
-    forum_topic_closed: {},
-    forum_topic_reopened: {},
     video_chat_scheduled: {},
     video_chat_started: {},
     video_chat_ended: {},
@@ -295,7 +294,14 @@ const MESSAGE_KEYS = {
     migrate_from_chat_id: {},
     successful_payment: {},
     connected_website: {},
+    write_access_allowed: {},
     passport_data: {},
+    forum_topic_created: {},
+    forum_topic_edited: { name: {}, icon_custom_emoji_id: {} },
+    forum_topic_closed: {},
+    forum_topic_reopened: {},
+    general_forum_topic_hidden: {},
+    general_forum_topic_unhidden: {},
 } as const;
 const CHANNEL_POST_KEYS = {
     ...COMMON_MESSAGE_KEYS,

--- a/src/types.deno.ts
+++ b/src/types.deno.ts
@@ -1,13 +1,13 @@
 // === Needed imports
 import { basename } from "https://deno.land/std@0.170.0/path/mod.ts";
 import { iterateReader } from "https://deno.land/std@0.170.0/streams/mod.ts";
-import { type InputFileProxy } from "https://esm.sh/@grammyjs/types@2.10.2";
+import { type InputFileProxy } from "https://esm.sh/@grammyjs/types@2.11.0";
 import { debug as d, isDeno, toRaw } from "./platform.deno.ts";
 
 const debug = d("grammy:warn");
 
 // === Export all API types
-export * from "https://esm.sh/@grammyjs/types@2.10.2";
+export * from "https://esm.sh/@grammyjs/types@2.11.0";
 
 /** Something that looks like a URL. */
 interface URLLike {

--- a/test/convenience/keyboard.test.ts
+++ b/test/convenience/keyboard.test.ts
@@ -37,13 +37,18 @@ describe("Keyboard", () => {
 
     it("should support reply markup options", () => {
         const keyboard = new Keyboard();
+        assertEquals(keyboard.is_persistent, undefined);
         assertEquals(keyboard.selective, undefined);
         assertEquals(keyboard.one_time_keyboard, undefined);
         assertEquals(keyboard.resize_keyboard, undefined);
         assertEquals(keyboard.input_field_placeholder, undefined);
         keyboard
-            .selected(false).oneTime(true)
-            .resized(false).placeholder("placeholder");
+            .persistent()
+            .selected(false)
+            .oneTime(true)
+            .resized(false)
+            .placeholder("placeholder");
+        assertEquals(keyboard.is_persistent, true);
         assertEquals(keyboard.selective, false);
         assertEquals(keyboard.one_time_keyboard, true);
         assertEquals(keyboard.resize_keyboard, false);


### PR DESCRIPTION
https://core.telegram.org/bots/api#december-30-2022

There is a small breaking change in this release. Two paramters in `editFormTopic` have become optional. As a result, they were removed from the respective method in `Api`. This is a known disadvantage of the convenience of having parameters in the function signature.