### PR TITLE
`.js` extension for web build

### DIFF
--- a/bundling/bundle-web.ts
+++ b/bundling/bundle-web.ts
@@ -30,7 +30,7 @@ const { code: bundledCode } = await bundle(source, {
 console.log("Emitting ...");
 // Strip the huge inline source map which is somehow generated anyway
 await Deno.writeTextFile(
-    "../out/web.mjs",
+    "../out/web.js",
     bundledCode.replace(/\/\/# sourceMappingURL=.*\n/, ""),
 );
 await Deno.writeTextFile(

--- a/package.json
+++ b/package.json
@@ -37,15 +37,15 @@
         ".": {
             "types": "./out/mod.d.ts",
             "node": "./out/mod.js",
-            "browser": "./out/web.mjs",
-            "default": "./out/web.mjs"
+            "browser": "./out/web.js",
+            "default": "./out/web.js"
         },
         "./types": {
             "types": "./out/types.d.ts"
         },
         "./web": {
             "types": "./out/web.d.ts",
-            "default": "./out/web.mjs"
+            "default": "./out/web.js"
         }
     },
     "typesVersions": {


### PR DESCRIPTION
Possible solution to fix Next.js builds using Edge Runtime (#435)

How to test:
```json
{
    "dependencies": {
        "grammy": "npm:@ponomarevlad/grammy@1.19.2-next-edge"
    }
}
```

[Full example](https://github.com/PonomareVlad/grammY-Vercel-TS/tree/next-edge)

![logs](https://github.com/grammyjs/grammY/assets/2877584/c1a0ac32-e9fd-4b98-8ae0-59783066139a)
