### PR TITLE
fix: properly define the subpath ./types in exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
         },
         "./types": {
             "types": "./out/types.d.ts",
-            "node": "./out/types.node.js",
             "default": "./out/types.js"
         },
         "./web": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
             "default": "./out/web.mjs"
         },
         "./types": {
-            "types": "./out/types.d.ts"
+            "types": "./out/types.d.ts",
+            "node": "./out/types.node.js",
+            "default": "./out/types.js"
         },
         "./web": {
             "types": "./out/web.d.ts",


### PR DESCRIPTION
Should fix

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './types' is not defined by "exports"
```