### PR TITLE
fix: add `"node"` condition to `"."` entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "exports": {
         ".": {
             "types": "./out/mod.d.ts",
-            "default": "./out/mod.js"
+            "node": "./out/mod.js",
+            "default": "./out/web.mjs"
         },
         "./types": {
             "types": "./out/types.d.ts"


### PR DESCRIPTION
Towards #372