### PR TITLE
refactor: avoid using a symbol for input files

### DIFF
--- a/src/core/payload.ts
+++ b/src/core/payload.ts
@@ -1,4 +1,4 @@
-import { itrToStream, toRaw } from "../platform.deno.ts";
+import { itrToStream } from "../platform.deno.ts";
 import { InputFile } from "../types.ts";
 
 // === Payload types (JSON vs. form data)
@@ -181,7 +181,7 @@ ${filename}
     yield enc.encode(
         `content-disposition:form-data;name="${id}";filename=${filename}\r\ncontent-type:application/octet-stream\r\n\r\n`,
     );
-    const data = await input[toRaw]();
+    const data = await input.toRaw();
     if (data instanceof Uint8Array) yield data;
     else yield* data;
 }

--- a/src/platform.deno.ts
+++ b/src/platform.deno.ts
@@ -24,7 +24,3 @@ export const baseFetchConfig = (_apiRoot: string) => ({});
 
 // === Default webhook adapter
 export const defaultAdapter = "oak";
-
-// === InputFile handling and File augmenting
-// Accessor for file data in `InputFile` instances
-export const toRaw = Symbol("InputFile data");

--- a/src/platform.node.ts
+++ b/src/platform.node.ts
@@ -23,7 +23,3 @@ export function baseFetchConfig(apiRoot: string) {
 
 // === Default webhook adapter
 export const defaultAdapter = "express";
-
-// === InputFile handling and File augmenting
-// Accessor for file data in `InputFile` instances
-export const toRaw = Symbol("InputFile data");

--- a/src/platform.web.ts
+++ b/src/platform.web.ts
@@ -9,7 +9,3 @@ export { readableStreamFromIterable as itrToStream } from "https://deno.land/std
 export const baseFetchConfig = (_apiRoot: string) => ({});
 
 export const defaultAdapter = "cloudflare";
-
-// === InputFile handling and File augmenting
-// Accessor for file data in `InputFile` instances
-export const toRaw = Symbol("InputFile data");

--- a/src/types.deno.ts
+++ b/src/types.deno.ts
@@ -1,7 +1,6 @@
 // === Needed imports
 import { basename } from "https://deno.land/std@0.178.0/path/mod.ts";
 import { iterateReader } from "https://deno.land/std@0.178.0/streams/mod.ts";
-import { debug as d, isDeno, toRaw } from "./platform.deno.ts";
 import {
     type ApiMethods as ApiMethodsF,
     type InputMedia as InputMediaF,
@@ -13,6 +12,7 @@ import {
     type InputSticker as InputStickerF,
     type Opts as OptsF,
 } from "https://deno.land/x/grammy_types@v3.0.0/mod.ts";
+import { debug as d, isDeno } from "./platform.deno.ts";
 
 const debug = d("grammy:warn");
 
@@ -87,7 +87,7 @@ export class InputFile {
         if (!(file instanceof URL)) return undefined;
         return basename(file.pathname) || basename(file.hostname);
     }
-    async [toRaw](): Promise<
+    async toRaw(): Promise<
         Uint8Array | Iterable<Uint8Array> | AsyncIterable<Uint8Array>
     > {
         if (this.consumed) {

--- a/src/types.deno.ts
+++ b/src/types.deno.ts
@@ -87,6 +87,12 @@ export class InputFile {
         if (!(file instanceof URL)) return undefined;
         return basename(file.pathname) || basename(file.hostname);
     }
+    /**
+     * Internal method. Do not use.
+     *
+     * Converts this instance into a binary representation that can be sent to
+     * the Bot API server in the request body.
+     */
     async toRaw(): Promise<
         Uint8Array | Iterable<Uint8Array> | AsyncIterable<Uint8Array>
     > {

--- a/src/types.deno.ts
+++ b/src/types.deno.ts
@@ -11,13 +11,13 @@ import {
     type InputMediaVideo as InputMediaVideoF,
     type InputSticker as InputStickerF,
     type Opts as OptsF,
-} from "https://deno.land/x/grammy_types@v3.0.0/mod.ts";
+} from "https://deno.land/x/grammy_types@v3.0.1/mod.ts";
 import { debug as d, isDeno } from "./platform.deno.ts";
 
 const debug = d("grammy:warn");
 
 // === Export all API types
-export * from "https://deno.land/x/grammy_types@v3.0.0/mod.ts";
+export * from "https://deno.land/x/grammy_types@v3.0.1/mod.ts";
 
 /** Something that looks like a URL. */
 interface URLLike {

--- a/src/types.node.ts
+++ b/src/types.node.ts
@@ -86,6 +86,12 @@ export class InputFile {
         if (!(file instanceof URL)) return undefined;
         return basename(file.pathname) || basename(file.hostname);
     }
+    /**
+     * Internal method. Do not use.
+     *
+     * Converts this instance into a binary representation that can be sent to
+     * the Bot API server in the request body.
+     */
     toRaw(): Uint8Array | Iterable<Uint8Array> | AsyncIterable<Uint8Array> {
         if (this.consumed) {
             throw new Error("Cannot reuse InputFile data source!");

--- a/src/types.node.ts
+++ b/src/types.node.ts
@@ -13,7 +13,7 @@ import {
 import { createReadStream, type ReadStream } from "fs";
 import fetch from "node-fetch";
 import { basename } from "path";
-import { debug as d, toRaw } from "./platform.node";
+import { debug as d } from "./platform.node";
 
 const debug = d("grammy:warn");
 
@@ -86,7 +86,7 @@ export class InputFile {
         if (!(file instanceof URL)) return undefined;
         return basename(file.pathname) || basename(file.hostname);
     }
-    [toRaw](): Uint8Array | Iterable<Uint8Array> | AsyncIterable<Uint8Array> {
+    toRaw(): Uint8Array | Iterable<Uint8Array> | AsyncIterable<Uint8Array> {
         if (this.consumed) {
             throw new Error("Cannot reuse InputFile data source!");
         }

--- a/src/types.web.ts
+++ b/src/types.web.ts
@@ -11,7 +11,6 @@ import {
     type InputSticker as InputStickerF,
     type Opts as OptsF,
 } from "https://deno.land/x/grammy_types@v3.0.0/mod.ts";
-import { toRaw } from "./platform.deno.ts";
 
 // === Export all API types
 export * from "https://deno.land/x/grammy_types@v3.0.0/mod.ts";
@@ -74,7 +73,7 @@ export class InputFile {
         if (!(file instanceof URL)) return undefined;
         return basename(file.pathname) || basename(file.hostname);
     }
-    [toRaw](): Uint8Array | Iterable<Uint8Array> | AsyncIterable<Uint8Array> {
+    toRaw(): Uint8Array | Iterable<Uint8Array> | AsyncIterable<Uint8Array> {
         if (this.consumed) {
             throw new Error("Cannot reuse InputFile data source!");
         }

--- a/src/types.web.ts
+++ b/src/types.web.ts
@@ -10,10 +10,10 @@ import {
     type InputMediaVideo as InputMediaVideoF,
     type InputSticker as InputStickerF,
     type Opts as OptsF,
-} from "https://deno.land/x/grammy_types@v3.0.0/mod.ts";
+} from "https://deno.land/x/grammy_types@v3.0.1/mod.ts";
 
 // === Export all API types
-export * from "https://deno.land/x/grammy_types@v3.0.0/mod.ts";
+export * from "https://deno.land/x/grammy_types@v3.0.1/mod.ts";
 
 /** Something that looks like a URL. */
 interface URLLike {

--- a/src/types.web.ts
+++ b/src/types.web.ts
@@ -73,6 +73,12 @@ export class InputFile {
         if (!(file instanceof URL)) return undefined;
         return basename(file.pathname) || basename(file.hostname);
     }
+    /**
+     * Internal method. Do not use.
+     *
+     * Converts this instance into a binary representation that can be sent to
+     * the Bot API server in the request body.
+     */
     toRaw(): Uint8Array | Iterable<Uint8Array> | AsyncIterable<Uint8Array> {
         if (this.consumed) {
             throw new Error("Cannot reuse InputFile data source!");


### PR DESCRIPTION
A common issue is that mismatches between patch versions lead to type errors. This can happen when a plugin imports a version of grammY that is different from the version of grammY that the bot code uses, or if two plugins rely on different versions of grammY.

At runtime, these mismatches do not cause any problems because grammY follows semver, and it also does not rely on any `instanceof` checks that could break due to different class identities. Hence, small version mismatches cause needlessly much headache.

The main contributor to these errors is the symbol that is used in `InputFile`. `InputFile` is a parameter of many API methods. API methods are used in the `Api` class. The `Api` class has an instance which is on the context object at `ctx.api`. The context type is checked in many places, such as when installing plugins. As the symbol used by `InputFile` is different for two different versions of grammY (because that's what symbols are used for), this means that the context objects are not assignable to each other. As a result, a type error is thrown.

This PQ exposes the `toRaw` method on `InputFile` and moves away from a symbol to a regular property. This means that `toRaw` now is part of grammY's public API. It is documented as internal, but it has not changed its shape in quite a bit of time, so it should not be a problem to keep it that way.