### PR TITLE
feat: suggest /developer_info as a command

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -38,7 +38,8 @@ export type StringWithCommandSuggestions =
     | "start"
     | "help"
     | "settings"
-    | "privacy";
+    | "privacy"
+    | "developer_info";
 
 type Other<M extends Methods<RawApi>, X extends string = never> = OtherApi<
     RawApi,


### PR DESCRIPTION
This is suggested in https://telegram.org/privacy-tpa so maybe embrace this a bit more?

See also #610