### PR TITLE
Revert "refactor: avoid top-level await"

### DIFF
--- a/src/composer.ts
+++ b/src/composer.ts
@@ -332,11 +332,11 @@ export class Composer<C extends Context> implements MiddlewareObj<C> {
      * via `ctx.match`.
      *
      * > **Did you know?** You can use deep linking
-     * > (https://core.telegram.org/bots/features#deep-linking) to let users
-     * > start your bot with a custom payload. As an example, send someone the
-     * > link https://t.me/name-of-your-bot?start=custom-payload and register a
-     * > start command handler on your bot with grammY. As soon as the user
-     * > starts your bot, you will receive `custom-payload` in the `ctx.match`
+     * > (https://core.telegram.org/bots/features#deep-linking) to let users start your
+     * > bot with a custom payload. As an example, send someone the link
+     * > https://t.me/name-of-your-bot?start=custom-payload and register a start
+     * > command handler on your bot with grammY. As soon as the user starts
+     * > your bot, you will receive `custom-payload` in the `ctx.match`
      * > property!
      * > ```ts
      * > bot.command('start', ctx => {
@@ -367,8 +367,8 @@ export class Composer<C extends Context> implements MiddlewareObj<C> {
      * // etc
      * ```
      *
-     * If you need more freedom matching your commands, check out the `commands`
-     * plugin.
+     * If you need more freedom matching your commands, check out the
+     * `command-filter` plugin.
      *
      * @param command The command to look for
      * @param middleware The middleware to register

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -332,11 +332,11 @@ export class Composer<C extends Context> implements MiddlewareObj<C> {
      * via `ctx.match`.
      *
      * > **Did you know?** You can use deep linking
-     * > (https://core.telegram.org/bots/features#deep-linking) to let users start your
-     * > bot with a custom payload. As an example, send someone the link
-     * > https://t.me/name-of-your-bot?start=custom-payload and register a start
-     * > command handler on your bot with grammY. As soon as the user starts
-     * > your bot, you will receive `custom-payload` in the `ctx.match`
+     * > (https://core.telegram.org/bots/features#deep-linking) to let users
+     * > start your bot with a custom payload. As an example, send someone the
+     * > link https://t.me/name-of-your-bot?start=custom-payload and register a
+     * > start command handler on your bot with grammY. As soon as the user
+     * > starts your bot, you will receive `custom-payload` in the `ctx.match`
      * > property!
      * > ```ts
      * > bot.command('start', ctx => {
@@ -367,8 +367,8 @@ export class Composer<C extends Context> implements MiddlewareObj<C> {
      * // etc
      * ```
      *
-     * If you need more freedom matching your commands, check out the
-     * `command-filter` plugin.
+     * If you need more freedom matching your commands, check out the `commands`
+     * plugin.
      *
      * @param command The command to look for
      * @param middleware The middleware to register

--- a/src/platform.deno.ts
+++ b/src/platform.deno.ts
@@ -8,7 +8,7 @@ const DEBUG = "DEBUG";
 if (isDeno) {
     d.useColors = () => !Deno.noColor;
     const env = { name: "env", variable: DEBUG } as const;
-    const res = Deno.permissions.querySync(env);
+    const res = await Deno.permissions.query(env);
     let namespace: string | undefined = undefined;
     if (res.state === "granted") namespace = Deno.env.get(DEBUG);
     if (namespace) d.enable(namespace);


### PR DESCRIPTION
Reverts grammyjs/grammY#436.

Deno Deploy does and and will never support sync APIs. However, we do see increasing support for TLA, with CFW being the most important runtime.