### PR TITLE
Fixed use of deprecated express method

### DIFF
--- a/src/convenience/frameworks.ts
+++ b/src/convenience/frameworks.ts
@@ -76,7 +76,7 @@ const express: FrameworkAdapter = (req, res) => ({
         res.send(json);
     },
     unauthorized: () => {
-        res.send(401, WRONG_TOKEN_ERROR);
+        res.status(401).send(WRONG_TOKEN_ERROR);
     },
 });
 


### PR DESCRIPTION
Tested by [this](https://github.com/PonomareVlad/grammYExportsTest/blob/express/index.mjs) example 🙂