### PR TITLE
refactor: prefer FsFile#readable over std/iterateReader

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -30,10 +30,5 @@
             "./package-lock.json",
             "./bundling/bundles"
         ]
-    },
-    "imports": {
-        "@std/path": "jsr:@std/path@^0.221.0",
-        "grammy_types": "https://deno.land/x/grammy_types@v3.6.2/mod.ts",
-        "debug": "https://cdn.skypack.dev/debug@4.3.4"
     }
 }

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -7,7 +7,6 @@
         "dev": "deno fmt && deno lint && deno task test && deno task check",
         "coverage": "rm -rf ./test/cov_profile && deno task test --coverage=./test/cov_profile && deno coverage --lcov --output=./coverage.lcov ./test/cov_profile",
         "report": "genhtml ./coverage.lcov --output-directory ./test/coverage/ && echo 'Point your browser to test/coverage/index.html to see the test coverage report.'",
-        "bundle": "cd bundling && ./bundle-all.sh",
         "bundle-web": "mkdir -p out deno_cache && cd bundling && DENO_DIR=$PWD/../deno_cache deno run --unstable --quiet --allow-net --allow-read --allow-env=DENO_DIR,XDG_CACHE_HOME,HOME,DENO_AUTH_TOKENS --allow-write=../out,$PWD/../deno_cache bundle-web.ts dev ../src/mod.ts",
         "contribs": "deno run --allow-env --allow-read --allow-write=. --allow-net=api.github.com --allow-sys npm:all-contributors-cli"
     },
@@ -31,5 +30,10 @@
             "./package-lock.json",
             "./bundling/bundles"
         ]
+    },
+    "imports": {
+        "@std/path": "jsr:@std/path@^0.221.0",
+        "grammy_types": "https://deno.land/x/grammy_types@v3.6.2/mod.ts",
+        "debug": "https://cdn.skypack.dev/debug@4.3.4"
     }
 }

--- a/src/platform.deno.ts
+++ b/src/platform.deno.ts
@@ -2,7 +2,7 @@
 export const isDeno = typeof Deno !== "undefined";
 
 // === Export debug
-import debug from "debug";
+import debug from "https://cdn.skypack.dev/debug@4.3.4";
 export { debug };
 const DEBUG = "DEBUG";
 if (isDeno) {

--- a/src/platform.deno.ts
+++ b/src/platform.deno.ts
@@ -2,7 +2,7 @@
 export const isDeno = typeof Deno !== "undefined";
 
 // === Export debug
-import debug from "https://cdn.skypack.dev/debug@4.3.4";
+import debug from "debug";
 export { debug };
 const DEBUG = "DEBUG";
 if (isDeno) {

--- a/src/types.deno.ts
+++ b/src/types.deno.ts
@@ -115,7 +115,7 @@ export class InputFile {
                 );
             }
             const file = await Deno.open(data);
-            return file.readable;
+            return file.readable[Symbol.asyncIterator]();
         }
         if (data instanceof Blob) return data.stream();
         if (isDenoFile(data)) return data.readable;

--- a/src/types.deno.ts
+++ b/src/types.deno.ts
@@ -1,6 +1,5 @@
 // === Needed imports
 import { basename } from "https://deno.land/std@0.211.0/path/basename.ts";
-import { iterateReader } from "https://deno.land/std@0.211.0/io/iterate_reader.ts";
 
 import {
     type ApiMethods as ApiMethodsF,
@@ -116,10 +115,10 @@ export class InputFile {
                 );
             }
             using file = await Deno.open(data);
-            return iterateReader(file);
+            return file.readable;
         }
         if (data instanceof Blob) return data.stream();
