### PR TITLE
feat: add `bot.preCheckoutQuery` and `bot.shippingQuery`

### DIFF
--- a/src/composer.ts
+++ b/src/composer.ts
@@ -8,7 +8,9 @@ import {
     type HearsContext,
     type InlineQueryContext,
     type MaybeArray,
+    type PreCheckoutQueryContext,
     type ReactionContext,
+    type ShippingQueryContext,
     type StringWithSuggestions,
 } from "./context.ts";
 import { type Filter, type FilterQuery } from "./filter.ts";
@@ -587,6 +589,61 @@ export class Composer<C extends Context> implements MiddlewareObj<C> {
     }
 
     /**
+     * Registers middleware for pre-checkout queries. Telegram sends a pre-checkout
+     * query to your bot whenever a user has confirmed their payment and shipping
+     * details. You bot will then receive all information about the order and
+     * has to respond within 10 seconds with a confirmation of whether everything
+     * is alright (goods are available, etc.) and the bot is ready to proceed
+     * with the order. Check out https://core.telegram.org/bots/api#precheckoutquery
+     * to read more about pre-checkout queries.
+     *
+     * ```ts
+     * bot.preCheckoutQuery('invoice_payload', async ctx => {
+     *   // Answer the pre-checkout query, confer https://core.telegram.org/bots/api#answerprecheckoutquery
+     *   await ctx.answerPreCheckoutQuery( ... )
+     * })
+     * ```
+     *
+     * @param trigger The string to look for in the invoice payload
+     * @param middleware The middleware to register
+     */
+    preCheckoutQuery(
+        trigger: MaybeArray<string | RegExp>,
+        ...middleware: Array<PreCheckoutQueryMiddleware<C>>
+    ): Composer<PreCheckoutQueryContext<C>> {
+        return this.filter(
+            Context.has.preCheckoutQuery(trigger),
+            ...middleware,
+        );
+    }
+
+    /**
+     * Registers middleware for shipping queries. If you sent an invoice requesting
+     * a shipping address and the parameter _is_flexible_ was specified, Telegram
+     * will send a shipping query to your bot whenever a user has confirmed their
+     * shipping details. You bot will then receive the shipping information and
+     * can respond with a confirmation of whether delivery to the specified address
+     * is possible. Check out https://core.telegram.org/bots/api#shippingquery to
+     * read more about shipping queries.
+     *
+     * ```ts
+     * bot.shippingQuery('invoice_payload', async ctx => {
+     *   // Answer the shipping query, confer https://core.telegram.org/bots/api#answershippingquery
+     *   await ctx.answerShippingQuery( ... )
+     * })
+     * ```
+     *
+     * @param trigger The string to look for in the invoice payload
+     * @param middleware The middleware to register
+     */
+    shippingQuery(
+        trigger: MaybeArray<string | RegExp>,
+        ...middleware: Array<ShippingQueryMiddleware<C>>
+    ): Composer<ShippingQueryContext<C>> {
+        return this.filter(Context.has.shippingQuery(trigger), ...middleware);
+    }
+
+    /**
      * > This is an advanced method of grammY.
      *
      * Registers middleware behind a custom filter function that operates on the
@@ -946,6 +1003,28 @@ export type InlineQueryMiddleware<C extends Context> = Middleware<
  */
 export type ChosenInlineResultMiddleware<C extends Context> = Middleware<
     ChosenInlineResultContext<C>
