### PR TITLE
feat: allow cloning `Api` instances

### DIFF
--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -97,17 +97,17 @@ export class Api<R extends RawApi = RawApi> {
      * if transformers.
      *
      * @param token Bot API token obtained from [@BotFather](https://t.me/BotFather)
-     * @param client Optional API client options for the underlying client instance
+     * @param options Optional API client options for the underlying client instance
      * @param webhookReplyEnvelope Optional envelope to handle webhook replies
      */
     constructor(
         public readonly token: string,
-        public readonly client?: ApiClientOptions,
+        public readonly options?: ApiClientOptions,
         webhookReplyEnvelope?: WebhookReplyEnvelope,
     ) {
         const { raw, use, installedTransformers } = createRawApi<R>(
             token,
-            client,
+            options,
             webhookReplyEnvelope,
         );
         this.raw = raw;

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -91,20 +91,29 @@ export class Api<R extends RawApi = RawApi> {
         readonly installedTransformers: () => Transformer<R>[];
     };
 
+    /**
+     * Constructs a new instance of `Api`. It is independent from all other
+     * instances of this class. For example, this lets you install a custom set
+     * if transformers.
+     *
+     * @param token Bot API token obtained from [@BotFather](https://t.me/BotFather)
+     * @param client Optional API client options for the underlying client instance
+     * @param webhookReplyEnvelope Optional envelope to handle webhook replies
+     */
     constructor(
-        token: string,
-        config?: ApiClientOptions,
+        public readonly token: string,
+        public readonly client?: ApiClientOptions,
         webhookReplyEnvelope?: WebhookReplyEnvelope,
     ) {
         const { raw, use, installedTransformers } = createRawApi<R>(
             token,
-            config,
+            client,
             webhookReplyEnvelope,
         );
         this.raw = raw;
         this.config = {
             use,
-            installedTransformers: () => [...installedTransformers],
+            installedTransformers: () => installedTransformers.slice(),
         };
     }
 


### PR DESCRIPTION
This exposes `api.token` and `api.options`. This is useful because it lets us create new `Api` instances from existing ones, optionally reconfiguring them on the fly.

The main use case for this is the second major version of the conversations plugin which no longer shares the same `Api` instance across context objects—something that was a big hack that mostly worked for v1.