### PR TITLE
fix: correct case usage for X-Telegram-Bot-Api-Secret-Token header in…

### DIFF
--- a/src/convenience/frameworks.ts
+++ b/src/convenience/frameworks.ts
@@ -181,7 +181,7 @@ const http: FrameworkAdapter = (req, res) => {
 /** AWS lambda serverless functions */
 const awsLambda: FrameworkAdapter = (event, _context, callback) => ({
     update: JSON.parse(event.body),
-    header: event.headers[SECRET_HEADER_LOWERCASE],
+    header: event.headers[SECRET_HEADER],
     end: () => callback(null, { statusCode: 200 }),
     respond: (json) =>
         callback(null, {
@@ -198,7 +198,7 @@ const awsLambdaAsync: FrameworkAdapter = (event, _context) => {
 
     return {
         update: JSON.parse(event.body),
-        header: event.headers[SECRET_HEADER_LOWERCASE],
+        header: event.headers[SECRET_HEADER],
         end: () => resolveResponse({ statusCode: 200 }),
         respond: (json) =>
             resolveResponse({


### PR DESCRIPTION
This update modifies the handling of the 'X-Telegram-Bot-Api-Secret-Token' header in both the synchronous and asynchronous AWS Lambda functions. 

In the previous implementation, the `SECRET_HEADER_LOWERCASE` constant was being used to retrieve the header from the event. This caused complications since AWS Lambda does not interpret headers in a case-insensitive way, leading to potential mismatches if the header was not supplied in the exact expected case.

With this fix, the `SECRET_HEADER` constant is used, which matches the exact casing of the 'X-Telegram-Bot-Api-Secret-Token' header as it appears in the event. This adjustment should eliminate any issues caused by case sensitivity.
