### PR TITLE
fix: add typesVersions for /types export

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,9 @@
         "*": {
             "web": [
                 "out/web"
+            ],
+            "types": [
+                "out/types"
             ]
         }
     },


### PR DESCRIPTION
Makes TypeScript aware of where the types for `grammy/types` are actually located.