-        if (isDenoFile(data)) return iterateReader(data);
+        if (isDenoFile(data)) return data.readable;
         // Handle Response objects
         if (data instanceof Response) {
             if (data.body === null) throw new Error(`No response body!`);

--- a/src/types.deno.ts
+++ b/src/types.deno.ts
@@ -146,7 +146,7 @@ async function fetchFile(
     if (body === null) {
         throw new Error(`Download failed, no response body from '${url}'`);
     }
-    return body;
+    return body[Symbol.asyncIterator]();
 }
 function isDenoFile(data: unknown): data is Deno.FsFile {
     return isDeno && data instanceof Deno.FsFile;

--- a/src/types.deno.ts
+++ b/src/types.deno.ts
@@ -1,6 +1,6 @@
 // === Needed imports
-import { basename } from "jsr:@std/path@^0.221.0";
-import { iterateReader } from "jsr:@std/io@^0.221.0";
+import { basename } from "https://deno.land/std@0.211.0/path/basename.ts";
+import { iterateReader } from "https://deno.land/std@0.211.0/io/iterate_reader.ts";
 
 import {
     type ApiMethods as ApiMethodsF,

--- a/src/types.deno.ts
+++ b/src/types.deno.ts
@@ -114,7 +114,7 @@ export class InputFile {
                     "Reading files by path requires a Deno environment",
                 );
             }
-            using file = await Deno.open(data);
+            const file = await Deno.open(data);
             return file.readable;
         }
         if (data instanceof Blob) return data.stream();

--- a/src/types.deno.ts
+++ b/src/types.deno.ts
@@ -118,7 +118,7 @@ export class InputFile {
             return file.readable[Symbol.asyncIterator]();
         }
         if (data instanceof Blob) return data.stream();
-        if (isDenoFile(data)) return data.readable;
+        if (isDenoFile(data)) return data.readable[Symbol.asyncIterator]();
         // Handle Response objects
         if (data instanceof Response) {
             if (data.body === null) throw new Error(`No response body!`);

--- a/src/types.deno.ts
+++ b/src/types.deno.ts
@@ -1,6 +1,5 @@
 // === Needed imports
-import { basename } from "https://deno.land/std@0.211.0/path/basename.ts";
-import { iterateReader } from "https://deno.land/std@0.211.0/streams/iterate_reader.ts";
+import { basename } from "@std/path";
 import {
     type ApiMethods as ApiMethodsF,
     type InputMedia as InputMediaF,
@@ -11,13 +10,13 @@ import {
     type InputMediaVideo as InputMediaVideoF,
     type InputSticker as InputStickerF,
     type Opts as OptsF,
-} from "https://deno.land/x/grammy_types@v3.6.2/mod.ts";
+} from "grammy_types";
 import { debug as d, isDeno } from "./platform.deno.ts";
 
 const debug = d("grammy:warn");
 
 // === Export all API types
-export * from "https://deno.land/x/grammy_types@v3.6.2/mod.ts";
+export * from "grammy_types";
 
 /** A value, or a potentially async function supplying that value */
 type MaybeSupplier<T> = T | (() => T | Promise<T>);
@@ -114,11 +113,11 @@ export class InputFile {
                     "Reading files by path requires a Deno environment",
                 );
             }
-            const file = await Deno.open(data);
-            return iterateReader(file);
+            using file = await Deno.open(data);
+            return file.readable;
         }
         if (data instanceof Blob) return data.stream();
-        if (isDenoFile(data)) return iterateReader(data);
+        if (isDenoFile(data)) return data.readable;
         // Handle Response objects
         if (data instanceof Response) {
             if (data.body === null) throw new Error(`No response body!`);

--- a/src/types.deno.ts
+++ b/src/types.deno.ts
@@ -1,5 +1,7 @@
 // === Needed imports
-import { basename } from "@std/path";
+import { basename } from "jsr:@std/path@^0.221.0";
+import { iterateReader } from "jsr:@std/io@^0.221.0";
+
 import {
     type ApiMethods as ApiMethodsF,
     type InputMedia as InputMediaF,
@@ -10,13 +12,13 @@ import {
     type InputMediaVideo as InputMediaVideoF,
     type InputSticker as InputStickerF,
     type Opts as OptsF,
-} from "grammy_types";
+} from "https://deno.land/x/grammy_types@v3.6.2/mod.ts";
 import { debug as d, isDeno } from "./platform.deno.ts";
 
 const debug = d("grammy:warn");
 
 // === Export all API types
-export * from "grammy_types";
+export * from "https://deno.land/x/grammy_types@v3.6.2/mod.ts";
 
 /** A value, or a potentially async function supplying that value */
 type MaybeSupplier<T> = T | (() => T | Promise<T>);
@@ -114,10 +116,10 @@ export class InputFile {
                 );
             }
             using file = await Deno.open(data);
-            return file.readable;
+            return iterateReader(file);
         }
         if (data instanceof Blob) return data.stream();
-        if (isDenoFile(data)) return data.readable;
+        if (isDenoFile(data)) return iterateReader(data);
         // Handle Response objects
         if (data instanceof Response) {
             if (data.body === null) throw new Error(`No response body!`);

--- a/src/types.deno.ts
+++ b/src/types.deno.ts
@@ -125,8 +125,8 @@ export class InputFile {
             return data.body;
         }
         // Handle URL and URLLike objects
-        if (data instanceof URL) return fetchFile(data);
-        if ("url" in data) return fetchFile(data.url);
+        if (data instanceof URL) return await fetchFile(data);
+        if ("url" in data) return await fetchFile(data.url);
         // Return buffers as-is
         if (data instanceof Uint8Array) return data;
         // Unwrap supplier functions
@@ -139,12 +139,14 @@ export class InputFile {
     }
 }
 
