### PR TITLE
feat: add native CloudFlare Workers adapter

### DIFF
--- a/src/convenience/frameworks.shared.ts
+++ b/src/convenience/frameworks.shared.ts
@@ -48,11 +48,14 @@ const stdHttp = (req: Request) => {
         update: req.json(),
         header: req.headers.get(SECRET_HEADER) || undefined,
         end: () => {
-            if (resolveResponse) resolveResponse(new Response());
+            if (resolveResponse) {
+                resolveResponse(new Response(null, { status: 200 }));
+            }
         },
         respond: (json: string) => {
             if (resolveResponse) {
                 const res = new Response(json, {
+                    status: 200,
                     headers: { "Content-Type": "application/json" },
                 });
                 resolveResponse(res);
@@ -60,8 +63,9 @@ const stdHttp = (req: Request) => {
         },
         unauthorized: () => {
             if (resolveResponse) {
-                const res = new Response("secret token is wrong", {
+                const res = new Response('"unauthorized"', {
                     status: 401,
+                    statusText: "secret token is wrong",
                 });
                 resolveResponse(res);
             }

--- a/src/convenience/frameworks.web.ts
+++ b/src/convenience/frameworks.web.ts
@@ -1,3 +1,4 @@
+// deno-lint-ignore-file no-explicit-any
 import { SECRET_HEADER } from "./frameworks.shared.ts";
 
 /** Native CloudFlare workers */

--- a/src/convenience/frameworks.web.ts
+++ b/src/convenience/frameworks.web.ts
@@ -1,1 +1,45 @@
-export const adapters = {};
+import { SECRET_HEADER } from "./frameworks.shared.ts";
+
+/** Native CloudFlare workers */
+const cloudflare = (
+    event: { request: Request; respondWith: (res: Promise<Response>) => void },
+) => {
+    let resolveResponse: (res: Response) => void;
+    event.respondWith(
+        new Promise<Response>((resolve) => {
+            resolveResponse = resolve;
+        }),
+    );
+    return {
+        update: event.request.json(),
+        header: event.request.headers.get(SECRET_HEADER) || undefined,
+        end: () => {
+            resolveResponse(new Response(null, { status: 200 }));
+        },
+        respond: (json: string) => {
+            const res = new Response(json, {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+            });
+            resolveResponse(res);
+        },
+        unauthorized: () => {
+            const res = new Response('"unauthorized"', {
+                status: 401,
+                statusText: "secret token is wrong",
+            });
+            resolveResponse(res);
+        },
+    };
+};
+
+/** worktop CloudFlare workers framework */
+const worktop = (req: any, res: any) => ({
+    update: Promise.resolve(req.body.json()),
+    header: req.headers.get(SECRET_HEADER),
+    end: () => res.end(),
+    respond: (json: string) => res.send(200, json),
+    unauthorized: () => res.send(401, "secret token is wrong"),
+});
+
+export const adapters = { cloudflare, worktop };

--- a/src/convenience/webhook.ts
+++ b/src/convenience/webhook.ts
@@ -132,13 +132,13 @@ export function webhookCallback<C extends Context = Context>(
         ? adapters[adapter]
         : adapter;
     return async (...args: any[]) => {
+        const { update, respond, unauthorized, end, handlerReturn, header } =
+            server(...args);
         if (!initialized) {
             // Will dedupe concurrently incoming calls from several updates
             await bot.init();
             initialized = true;
         }
-        const { update, respond, unauthorized, end, handlerReturn, header } =
-            server(...args);
         if (header !== token) {
             await unauthorized();
             // TODO: investigate deno bug that happens when this console logging is removed


### PR DESCRIPTION
So far, only worktop is supported. With this PQ, we can do
```ts
addEventListener('fetch', webhookCallback(bot, "cloudflare"))
```