### PR TITLE
 feat: add possibility to catch errors with `bot.catch` on webhook

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -316,17 +316,7 @@ export class Bot<
         // handle updates sequentially (!)
         for (const update of updates) {
             this.lastTriedUpdateId = update.update_id;
-            try {
-                await this.handleUpdate(update);
-            } catch (err) {
-                // should always be true
-                if (err instanceof BotError) {
-                    await this.errorHandler(err);
-                } else {
-                    console.error("FATAL: grammY unable to handle:", err);
-                    throw err;
-                }
-            }
+            await this.handleUpdate(update);
         }
     }
 
@@ -367,7 +357,7 @@ a known bot info object.",
             await run(this.middleware(), ctx);
         } catch (err) {
             debugErr(`Error in middleware for update ${update.update_id}`);
-            throw new BotError<C>(err, ctx);
+            await this.errorHandler(new BotError<C>(err, ctx));
         }
     }
 

--- a/test/deps.test.ts
+++ b/test/deps.test.ts
@@ -3,6 +3,7 @@ export {
     assertEquals,
     assertFalse,
     assertInstanceOf,
+    assertIsError,
     assertNotStrictEquals,
     assertObjectMatch,
     assertRejects,


### PR DESCRIPTION
This PR adds error handling with bot.catch for webhooks.

I have several questions:

Should we log to the console if no handler is set in case of webhook (in the case of a default handler)?
Is it necessary to extend the try scope to cover the cases of new Api, new Context, and this.botInfo === undefined? I remove try-catch on a higher level caller handleUpdates which is using on polling.

Closes https://github.com/grammyjs/grammY/issues/702