### PR TITLE
Improve aws-lambda webhookCallback adapter

### DIFF
--- a/src/convenience/frameworks.ts
+++ b/src/convenience/frameworks.ts
@@ -181,9 +181,14 @@ const http: FrameworkAdapter = (req, res) => {
 /** AWS lambda serverless functions */
 const awsLambda: FrameworkAdapter = (event, _context, callback) => ({
     update: JSON.parse(event.body),
-    header: event.headers[SECRET_HEADER],
+    header: event.headers[SECRET_HEADER_LOWERCASE],
     end: () => callback(null, { statusCode: 200 }),
-    respond: (json) => callback(null, { statusCode: 200, body: json }),
+    respond: (json) =>
+        callback(null, {
+            statusCode: 200,
+            headers: { "Content-Type": "application/json" },
+            body: json,
+        }),
     unauthorized: () => callback(null, { statusCode: 401 }),
 });
 


### PR DESCRIPTION
Changes:
- feat: add aws-lambda-async webhookCallback adapter
- fix: apply correct headers to aws-lambda webhookCallback adapter

I did not find any relevant test cases covering adapters, so I am opening this PR with just a few manual tests.