### PR TITLE
fix: resolve type conflict of ctx.chatId for callback queries

### DIFF
--- a/src/filter.ts
+++ b/src/filter.ts
@@ -638,7 +638,8 @@ interface Shortcuts<U extends Update> {
         : [U["message_reaction"]] extends [object] ? number
         : [U["message_reaction_count"]] extends [object] ? number
         : undefined;
-    chatId: [Shortcuts<U>["chat"]] extends [object] ? number
+    chatId: [U["callback_query"]] extends [object] ? number | undefined
+        : [Shortcuts<U>["chat"]] extends [object] ? number
         : [U["business_connection"]] extends [object] ? number
         : undefined;
     // inlineMessageId: disregarded here because always optional on both types

--- a/test/composer.type.test.ts
+++ b/test/composer.type.test.ts
@@ -60,6 +60,7 @@ describe("Composer types", () => {
                 const callbackQueryMessage = ctx.callbackQuery.message;
                 const callbackQueryData = ctx.callbackQuery.data;
                 const match = ctx.match;
+                const chatId = ctx.chatId;
                 assertType<
                     IsExact<typeof msg, MaybeInaccessibleMessage | undefined>
                 >(
@@ -92,6 +93,7 @@ describe("Composer types", () => {
                 assertType<IsExact<typeof match, string | RegExpMatchArray>>(
                     true,
                 );
+                assertType<IsExact<typeof chatId, number | undefined>>(true);
             });
         });
     });
@@ -308,6 +310,17 @@ describe("Composer types", () => {
             composer.filter((_ctx): _ctx is TmpCtx => true, (ctx) => {
                 assertType<IsExact<typeof ctx, TmpCtx>>(true);
                 assertType<IsExact<typeof ctx.prop, number>>(true);
+            });
+        });
+    });
+
+    describe("known combined usages", () => {
+        it("should work with .chatType.callbackQuery", () => {
+            composer.chatType("private").callbackQuery("query", (ctx) => {
+                assertType<IsExact<typeof ctx.from.id, number>>(true);
+            });
+            composer.callbackQuery("query").chatType("private", (ctx) => {
+                assertType<IsExact<typeof ctx.from.id, number>>(true);
             });
         });
     });


### PR DESCRIPTION
First reported in https://t.me/grammyjs/248339