### PR TITLE
refactor: inline SomeObject type alias

### DIFF
--- a/src/filter.ts
+++ b/src/filter.ts
@@ -402,9 +402,7 @@ export type FilterQuery = AllValidFilterQueries;
  * Any kind of value that appears in the Telegram Bot API. When intersected with
  * an optional field, it effectively removes `| undefined`.
  */
-// deno-lint-ignore ban-types
-type SomeObject = object;
-type NotUndefined = string | number | boolean | SomeObject;
+type NotUndefined = string | number | boolean | object;
 
 /**
  * Given a FilterQuery, returns an object that, when intersected with an Update,
@@ -468,11 +466,11 @@ export type Filter<C extends Context, Q extends FilterQuery> = PerformQuery<
     C,
     RunQuery<ExpandShortcuts<Q>>
 >;
-type PerformQueryCore<U extends SomeObject> = U extends unknown
+type PerformQueryCore<U extends object> = U extends unknown
     ? FilteredContextCore<Update & U>
     : never;
 // apply a query result by intersecting it with Update, and then injecting into C
-type PerformQuery<C extends Context, U extends SomeObject> = U extends unknown
+type PerformQuery<C extends Context, U extends object> = U extends unknown
     ? FilteredContext<C, Update & U>
     : never;
 
@@ -488,44 +486,44 @@ type FilteredContext<C extends Context, U extends Update> =
 
 // helper type to infer shortcuts on context object based on present properties, must be in sync with shortcut impl!
 interface Shortcuts<U extends Update> {
-    msg: [U["callback_query"]] extends [SomeObject]
+    msg: [U["callback_query"]] extends [object]
         ? U["callback_query"]["message"]
-        : [U["message"]] extends [SomeObject] ? U["message"]
-        : [U["edited_message"]] extends [SomeObject] ? U["edited_message"]
-        : [U["channel_post"]] extends [SomeObject] ? U["channel_post"]
-        : [U["edited_channel_post"]] extends [SomeObject]
+        : [U["message"]] extends [object] ? U["message"]
+        : [U["edited_message"]] extends [object] ? U["edited_message"]
+        : [U["channel_post"]] extends [object] ? U["channel_post"]
+        : [U["edited_channel_post"]] extends [object]
             ? U["edited_channel_post"]
         : undefined;
-    chat: [U["callback_query"]] extends [SomeObject]
+    chat: [U["callback_query"]] extends [object]
         ? NonNullable<U["callback_query"]["message"]>["chat"] | undefined
-        : [Shortcuts<U>["msg"]] extends [SomeObject]
+        : [Shortcuts<U>["msg"]] extends [object]
             ? Shortcuts<U>["msg"]["chat"]
-        : [U["my_chat_member"]] extends [SomeObject]
+        : [U["my_chat_member"]] extends [object]
             ? U["my_chat_member"]["chat"]
-        : [U["chat_member"]] extends [SomeObject] ? U["chat_member"]["chat"]
-        : [U["chat_join_request"]] extends [SomeObject]
+        : [U["chat_member"]] extends [object] ? U["chat_member"]["chat"]
+        : [U["chat_join_request"]] extends [object]
             ? U["chat_join_request"]["chat"]
         : undefined;
-    senderChat: [Shortcuts<U>["msg"]] extends [SomeObject]
+    senderChat: [Shortcuts<U>["msg"]] extends [object]
         ? Shortcuts<U>["msg"]["sender_chat"]
         : undefined;
-    from: [U["callback_query"]] extends [SomeObject]
+    from: [U["callback_query"]] extends [object]
         ? U["callback_query"]["from"]
-        : [U["inline_query"]] extends [SomeObject] ? U["inline_query"]["from"]
-        : [U["shipping_query"]] extends [SomeObject]
+        : [U["inline_query"]] extends [object] ? U["inline_query"]["from"]
+        : [U["shipping_query"]] extends [object]
             ? U["shipping_query"]["from"]
-        : [U["pre_checkout_query"]] extends [SomeObject]
+        : [U["pre_checkout_query"]] extends [object]
             ? U["pre_checkout_query"]["from"]
-        : [U["chosen_inline_result"]] extends [SomeObject]
+        : [U["chosen_inline_result"]] extends [object]
             ? U["chosen_inline_result"]["from"]
-        : [U["message"]] extends [SomeObject]
+        : [U["message"]] extends [object]
             ? NonNullable<U["message"]["from"]>
-        : [U["edited_message"]] extends [SomeObject]
+        : [U["edited_message"]] extends [object]
             ? NonNullable<U["edited_message"]["from"]>
-        : [U["my_chat_member"]] extends [SomeObject]
+        : [U["my_chat_member"]] extends [object]
             ? U["my_chat_member"]["from"]
-        : [U["chat_member"]] extends [SomeObject] ? U["chat_member"]["from"]
-        : [U["chat_join_request"]] extends [SomeObject]
+        : [U["chat_member"]] extends [object] ? U["chat_member"]["from"]
+        : [U["chat_join_request"]] extends [object]
             ? U["chat_join_request"]["from"]
         : undefined;
     // inlineMessageId: disregarded here because always optional on both types

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -486,20 +486,16 @@ type FilteredContext<C extends Context, U extends Update> =
 
 // helper type to infer shortcuts on context object based on present properties, must be in sync with shortcut impl!
 interface Shortcuts<U extends Update> {
-    msg: [U["callback_query"]] extends [object]
-        ? U["callback_query"]["message"]
+    msg: [U["callback_query"]] extends [object] ? U["callback_query"]["message"]
         : [U["message"]] extends [object] ? U["message"]
         : [U["edited_message"]] extends [object] ? U["edited_message"]
         : [U["channel_post"]] extends [object] ? U["channel_post"]
-        : [U["edited_channel_post"]] extends [object]
-            ? U["edited_channel_post"]
+        : [U["edited_channel_post"]] extends [object] ? U["edited_channel_post"]
         : undefined;
     chat: [U["callback_query"]] extends [object]
         ? NonNullable<U["callback_query"]["message"]>["chat"] | undefined
-        : [Shortcuts<U>["msg"]] extends [object]
-            ? Shortcuts<U>["msg"]["chat"]
-        : [U["my_chat_member"]] extends [object]
-            ? U["my_chat_member"]["chat"]
+        : [Shortcuts<U>["msg"]] extends [object] ? Shortcuts<U>["msg"]["chat"]
+        : [U["my_chat_member"]] extends [object] ? U["my_chat_member"]["chat"]
         : [U["chat_member"]] extends [object] ? U["chat_member"]["chat"]
         : [U["chat_join_request"]] extends [object]
             ? U["chat_join_request"]["chat"]
@@ -507,21 +503,17 @@ interface Shortcuts<U extends Update> {
     senderChat: [Shortcuts<U>["msg"]] extends [object]
         ? Shortcuts<U>["msg"]["sender_chat"]
         : undefined;
-    from: [U["callback_query"]] extends [object]
-        ? U["callback_query"]["from"]
+    from: [U["callback_query"]] extends [object] ? U["callback_query"]["from"]
         : [U["inline_query"]] extends [object] ? U["inline_query"]["from"]
-        : [U["shipping_query"]] extends [object]
-            ? U["shipping_query"]["from"]
+        : [U["shipping_query"]] extends [object] ? U["shipping_query"]["from"]
         : [U["pre_checkout_query"]] extends [object]
             ? U["pre_checkout_query"]["from"]
         : [U["chosen_inline_result"]] extends [object]
             ? U["chosen_inline_result"]["from"]
-        : [U["message"]] extends [object]
-            ? NonNullable<U["message"]["from"]>
+        : [U["message"]] extends [object] ? NonNullable<U["message"]["from"]>
         : [U["edited_message"]] extends [object]
             ? NonNullable<U["edited_message"]["from"]>
-        : [U["my_chat_member"]] extends [object]
-            ? U["my_chat_member"]["from"]
+        : [U["my_chat_member"]] extends [object] ? U["my_chat_member"]["from"]
         : [U["chat_member"]] extends [object] ? U["chat_member"]["from"]
         : [U["chat_join_request"]] extends [object]
             ? U["chat_join_request"]["from"]


### PR DESCRIPTION
`object` was now finally allowed by `deno lint` so we can get rid of that ugly helper type alias.