### PR TITLE
support `nhttp` for webhook handler

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -330,7 +330,7 @@ export class Bot<
     ) {
         if (this.me === undefined) {
             throw new Error(
-"Bot not initialized! Either call `await bot.init()`, \
+                "Bot not initialized! Either call `await bot.init()`, \
 or directly set the `botInfo` option in the `Bot` constructor to specify \
 a known bot info object.",
             );

--- a/src/convenience/frameworks.ts
+++ b/src/convenience/frameworks.ts
@@ -344,7 +344,7 @@ const worktop: FrameworkAdapter = (req, res) => ({
 const nhttp: FrameworkAdapter = (rev) => ({
     update: rev.body,
     header: rev.headers.get(SECRET_HEADER) || undefined,
-    end: () => rev.response.status(200),
+    end: () => rev.response.sendStatus(200),
     respond: (json) => rev.response.status(200).send(json),
     unauthorized: () => rev.response.status(401).send(WRONG_TOKEN_ERROR),
 });

--- a/src/convenience/frameworks.ts
+++ b/src/convenience/frameworks.ts
@@ -340,6 +340,15 @@ const worktop: FrameworkAdapter = (req, res) => ({
     unauthorized: () => res.send(401, WRONG_TOKEN_ERROR),
 });
 
+/** nhttp web framework */
+const nhttp: FrameworkAdapter = (rev) => ({
+    update: rev.body,
+    header: rev.headers.get(SECRET_HEADER) || undefined,
+    end: () => rev.response.status(200),
+    respond: (json) => rev.response.status(200).send(json),
+    unauthorized: () => rev.response.status(401).send(WRONG_TOKEN_ERROR),
+});
+
 // Please open a PR if you want to add another adapter
 export const adapters = {
     express,
@@ -359,4 +368,5 @@ export const adapters = {
     "cloudflare-mod": cloudflareModule,
     hono,
     worktop,
+    nhttp,
 };


### PR DESCRIPTION
This PR adds support for [nhttp](https://nhttp.deno.dev/) for webhook handler.