### PR TITLE
feat: add types and improved docs for API_CONSTANTS

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -173,10 +173,9 @@ const checker: StaticHas = {
                 }
                 const index = cmd.indexOf("@");
                 if (index === -1) return false;
-                const atTarget = cmd.substring(index + 1);
-                if (atTarget.toLowerCase() !== ctx.me.username.toLowerCase()) {
-                    return false;
-                }
+                const atTarget = cmd.substring(index + 1).toLowerCase();
+                const username = ctx.me.username.toLowerCase();
+                if (atTarget !== username) return false;
                 const atCommand = cmd.substring(0, index);
                 if (noAtCommands.has(atCommand)) {
                     ctx.match = txt.substring(cmd.length + 1).trimStart();

--- a/src/convenience/constants.ts
+++ b/src/convenience/constants.ts
@@ -18,44 +18,84 @@ const ALL_CHAT_PERMISSIONS = {
     can_manage_topics: true,
 } as const;
 
+export interface ApiConstants {
+    /**
+     * List of update types a bot receives by default. Useful if you want to
+     * receive all update types but `chat_member`.
+     *
+     * ```ts
+     * // Built-in polling:
+     * bot.start({ allowed_updates: DEFAULT_UPDATE_TYPES });
+     * // grammY runner:
+     * run(bot, { runner: { fetch: { allowed_updates: DEFAULT_UPDATE_TYPES } } });
+     * // Webhooks:
+     * await bot.api.setWebhook(url, { allowed_updates: DEFAULT_UPDATE_TYPES });
+     * ```
+     *
+     * See the [Bot API reference](https://core.telegram.org/bots/api#update)
+     * for more information.
+     */
+    DEFAULT_UPDATE_TYPES: typeof DEFAULT_UPDATE_TYPES[number];
+
+    /**
+     * List of all available update types. Useful if you want to receive all
+     * updates from the Bot API, rather than just those that are delivered by
+     * default.
+     *
+     * The main use case for this is when you want to receive `chat_member`
+     * updates, as they need to be enabled first. Use it like so:
+     *
+     * ```ts
+     * // Built-in polling:
+     * bot.start({ allowed_updates: ALL_UPDATE_TYPES });
+     * // grammY runner:
+     * run(bot, { runner: { fetch: { allowed_updates: ALL_UPDATE_TYPES } } });
+     * // Webhooks:
+     * await bot.api.setWebhook(url, { allowed_updates: ALL_UPDATE_TYPES });
+     * ```
+     *
+     * See the [Bot API reference](https://core.telegram.org/bots/api#update)
+     * for more information.
+     */
+    ALL_UPDATE_TYPES: typeof ALL_UPDATE_TYPES[number];
+
+    /**
+     * An object containing all available chat permissions. Useful if you want
+     * to lift restrictions from a user, as this action requires you to pass
+     * `true` for all permissions. Use it like so:
+     *
+     * ```ts
+     * // On `Bot`:
+     * await bot.api.restrictChatMember(chat_id, user_id, ALL_CHAT_PERMISSIONS);
+     * // On `Api`:
+     * await ctx.api.restrictChatMember(chat_id, user_id, ALL_CHAT_PERMISSIONS);
+     * // On `Context`:
+     * await ctx.restrictChatMember(user_id, ALL_CHAT_PERMISSIONS);
+     * await ctx.restrictAuthor(ALL_CHAT_PERMISSIONS);
+     * ```
+     *
+     * See the [Bot API reference](https://core.telegram.org/bots/api#update)
+     * for more information.
+     */
+    ALL_CHAT_PERMISSIONS: keyof typeof ALL_CHAT_PERMISSIONS;
+}
+
+interface TypeOf {
+    DEFAULT_UPDATE_TYPES: typeof DEFAULT_UPDATE_TYPES;
+    ALL_UPDATE_TYPES: typeof ALL_UPDATE_TYPES;
+    ALL_CHAT_PERMISSIONS: typeof ALL_CHAT_PERMISSIONS;
+}
+type ValuesFor<T> = {
+    [K in keyof T]: K extends keyof TypeOf ? Readonly<TypeOf[K]> : never;
+};
+
 /**
- * Contains lists of constants which are useful when working with the Bot API.
+ * A container for constants used in the Telegram Bot API. Currently holds all
+ * available update types as well as all chat permissions.
  */
-export const API_CONSTANTS = Object.freeze(
-    {
-        /**
-         * List of all available update types. Useful if you want to receive all
-         * updates from the Bot API, rather than just those that are delivered by
-         * default.
-         *
-         * The main use case for this is when you want to receive `chat_member`
-         * updates, as they need to be enabled first. Use it like so:
-         *
-         * ```ts
-         * // Built-in polling:
-         * bot.start({ allowed_updates: ALL_UPDATE_TYPES });
-         * // grammY runner:
-         * run(bot, { runner: { fetch: { allowed_updates: ALL_UPDATE_TYPES } } });
-         * // Webhooks:
-         * await bot.api.setWebhook(url, { allowed_updates: ALL_UPDATE_TYPES });
-         * ```
-         */
-        ALL_UPDATE_TYPES,
-        /**
-         * An object containing all available chat permissions. Useful if you want
-         * to lift restrictions from a user, as this action requires you to pass
-         * `true` for all permissions. Use it like so:
-         *
-         * ```ts
-         * // On `Bot`:
-         * await bot.api.restrictChatMember(chat_id, user_id, ALL_CHAT_PERMISSIONS);
-         * // On `Api`:
-         * await ctx.api.restrictChatMember(chat_id, user_id, ALL_CHAT_PERMISSIONS);
-         * // On `Context`:
-         * await ctx.restrictChatMember(user_id, ALL_CHAT_PERMISSIONS);
-         * await ctx.restrictAuthor(ALL_CHAT_PERMISSIONS);
-         * ```
-         */
-        ALL_CHAT_PERMISSIONS,
-    } as const,
-);
+export const API_CONSTANTS: ValuesFor<ApiConstants> = {
+    DEFAULT_UPDATE_TYPES,
+    ALL_UPDATE_TYPES,
+    ALL_CHAT_PERMISSIONS,
+};
+Object.freeze(API_CONSTANTS);

--- a/src/convenience/constants.ts
+++ b/src/convenience/constants.ts
@@ -18,6 +18,10 @@ const ALL_CHAT_PERMISSIONS = {
     can_manage_topics: true,
 } as const;
 
+/**
+ * Types of the constants used in the Telegram Bot API. Currently holds all
+ * available update types as well as all chat permissions.
+ */
 export interface ApiConstants {
     /**
      * List of update types a bot receives by default. Useful if you want to

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -47,7 +47,7 @@ describe("Context", () => {
         chat_join_request: { date: 3, from: u, chat: c },
     } as Update;
     const api = new Api("dummy-token");
-    const me = { id: 42 } as UserFromGetMe;
+    const me = { id: 42, username: "bot" } as UserFromGetMe;
 
     it("provide basic properties", () => {
         const ctx = new Context(update, api, me);
@@ -274,6 +274,34 @@ describe("Context", () => {
                     type: "bot_command",
                     offset: "Test with ".length,
                     length: "/start".length,
+                }],
+            },
+        } as Update;
+        ctx = new Context(up, api, me);
+        assertFalse(Context.has.command("start")(ctx));
+        assertFalse(ctx.hasCommand("start"));
+
+        up = {
+            message: {
+                text: "/start@BoT args",
+                entities: [{
+                    type: "bot_command",
+                    offset: 0,
+                    length: "/start@BoT".length,
+                }],
+            },
+        } as Update;
+        ctx = new Context(up, api, me);
+        assert(Context.has.command("start")(ctx));
+        assert(ctx.hasCommand("start"));
+
+        up = {
+            message: {
+                text: "/start@not args",
+                entities: [{
+                    type: "bot_command",
+                    offset: 0,
+                    length: "/start@not".length,
                 }],
             },
         } as Update;


### PR DESCRIPTION
Exports `DEFAULT_UPDATE_TYPES` from grammY.

Exports a new `interface ApiConstants` which provides types for `API_CONSTANTS`.

Closes #453 which has several problems:
- it provides two very similar interfaces called `ApiConstants` and `API_CONSTANTS` which is maximally confusing
- one of the two interfaces is not documented at all, but it is the more useful one
- there is no link from the values to the types in the generated Deno module docs

This PQ fixes all of that.