### PR TITLE
feat: log webhook timeout in DEBUG mode

### DIFF
--- a/src/convenience/webhook.ts
+++ b/src/convenience/webhook.ts
@@ -140,6 +140,7 @@ function timeoutIfNecessary(
     if (timeout === Infinity) return task;
     return new Promise((resolve, reject) => {
         const handle = setTimeout(() => {
+            debugErr(`Request timed out after ${timeout} ms`);
             if (onTimeout === "throw") {
                 reject(new Error(`Request timed out after ${timeout} ms`));
             } else {


### PR DESCRIPTION
grammY already throws an error in these cases,
but sometimes, people don't put their errors in
the logs. This will fix that.