### PR TITLE
build: update deno2node, fix docs, add suggestions to sendDice

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -2,7 +2,7 @@
     "lock": false,
     "tasks": {
         "check": "deno cache --check=all src/mod.ts",
-        "backport": "deno run --no-prompt --allow-read=. --allow-write=. https://deno.land/x/deno2node@v1.9.0/src/cli.ts tsconfig.json",
+        "backport": "deno run --no-prompt --allow-read=. --allow-write=. https://deno.land/x/deno2node@v1.13.0/src/cli.ts tsconfig.json",
         "test": "deno test --seed=123456 --parallel ./test/",
         "dev": "deno fmt && deno lint && deno task test && deno task check",
         "coverage": "rm -rf ./test/cov_profile && deno task test --coverage=./test/cov_profile && deno coverage --lcov --output=./coverage.lcov ./test/cov_profile",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "@types/debug": "^4.1.12",
         "@types/node": "^12.20.55",
         "@types/node-fetch": "2.6.2",
-        "deno2node": "^1.9.0"
+        "deno2node": "^1.13.0"
     },
     "files": [
         "out/"

--- a/src/context.ts
+++ b/src/context.ts
@@ -1467,14 +1467,21 @@ export class Context implements RenamedUpdate {
     /**
      * Context-aware alias for `api.sendDice`. Use this method to send an animated emoji that will display a random value. On success, the sent Message is returned.
      *
-     * @param emoji Emoji on which the dice throw animation is based. Currently, must be one of “🎲”, “🎯”, “🏀”, “⚽”, or “🎰”. Dice can have values 1-6 for “🎲” and “🎯”, values 1-5 for “🏀” and “⚽”, and values 1-64 for “🎰”. Defaults to “🎲”
+     * @param emoji Emoji on which the dice throw animation is based. Currently, must be one of “🎲”, “🎯”, “🏀”, “⚽”, “🎳”, or “🎰”. Dice can have values 1-6 for “🎲”, “🎯” and “🎳”, values 1-5 for “🏀” and “⚽”, and values 1-64 for “🎰”. Defaults to “🎲”
      * @param other Optional remaining parameters, confer the official reference below
      * @param signal Optional `AbortSignal` to cancel the request
      *
      * **Official reference:** https://core.telegram.org/bots/api#senddice
      */
     replyWithDice(
-        emoji: string,
+        emoji:
+            | (string & Record<never, never>)
+            | "🎲"
+            | "🎯"
+            | "🏀"
+            | "⚽"
+            | "🎳"
+            | "🎰",
         other?: Other<"sendDice", "chat_id" | "emoji">,
         signal?: AbortSignal,
     ) {
@@ -2517,7 +2524,7 @@ export class Context implements RenamedUpdate {
      * @param other Optional remaining parameters, confer the official reference below
      * @param signal Optional `AbortSignal` to cancel the request
      *
-     * **Official reference:** https://core.telegram.org/bots/api#setchatmenubutton
+     * **Official reference:** https://core.telegram.org/bots/api#getchatmenubutton
      */
     getChatMenuButton(
         other?: Other<"getChatMenuButton">,

--- a/src/convenience/frameworks.ts
+++ b/src/convenience/frameworks.ts
@@ -413,6 +413,7 @@ const http: HttpAdapter = (req, res) => {
             req.on("data", (chunk: Chunk) => chunks.push(chunk))
                 .once("end", () => {
                     // @ts-ignore `Buffer` is Node-only
+                    // deno-lint-ignore no-node-globals
                     const raw = Buffer.concat(chunks).toString("utf-8");
                     resolve(JSON.parse(raw));
                 })

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -766,7 +766,7 @@ export class Api<R extends RawApi = RawApi> {
      * Use this method to send an animated emoji that will display a random value. On success, the sent Message is returned.
      *
      * @param chat_id Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-     * @param emoji Emoji on which the dice throw animation is based. Currently, must be one of “🎲”, “🎯”, “🏀”, “⚽”, or “🎰”. Dice can have values 1-6 for “🎲” and “🎯”, values 1-5 for “🏀” and “⚽”, and values 1-64 for “🎰”. Defaults to “🎲”
+     * @param emoji Emoji on which the dice throw animation is based. Currently, must be one of “🎲”, “🎯”, “🏀”, “⚽”, “🎳”, or “🎰”. Dice can have values 1-6 for “🎲”, “🎯” and “🎳”, values 1-5 for “🏀” and “⚽”, and values 1-64 for “🎰”. Defaults to “🎲”
      * @param other Optional remaining parameters, confer the official reference below
      * @param signal Optional `AbortSignal` to cancel the request
      *
@@ -774,7 +774,14 @@ export class Api<R extends RawApi = RawApi> {
      */
     sendDice(
         chat_id: number | string,
-        emoji: string,
+        emoji:
+            | (string & Record<never, never>)
+            | "🎲"
+            | "🎯"
+            | "🏀"
+            | "⚽"
+            | "🎳"
+            | "🎰",
         other?: Other<R, "sendDice", "chat_id" | "emoji">,
         signal?: AbortSignal,
     ) {
@@ -790,7 +797,7 @@ export class Api<R extends RawApi = RawApi> {
      * @param other Optional remaining parameters, confer the official reference below
      * @param signal Optional `AbortSignal` to cancel the request
      *
-     * **Official reference:** https://core.telegram.org/bots/api#senddice
+     * **Official reference:** https://core.telegram.org/bots/api#setmessagereaction
      */
     setMessageReaction(
         chat_id: number | string,


### PR DESCRIPTION
The JSDocs for `api.sendDice` and `ctx.replyWithDice` were missing '🎳'  so I brought them up to date with the latest changes on https://core.telegram.org/bots/api#senddice.
I also added suggestions for the parameter `emoji` following the style in `sendChatAction`. It might be reasonable to remove `| (string & Record<never, never>)` but I didn't want to introduce a breaking change.

I also fixed two JSDocs with an incorrect link to the documentation.