### PR TITLE
fix: do not JSON.stringify twice for serveHttp adapter

### DIFF
--- a/src/convenience/frameworks.deno.ts
+++ b/src/convenience/frameworks.deno.ts
@@ -7,15 +7,9 @@ const serveHttp = (requestEvent: Deno.RequestEvent) => ({
     update: requestEvent.request.json(),
     header: requestEvent.request.headers.get(SECRET_HEADER) || undefined,
     end: () =>
-        requestEvent.respondWith(
-            new Response(undefined, {
-                status: 200,
-            }),
-        ),
+        requestEvent.respondWith(new Response(undefined, { status: 200 })),
     respond: (json: string) =>
-        requestEvent.respondWith(
-            new Response(JSON.stringify(json), { status: 200 }),
-        ),
+        requestEvent.respondWith(new Response(json, { status: 200 })),
     unauthorized: () =>
         requestEvent.respondWith(
             new Response('"unauthorized"', {

--- a/src/convenience/frameworks.deno.ts
+++ b/src/convenience/frameworks.deno.ts
@@ -6,10 +6,14 @@ import {
 const serveHttp = (requestEvent: Deno.RequestEvent) => ({
     update: requestEvent.request.json(),
     header: requestEvent.request.headers.get(SECRET_HEADER) || undefined,
-    end: () =>
-        requestEvent.respondWith(new Response(undefined, { status: 200 })),
+    end: () => requestEvent.respondWith(new Response(null, { status: 200 })),
     respond: (json: string) =>
-        requestEvent.respondWith(new Response(json, { status: 200 })),
+        requestEvent.respondWith(
+            new Response(json, {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+            }),
+        ),
     unauthorized: () =>
         requestEvent.respondWith(
             new Response('"unauthorized"', {


### PR DESCRIPTION
We already receive a JSON string, passing it to `JSON.stringify` seems wrong. I need someone to confirm this, though.