+>;
+/**
+ * Type of the middleware that can be passed to `bot.preCheckoutQuery`.
+ *
+ * This helper type can be used to annotate middleware functions that are
+ * defined in one place, so that they have the correct type when passed to
+ * `bot.preCheckoutQuery` in a different place. For instance, this allows for more
+ * modular code where handlers are defined in separate files.
+ */
+export type PreCheckoutQueryMiddleware<C extends Context> = Middleware<
+    PreCheckoutQueryContext<C>
+>;
+/**
+ * Type of the middleware that can be passed to `bot.shippingQuery`.
+ *
+ * This helper type can be used to annotate middleware functions that are
+ * defined in one place, so that they have the correct type when passed to
+ * `bot.shippingQuery` in a different place. For instance, this allows for more
+ * modular code where handlers are defined in separate files.
+ */
+export type ShippingQueryMiddleware<C extends Context> = Middleware<
+    ShippingQueryContext<C>
 >;
 /**
  * Type of the middleware that can be passed to `bot.chatType`.

--- a/test/composer.test.ts
+++ b/test/composer.test.ts
@@ -294,6 +294,64 @@ describe("Composer", () => {
         });
     });
 
+    describe(".preCheckoutQuery", () => {
+        const c = new Context(
+            // deno-lint-ignore no-explicit-any
+            { pre_checkout_query: { invoice_payload: "test" } } as any,
+            // deno-lint-ignore no-explicit-any
+            0 as any,
+            // deno-lint-ignore no-explicit-any
+            0 as any,
+        );
+        it("should check for pre-checkout query data", async () => {
+            composer.preCheckoutQuery("no-data", middleware);
+            composer.preCheckoutQuery(["nope", "test"], middleware);
+            await exec(c);
+            assertEquals(middleware.calls.length, 1);
+            assertEquals(middleware.calls[0].args[0], c);
+        });
+        it("should allow chaining pre-checkout query data checks", async () => {
+            composer.preCheckoutQuery(["nope"])
+                .preCheckoutQuery(["test", "nei"], middleware); // nope
+            composer.preCheckoutQuery(["nope", "test"])
+                .preCheckoutQuery(["nei"], middleware); // nope
+            composer.preCheckoutQuery(["nope", /test/])
+                .preCheckoutQuery(["test", "nei"], middleware);
+            await exec(c);
+            assertEquals(middleware.calls.length, 1);
+            assertEquals(middleware.calls[0].args[0], c);
+        });
+    });
+
+    describe(".shippingQuery", () => {
+        const c = new Context(
+            // deno-lint-ignore no-explicit-any
+            { shipping_query: { invoice_payload: "test" } } as any,
+            // deno-lint-ignore no-explicit-any
+            0 as any,
+            // deno-lint-ignore no-explicit-any
+            0 as any,
+        );
+        it("should check for shipping query data", async () => {
+            composer.shippingQuery("no-data", middleware);
+            composer.shippingQuery(["nope", "test"], middleware);
+            await exec(c);
+            assertEquals(middleware.calls.length, 1);
+            assertEquals(middleware.calls[0].args[0], c);
+        });
+        it("should allow chaining shipping query data checks", async () => {
+            composer.shippingQuery(["nope"])
+                .shippingQuery(["test", "nei"], middleware); // nope
+            composer.shippingQuery(["nope", "test"])
+                .shippingQuery(["nei"], middleware); // nope
+            composer.shippingQuery(["nope", /test/])
+                .shippingQuery(["test", "nei"], middleware);
+            await exec(c);
+            assertEquals(middleware.calls.length, 1);
+            assertEquals(middleware.calls[0].args[0], c);
+        });
+    });
+
     describe(".filter", () => {
         const t = () => true;
         const f = () => false;

--- a/test/composer.type.test.ts
+++ b/test/composer.type.test.ts
@@ -304,6 +304,32 @@ describe("Composer types", () => {
         });
     });
 
+    describe(".preCheckoutQuery", () => {
+        it("should have correct type for properties", () => {
+            composer.preCheckoutQuery("test", (ctx) => {
+                const invoicePayload = ctx.preCheckoutQuery.invoice_payload;
+                const match = ctx.match;
+                assertType<IsExact<typeof invoicePayload, string>>(true);
+                assertType<IsExact<typeof match, RegExpMatchArray | string>>(
+                    true,
+                );
+            });
+        });
+    });
+
+    describe(".shippingQuery", () => {
+        it("should have correct type for properties", () => {
+            composer.shippingQuery("test", (ctx) => {
+                const invoicePayload = ctx.shippingQuery.invoice_payload;
+                const match = ctx.match;
+                assertType<IsExact<typeof invoicePayload, string>>(true);
+                assertType<IsExact<typeof match, RegExpMatchArray | string>>(
+                    true,
+                );
+            });
+        });
+    });
+
     describe(".filter", () => {
         it("should have correct type for properties", () => {
             type TmpCtx = Context & { prop: number };

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -71,8 +71,8 @@ describe("Context", () => {
             from: u,
             inline_message_id: "y",
         },
-        shipping_query: { id: "d", from: u },
-        pre_checkout_query: { id: "e", from: u },
+        shipping_query: { id: "d", from: u, invoice_payload: "sq" },
+        pre_checkout_query: { id: "e", from: u, invoice_payload: "pcq" },
         poll: { id: "f" },
         poll_answer: { poll_id: "g" },
         my_chat_member: { date: 1, from: u, chat: c },
@@ -489,6 +489,30 @@ describe("Context", () => {
         assert(ctx.hasChosenInlineResult(/^p/));
         assertFalse(Context.has.chosenInlineResult("q")(ctx));
         assertFalse(ctx.hasChosenInlineResult("q"));
+    });
+
+    it("should be able to check for pre-checkout queries", () => {
+        const ctx = new Context(update, api, me);
+
+        assert(Context.has.preCheckoutQuery("pcq")(ctx));
+        assert(ctx.hasPreCheckoutQuery("pcq"));
+        assert(Context.has.preCheckoutQuery(/^p.q/)(ctx));
+        assertEquals(ctx.match, "pcq".match(/^p.q/));
+        assert(ctx.hasPreCheckoutQuery(/^p.q/));
+        assertFalse(Context.has.preCheckoutQuery("pq")(ctx));
+        assertFalse(ctx.hasPreCheckoutQuery("pq"));
+    });
+
+    it("should be able to check for shipping queries", () => {
+        const ctx = new Context(update, api, me);
+
+        assert(Context.has.shippingQuery("sq")(ctx));
+        assert(ctx.hasShippingQuery("sq"));
+        assert(Context.has.shippingQuery(/^s./)(ctx));
+        assertEquals(ctx.match, "sq".match(/^s./));
+        assert(ctx.hasShippingQuery(/^s./));
+        assertFalse(Context.has.shippingQuery("sp")(ctx));
+        assertFalse(ctx.hasShippingQuery("sp"));
     });
 
     it("should be able to match filter queries", () => {


### PR DESCRIPTION
This PQ adds `preCheckoutQuery()` and `shippingQuery()` to `Composer`. Developers can write regular expression to match the invoice payload of pre-checkout queries and shipping queries.
