### PR TITLE
Package exports for Vercel Edge Runtime support

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
         ".": {
             "types": "./out/mod.d.ts",
             "node": "./out/mod.js",
+            "browser": "./out/web.mjs",
             "default": "./out/web.mjs"
         },
         "./types": {


### PR DESCRIPTION
### Details

**Vercel Edge Runtime** need a different key in `"exports"` for **web** target

If we add a `"browser"` target, **Vercel Edge Runtime** can automatically switch to **web** build instead specifying it manually:

```js
import { Bot } from "grammy/web"; // now

import { Bot } from "grammy"; // after merge
```

Also, this can solve incompatibility for some plugins that not depend on **Node** internal packages, but uses default import for core **grammY** package

### Might be able to fix

- [ ] https://github.com/grammyjs/grammY/issues/372
- [ ] https://github.com/grammyjs/grammY/issues/435
- [ ] https://github.com/vercel/next.js/issues/51313

### How to test

I think we need to test this change on other platforms before merging 🌚

```json
{
  "dependencies": {
    "grammy": "npm:@ponomarevlad/grammy@1.17.0-vercel-edge"
  }
  "overrides": {
    "grammy": "npm:@ponomarevlad/grammy@1.17.0-vercel-edge"
  }
}
```

### Where need to test

- [x] [Node](https://github.com/PonomareVlad/grammYExportsTest/tree/node)
- [x] [Deno](https://github.com/PonomareVlad/grammYExportsTest/tree/deno)
- [x] ~~Deno Deploy~~ (same as Deno)
- [x] [Vercel Serverless](https://github.com/PonomareVlad/grammYExportsTest/tree/vercel-serverless)
- [x] [Vercel Edge Runtime](https://github.com/PonomareVlad/grammYExportsTest/tree/vercel-edge)
- [x] ~~Supabase Edge Functions~~ (same as Deno)
- [x] [Google Cloud Functions](https://github.com/PonomareVlad/grammYExportsTest/tree/google-cloud-functions)
- [x] [Cloudflare Workers](https://github.com/PonomareVlad/grammYExportsTest/tree/cloudflare)
- [x] [Firebase Functions](https://github.com/PonomareVlad/grammYExportsTest/tree/firebase-functions)
- [x] [Netlify Functions](https://github.com/PonomareVlad/grammYExportsTest/tree/netlify)

> [Complete example for Vercel Edge Runtime](https://github.com/PonomareVlad/grammYVercelEdge/tree/main)