### PR TITLE
feat: exponential backoff for retries and permit cancelling `bot.init`

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -2,7 +2,7 @@
     "lock": false,
     "tasks": {
         "check": "deno cache --check=all src/mod.ts",
-        "backport": "deno run --no-prompt --allow-read=. --allow-write=. https://deno.land/x/deno2node@v1.7.1/src/cli.ts tsconfig.json",
+        "backport": "deno run --no-prompt --allow-read=. --allow-write=. https://deno.land/x/deno2node@v1.7.2/src/cli.ts tsconfig.json",
         "test": "deno test --seed=123456 --parallel ./test/",
         "dev": "deno fmt && deno lint && deno task test && deno task check",
         "coverage": "deno task test --coverage=./test/cov_profile && deno coverage --lcov --output=./coverage.lcov ./test/cov_profile",

--- a/package.json
+++ b/package.json
@@ -21,14 +21,14 @@
         "@grammyjs/types": "^2.12.1",
         "abort-controller": "^3.0.0",
         "debug": "^4.3.4",
-        "node-fetch": "^2.6.7"
+        "node-fetch": "^2.6.9"
     },
     "devDependencies": {
         "@types/debug": "^4.1.7",
         "@types/node": "^12.20.55",
         "@types/node-fetch": "^2.6.2",
         "all-contributors-cli": "^6.24.0",
-        "deno2node": "^1.7.1"
+        "deno2node": "^1.7.2"
     },
     "files": [
         "out/"

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -231,11 +231,16 @@ export class Bot<
      * Initializes the bot, i.e. fetches information about the bot itself. This
      * method is called automatically, you usually don't have to call it
      * manually.
+     *
+     * @param signal Optional `AbortSignal` to cancel the initialization
      */
-    async init() {
+    async init(signal?: AbortSignal) {
         if (!this.isInited()) {
             debug("Initializing bot");
-            this.mePromise ??= withRetries(() => this.api.getMe());
+            this.mePromise ??= withRetries(
+                () => this.api.getMe(signal),
+                signal,
+            );
             let me: UserFromGetMe;
             try {
                 me = await this.mePromise;
@@ -353,19 +358,26 @@ a known bot info object.",
      */
     async start(options?: PollingOptions) {
         // Perform setup
-        if (!this.isInited()) await this.init();
+        if (!this.isInited()) {
+            await this.init(this.pollingAbortController?.signal);
+        }
         if (this.pollingRunning) {
             debug("Simple long polling already running!");
             return;
         }
-        await withRetries(() =>
-            this.api.deleteWebhook({
-                drop_pending_updates: options?.drop_pending_updates,
-            })
+        await withRetries(
+            () =>
+                this.api.deleteWebhook({
+                    drop_pending_updates: options?.drop_pending_updates,
+                }, this.pollingAbortController?.signal),
+            this.pollingAbortController?.signal,
         );
 
         // All async ops of setup complete, run callback
         await options?.onStart?.(this.botInfo);
+
+        // Bot was stopped during `onStart`
+        if (!this.pollingRunning) return;
 
         // Prevent common misuse that causes memory leak
         this.use = () => {
@@ -534,8 +546,12 @@ you can circumvent this protection against memory leaks.`);
  * hour before retrying.
  *
  * @param task Async task to perform
+ * @param signal Optional `AbortSignal` to prevent further retries
  */
-async function withRetries<T>(task: () => Promise<T>): Promise<T> {
+async function withRetries<T>(
+    task: () => Promise<T>,
+    signal?: AbortSignal,
+): Promise<T> {
     let result: { ok: false } | { ok: true; value: T } = { ok: false };
     const INITIAL_DELAY = 100; // ms
     let delay = INITIAL_DELAY;
@@ -552,7 +568,7 @@ async function withRetries<T>(task: () => Promise<T>): Promise<T> {
                 if (error.error_code === 429) {
                     const retryAfter = error.parameters.retry_after;
                     if (retryAfter !== undefined) {
-                        await sleep(retryAfter);
+                        await sleep(retryAfter, signal);
                         mustDelay = false;
                     }
                     continue;
@@ -562,7 +578,7 @@ async function withRetries<T>(task: () => Promise<T>): Promise<T> {
         } finally {
             if (mustDelay) {
                 if (delay !== INITIAL_DELAY) {
-                    await sleep(delay);
+                    await sleep(delay, signal);
                 }
                 // double the next delay but cap it at 1 hour
                 delay = Math.min(1 * 60 * 60 * 1000, delay + delay);
@@ -573,8 +589,27 @@ async function withRetries<T>(task: () => Promise<T>): Promise<T> {
 }
 
 /**
- * Returns a new promise that resolves after the specified number of seconds.
+ * Returns a new promise that resolves after the specified number of seconds, or
+ * rejects as soon as the given signal is aborted.
  */
-function sleep(seconds: number) {
-    return new Promise((r) => setTimeout(r, 1000 * seconds));
+async function sleep(seconds: number, signal?: AbortSignal) {
+    let handle: number | undefined;
+    let reject: ((err: Error) => void) | undefined;
+    function abort() {
+        reject?.(new Error("Aborted delay"));
+        if (handle !== undefined) clearTimeout(handle);
+    }
+    try {
+        await new Promise<void>((res, rej) => {
+            reject = rej;
+            if (signal?.aborted) {
+                abort();
+                return;
+            }
+            signal?.addEventListener("abort", abort);
+            handle = setTimeout(res, 1000 * seconds);
+        });
+    } finally {
+        signal?.removeEventListener("abort", abort);
+    }
 }

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -537,7 +537,8 @@ you can circumvent this protection against memory leaks.`);
  */
 async function withRetries<T>(task: () => Promise<T>): Promise<T> {
     let result: { ok: false } | { ok: true; value: T } = { ok: false };
-    let delay = 100; // ms
+    const INITIAL_DELAY = 100; // ms
+    let delay = INITIAL_DELAY;
     while (!result.ok) {
         let mustDelay = true;
         try {
@@ -560,7 +561,7 @@ async function withRetries<T>(task: () => Promise<T>): Promise<T> {
             throw error;
         } finally {
             if (mustDelay) {
-                if (delay !== 100) {
+                if (delay !== INITIAL_DELAY) {
                     await sleep(delay);
                 }
                 // double the next delay but cap it at 1 hour


### PR DESCRIPTION
Makes sure that `bot.init` does not retry too fast.

Allows passing an `AbortSignal` to `bot.init` so the initialization process can be cancelled anytime.

Makes sure that calling `bot.stop` will abort any pending initialization.

Makes sure that polling does not start if the bot is stopped while the `onStart` callback is running.

Closes #291.