### PR TITLE
Fix hono adapter

### DIFF
--- a/src/convenience/frameworks.ts
+++ b/src/convenience/frameworks.ts
@@ -193,7 +193,7 @@ const hono: FrameworkAdapter = (ctx) => {
     let resolveResponse: (res: Response) => void;
     return {
         update: ctx.req.json(),
-        header: ctx.req.header(SECRET_HEADER) || undefined,
+        header: ctx.req.header(SECRET_HEADER),
         end: () => {
             resolveResponse(ctx.body());
         },

--- a/src/convenience/frameworks.ts
+++ b/src/convenience/frameworks.ts
@@ -193,7 +193,7 @@ const hono: FrameworkAdapter = (ctx) => {
     let resolveResponse: (res: Response) => void;
     return {
         update: ctx.req.json(),
-        header: ctx.req.headers.get(SECRET_HEADER) || undefined,
+        header: ctx.req.header(SECRET_HEADER) || undefined,
         end: () => {
             resolveResponse(ctx.body());
         },

--- a/src/convenience/frameworks.ts
+++ b/src/convenience/frameworks.ts
@@ -198,8 +198,7 @@ const hono: FrameworkAdapter = (ctx) => {
             resolveResponse(ctx.body());
         },
         respond: (json) => {
-            ctx.header('Content-Type", "application/json');
-            resolveResponse(ctx.body(json));
+            resolveResponse(ctx.json(json));
         },
         unauthorized: () => {
             ctx.status(401);


### PR DESCRIPTION
Experiencing the following errors when using Hono and grammY.

```
2024-02-10T06:11:33.126 app[90806145c55418] syd [info] 123 | /** hono web framework */

2024-02-10T06:11:33.126 app[90806145c55418] syd [info] 124 | const hono = (ctx) => {

2024-02-10T06:11:33.126 app[90806145c55418] syd [info] 125 | let resolveResponse;

2024-02-10T06:11:33.126 app[90806145c55418] syd [info] 126 | return {

2024-02-10T06:11:33.126 app[90806145c55418] syd [info] 127 | update: ctx.req.json(),

2024-02-10T06:11:33.126 app[90806145c55418] syd [info] 128 | header: ctx.req.headers.get(SECRET_HEADER) || undefined,

2024-02-10T06:11:33.126 app[90806145c55418] syd [info] ^

2024-02-10T06:11:33.126 app[90806145c55418] syd [info] TypeError: undefined is not an object (evaluating 'ctx.req.headers.get')

2024-02-10T06:11:33.126 app[90806145c55418] syd [info] at hono (/app/node_modules/grammy/out/convenience/frameworks.js:128:17)

2024-02-10T06:11:33.126 app[90806145c55418] syd [info] at /app/node_modules/grammy/out/convenience/webhook.js:23:79

2024-02-10T06:11:33.126 app[90806145c55418] syd [info] at /app/node_modules/grammy/out/convenience/webhook.js:22:22

2024-02-10T06:11:33.126 app[90806145c55418] syd [info] at dispatch (/app/node_modules/hono/dist/hono-base.js:213:15)

2024-02-10T06:11:33.127 app[90806145c55418] syd [info] TypeError: Request aborted

2024-02-10T06:11:33.127 app[90806145c55418] syd [info] code: "ABORT_ERR"
```

The fix ensures we correctly access the incoming header via the correct Hono API: `c.req.header`.