### PR TITLE
Update frameworks.ts

### DIFF
--- a/src/convenience/frameworks.ts
+++ b/src/convenience/frameworks.ts
@@ -309,6 +309,9 @@ const bun: BunAdapter = (request) => {
         unauthorized: () => {
             resolveResponse(unauthorized());
         },
+        handlerReturn: new Promise<Response>((resolve) => {
+            resolveResponse = resolve;
+        }),
     };
 };
 


### PR DESCRIPTION
74 |     let resolveResponse;
75 |     return {
76 |         update: request.json(),
77 |         header: request.headers.get(SECRET_HEADER) || undefined,
78 |         end: () => {
79 |             resolveResponse(ok());
                 ^
TypeError: resolveResponse is not a function. (In 'resolveResponse(ok())', 'resolveResponse' is undefined)