### PR TITLE
feat: add custom prefix for session key

### DIFF
--- a/src/convenience/session.ts
+++ b/src/convenience/session.ts
@@ -119,7 +119,7 @@ export interface SessionOptions<S, C extends Context = Context> {
      */
     initial?: () => S;
     /**
-     * A optional prefix to prepend to the session key after it was generated.
+     * An optional prefix to prepend to the session key after it was generated.
      *
      * This makes it easier to store session data under a namespace. You can
      * technically achieve the same functionality by returning an already

--- a/src/convenience/session.ts
+++ b/src/convenience/session.ts
@@ -229,9 +229,7 @@ export function session<S, C extends Context>(
 function strictSingleSession<S, C extends Context>(
     options: SessionOptions<S, C>,
 ): MiddlewareFn<C & SessionFlavor<S>> {
-    const { initial, storage, getSessionKey, custom } = fillDefaults(
-        options,
-    );
+    const { initial, storage, getSessionKey, custom } = fillDefaults(options);
     return async (ctx, next) => {
         const propSession = new PropertySession<SessionFlavor<S>, "session">(
             storage,
@@ -311,9 +309,7 @@ export function lazySession<S, C extends Context>(
     if (options.type !== undefined && options.type !== "single") {
         throw new Error("Cannot use lazy multi sessions!");
     }
-    const { initial, storage, getSessionKey, custom } = fillDefaults(
-        options,
-    );
+    const { initial, storage, getSessionKey, custom } = fillDefaults(options);
     return async (ctx, next) => {
         const propSession = new PropertySession(
             // @ts-expect-error suppress promise nature of values

--- a/test/convenience/session.test.ts
+++ b/test/convenience/session.test.ts
@@ -142,7 +142,7 @@ describe("session", () => {
         let ctx = { chatId: 42 } as C;
         composer.use(
             session({
-                prefix: "xyz",
+                prefix: "xyz-",
                 getSessionKey: (ctx) =>
                     ctx.chatId ? (ctx.chatId ** 2).toString() : undefined,
                 storage,


### PR DESCRIPTION
With multi sessions and the conversations plugin, storage adapters are used in many places. It needs to be made simple to store session data under namespaces. This PQ does that by adding a new option `prefix` to session config. The prefix will be prepended to every session key before reading, writing, or deleting data.