### PR TITLE
build: move helper type to JSR

### DIFF
--- a/test/deps.test.ts
+++ b/test/deps.test.ts
@@ -12,23 +12,7 @@ export {
 export { afterEach, beforeEach, describe, it } from "jsr:@std/testing/bdd";
 export { type Spy, spy, type Stub, stub } from "jsr:@std/testing/mock";
 export { assertType, type IsExact } from "jsr:@std/testing/types";
-
-/**
- * Checks if the actual type `A` is assignable to the expected type `E`, and
- * vice versa.
- *
- * ```ts
- * // false because E is not assignable to A
- * type P = IsMutuallyAssignable<string & RegExpMatchArray, string>;
- * // false because A is not assignable to E
- * type Q = IsMutuallyAssignable<string | RegExpMatchArray, string>;
- * // true
- * type R = IsMutuallyAssignable<string | (string & RegExpMatchArray), string>;
- * ```
- */
-export type IsMutuallyAssignable<A, E> = [E] extends [A]
-    ? [A] extends [E] ? true : false
-    : false;
+export { type IsMutuallyAssignable } from "jsr:@std/testing/unstable-types";
 
 /**
  * Collects a potentially async iterator of `Uint8Array` objects into a single


### PR DESCRIPTION
After https://github.com/denoland/std/pull/6154 was accepted, we no longer need to rely on our implementation of it. This PQ replaces it with the implementation from @std.