### PR TITLE
feat: detect concurrent polling/webhook setups and throw error

### DIFF
--- a/src/convenience/webhook.ts
+++ b/src/convenience/webhook.ts
@@ -92,7 +92,7 @@ export function webhookCallback<C extends Context = Context>(
 ) {
     if (bot.isRunning()) {
         throw new Error(
-            "Bot is already running via long polling, the webhook setup likely won't receive any updates!",
+            "Bot is already running via long polling, the webhook setup won't receive any updates!",
         );
     } else {
         bot.start = () => {

--- a/src/convenience/webhook.ts
+++ b/src/convenience/webhook.ts
@@ -8,7 +8,6 @@ import {
     adapters as nativeAdapters,
     type FrameworkAdapter,
 } from "./frameworks.ts";
-const debug = d("grammy:warn");
 const debugErr = d("grammy:error");
 
 const callbackAdapter: FrameworkAdapter = (
@@ -92,16 +91,14 @@ export function webhookCallback<C extends Context = Context>(
     secretToken?: WebhookOptions["secretToken"],
 ) {
     if (bot.isRunning()) {
-        debug(
+        throw new Error(
             "Bot is already running via long polling, the webhook setup likely won't receive any updates!",
         );
     } else {
-        const oldStart = bot.start.bind(bot);
-        bot.start = (...args) => {
-            debug(
+        bot.start = () => {
+            throw new Error(
                 "You already started the bot via webhooks, calling `bot.start()` starts the bot with long polling and this will prevent your webhook setup from receiving any updates!",
             );
-            return oldStart(...args);
         };
     }
     const {


### PR DESCRIPTION
People sometimes do
```ts
webhookCallback(bot)
bot.start()
```
or
```ts
bot.start()
webhookCallback(bot)
```
and in 99 % of cases, this is just wrong.

This PQ interdicts this type of usage and throws a helpful error message.

If this is actually desired (run the bot on built-in polling but then also supply old updates from a webhook queue, whatever) then it can be done anyway:

```ts
const middleware = new Composer()
middleware.use(..) // etc

const pollingBot = new Bot(token)
const webhookBot = new Bot(token)
pollingBot.use(middleware)
webhookBot.use(middleware)

pollingBot.start()
webhookCallback(webhookBot)
```