### PR TITLE
chore(ci): type-check library in CI

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -59,7 +59,7 @@ jobs:
                   deno-version: v1.x
 
             - name: Cache Dependencies
-              run: deno cache src/mod.ts
+              run: deno task check
 
             - name: Run Tests
               run: deno task test

--- a/src/convenience/frameworks.ts
+++ b/src/convenience/frameworks.ts
@@ -145,7 +145,7 @@ export type HonoAdapter = (c: {
 }) => ReqResHandler<Response>;
 
 export type HttpAdapter = (req: {
-    headers: NodeJS.Dict<string | string[]>;
+    headers: Record<string, string | string[] | undefined>;
     on: (event: string, listener: (chunk: unknown) => void) => typeof req;
     once: (event: string, listener: () => void) => typeof req;
 }, res: {
@@ -172,7 +172,7 @@ export type KoaAdapter = (ctx: {
 
 export type NextAdapter = (req: {
     body: Update;
-    headers: NodeJS.Dict<string | string[]>;
+    headers: Record<string, string | string[] | undefined>;
 }, res: {
     end: (cb?: () => void) => typeof res;
     status: (code: number) => typeof res;


### PR DESCRIPTION
How did we never type-check grammY in CI? It currently fails and I only discovered this locally.