-async function* fetchFile(url: string | URL): AsyncIterable<Uint8Array> {
+async function fetchFile(
+    url: string | URL,
+): Promise<AsyncIterable<Uint8Array>> {
     const { body } = await fetch(url);
     if (body === null) {
         throw new Error(`Download failed, no response body from '${url}'`);
     }
-    yield* body;
+    return body;
 }
 function isDenoFile(data: unknown): data is Deno.FsFile {
     return isDeno && data instanceof Deno.FsFile;

--- a/test/core/payload.test.ts
+++ b/test/core/payload.test.ts
@@ -7,10 +7,9 @@ import {
     assert,
     assertEquals,
     assertFalse,
+    convertToUint8Array,
     describe,
     it,
-    readAll,
-    readerFromIterable,
 } from "../deps.test.ts";
 
 describe("requiresFormDataUpload", () => {
@@ -67,7 +66,7 @@ describe("requiresFormDataUpload", () => {
             connection: "keep-alive",
         };
         assertEquals(payload.headers, headers);
-        const body = await readAll(readerFromIterable(payload.body));
+        const body = await convertToUint8Array(payload.body);
         const actual = new TextDecoder().decode(body);
         const expected = `--${boundary}\r
 content-disposition:form-data;name="chat_id"\r

--- a/test/deps.test.ts
+++ b/test/deps.test.ts
@@ -25,14 +25,10 @@ export {
 export async function convertToUint8Array(
     data: Iterable<Uint8Array> | AsyncIterable<Uint8Array>,
 ) {
-    const stream = ReadableStream.from(data);
-    const reader = stream.getReader();
-
     const values = [] as number[];
-    while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        values.push(...value);
+
+    for await (const chunk of data) {
+        values.push(...chunk);
     }
 
     return new Uint8Array(values);

--- a/test/deps.test.ts
+++ b/test/deps.test.ts
@@ -1,8 +1,4 @@
 export {
-    readAll,
-    readerFromIterable,
-} from "https://deno.land/std@0.211.0/streams/mod.ts";
-export {
     assert,
     assertEquals,
     assertFalse,
@@ -25,3 +21,19 @@ export {
     type Stub,
     stub,
 } from "https://deno.land/std@0.211.0/testing/mock.ts";
+
+export async function convertToUint8Array(
+    data: Iterable<Uint8Array> | AsyncIterable<Uint8Array>,
+) {
+    const stream = ReadableStream.from(data);
+    const reader = stream.getReader();
+
+    const values = [] as number[];
+    while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        values.push(...value);
+    }
+
+    return new Uint8Array(values);
+}

--- a/test/deps.test.ts
+++ b/test/deps.test.ts
@@ -25,7 +25,7 @@ export {
 export async function convertToUint8Array(
     data: Iterable<Uint8Array> | AsyncIterable<Uint8Array>,
 ) {
-    const values = [] as number[];
+    const values: number[] = [];
 
     for await (const chunk of data) {
         values.push(...chunk);

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -83,9 +83,7 @@ Deno.test({
             }
 
             const stream = ReadableStream.from(data());
-            return Promise.resolve(
-                { readable: stream, [Symbol.dispose]() {} } as Deno.FsFile,
-            );
+            return Promise.resolve({ readable: stream } as Deno.FsFile);
         });
         const file = new InputFile("/tmp/file.txt");
         assertEquals(file.filename, "file.txt");

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -158,18 +158,16 @@ Deno.test({
 
 Deno.test({
     name: "handle invalid URLs",
-    async fn() {
+    fn() {
         const source = stub(
             globalThis,
             "fetch",
             () => Promise.resolve(new Response(null)),
         );
         const file = new InputFile({ url: "https://grammy.dev" });
-        const data = await file.toRaw();
-        if (data instanceof Uint8Array) throw new Error("no itr");
 
         assertRejects(
-            () => convertToUint8Array(data),
+            () => file.toRaw(),
             "no response body from 'https://grammy.dev'",
         );
         source.restore();


### PR DESCRIPTION
1. `iterateReader` was deprecated. See: <https://deno.land/std@0.211.0/streams/iterate_reader.ts?s=iterateReader>.
2. `Deno.open` need to release resources. Deno provided `using` keywords for this purpose. Like this: <https://github.com/denoland/deno/blob/08f46ac4467968f53400c4cf9db95f62b424a161/cli/tsc/dts/lib.deno.ns.d.ts#L1891>
3. `importMaps`, it would be more convenient, if `grammy` and `grammy_type` were to be published JSR. (Like: `deno add`)