### PR TITLE
refactor(webhook): change the way to get webhook handler 

### DIFF
--- a/src/convenience/frameworks.ts
+++ b/src/convenience/frameworks.ts
@@ -138,12 +138,8 @@ export type HonoAdapter = (c: {
         json: <T>() => Promise<T>;
         header: (header: string) => string | undefined;
     };
-    body: (
-        data: string | ArrayBuffer | ReadableStream | null,
-        // deno-lint-ignore no-explicit-any
-        arg?: any,
-        headers?: Record<string, string | string[]>,
-    ) => Response;
+    body(data: string): Response;
+    body(data: null, status: 204): Response;
     // deno-lint-ignore no-explicit-any
     status: (status: any) => void;
     json: (json: string) => Response;
@@ -390,14 +386,14 @@ const hono: HonoAdapter = (c) => {
         update: c.req.json(),
         header: c.req.header(SECRET_HEADER),
         end: () => {
-            resolveResponse(c.body(null));
+            resolveResponse(c.body(""));
         },
         respond: (json) => {
             resolveResponse(c.json(json));
         },
         unauthorized: () => {
             c.status(401);
-            resolveResponse(c.body(null));
+            resolveResponse(c.body(""));
         },
         handlerReturn: new Promise<Response>((resolve) => {
             resolveResponse = resolve;
@@ -545,23 +541,23 @@ const worktop: WorktopAdapter = (req, res) => ({
 
 // Please open a pull request if you want to add another adapter
 export const adapters = {
-    "aws-lambda": awsLambda,
-    "aws-lambda-async": awsLambdaAsync,
+    awsLambda,
+    awsLambdaAsync,
     azure,
     bun,
     cloudflare,
-    "cloudflare-mod": cloudflareModule,
+    cloudflareModule,
     express,
     fastify,
     hono,
     http,
     https: http,
     koa,
-    "next-js": nextJs,
+    nextJs,
     nhttp,
     oak,
     serveHttp,
-    "std/http": stdHttp,
+    stdHttp,
     sveltekit,
     worktop,
 };

--- a/src/convenience/webhook.ts
+++ b/src/convenience/webhook.ts
@@ -96,26 +96,66 @@ function createWebhookAdapter<
  * @param webhookOptions Further options for the webhook setup
  */
 export const webhookAdapters = {
-    awsLambda: createWebhookAdapter(adapters.awsLambda),
-    awsLambdaAsync: createWebhookAdapter(adapters.awsLambdaAsync),
-    azure: createWebhookAdapter(adapters.azure),
-    bun: createWebhookAdapter(adapters.bun),
-    cloudflare: createWebhookAdapter(adapters.cloudflare),
-    cloudflareModule: createWebhookAdapter(adapters.cloudflareModule),
-    express: createWebhookAdapter(adapters.express),
-    fastify: createWebhookAdapter(adapters.fastify),
-    hono: createWebhookAdapter(adapters.hono),
-    http: createWebhookAdapter(adapters.http),
-    https: createWebhookAdapter(adapters.http),
-    koa: createWebhookAdapter(adapters.koa),
-    nextJs: createWebhookAdapter(adapters.nextJs),
-    nhttp: createWebhookAdapter(adapters.nhttp),
-    oak: createWebhookAdapter(adapters.oak),
-    serveHttp: createWebhookAdapter(adapters.serveHttp),
-    stdHttp: createWebhookAdapter(adapters.stdHttp),
-    sveltekit: createWebhookAdapter(adapters.sveltekit),
-    worktop: createWebhookAdapter(adapters.worktop),
-    callback: createWebhookAdapter(adapters.callback),
+    get awsLambda() {
+        return createWebhookAdapter(adapters.awsLambda);
+    },
+    get awsLambdaAsync() {
+        return createWebhookAdapter(adapters.awsLambdaAsync);
+    },
+    get azure() {
+        return createWebhookAdapter(adapters.azure);
+    },
+    get bun() {
+        return createWebhookAdapter(adapters.bun);
+    },
+    get cloudflare() {
+        return createWebhookAdapter(adapters.cloudflare);
+    },
+    get cloudflareModule() {
+        return createWebhookAdapter(adapters.cloudflareModule);
+    },
+    get express() {
+        return createWebhookAdapter(adapters.express);
+    },
+    get fastify() {
+        return createWebhookAdapter(adapters.fastify);
+    },
+    get hono() {
+        return createWebhookAdapter(adapters.hono);
+    },
+    get http() {
+        return createWebhookAdapter(adapters.http);
+    },
+    get https() {
+        return createWebhookAdapter(adapters.http);
+    },
+    get koa() {
+        return createWebhookAdapter(adapters.koa);
+    },
+    get nextJs() {
+        return createWebhookAdapter(adapters.nextJs);
+    },
+    get nhttp() {
+        return createWebhookAdapter(adapters.nhttp);
+    },
+    get oak() {
+        return createWebhookAdapter(adapters.oak);
+    },
+    get serveHttp() {
+        return createWebhookAdapter(adapters.serveHttp);
+    },
+    get stdHttp() {
+        return createWebhookAdapter(adapters.stdHttp);
+    },
+    get sveltekit() {
+        return createWebhookAdapter(adapters.sveltekit);
+    },
+    get worktop() {
+        return createWebhookAdapter(adapters.worktop);
+    },
+    get callback() {
+        return createWebhookAdapter(adapters.callback);
+    },
 };
 
 /**

--- a/src/convenience/webhook.ts
+++ b/src/convenience/webhook.ts
@@ -168,8 +168,6 @@ function webhookCallback<C extends Context = Context>(
         secretToken,
     } = options ?? {};
 
-    console.log(onTimeout, timeoutMilliseconds, secretToken);
-
     if (bot.isRunning()) {
         throw new Error(
             "Bot is already running via long polling, the webhook setup won't receive any updates!",

--- a/src/convenience/webhook.ts
+++ b/src/convenience/webhook.ts
@@ -63,10 +63,10 @@ type WebhookAdapters<C extends Context = Context> = {
 function createWebhookAdapters<C extends Context = Context>(
     adapters: Adapters,
 ): WebhookAdapters<C> {
-    const callbacks = {} as WebhookAdapters<C>;
+    const handlers = {} as WebhookAdapters<C>;
 
     for (const [name, handler] of Object.entries(adapters)) {
-        callbacks[name as AdapterNames] = (
+        handlers[name as AdapterNames] = (
             bot: Bot<C>,
             onTimeout?:
                 | WebhookOptions
@@ -86,7 +86,7 @@ function createWebhookAdapters<C extends Context = Context>(
         };
     }
 
-    return callbacks;
+    return handlers;
 }
 
 /**

--- a/src/convenience/webhook.ts
+++ b/src/convenience/webhook.ts
@@ -34,13 +34,10 @@ export interface WebhookOptions {
 
 type Adapters = typeof adapters;
 type AdapterNames = keyof Adapters;
-type ResolveName<A extends FrameworkAdapter | AdapterNames> = A extends
-    AdapterNames ? Adapters[A] : A;
-type AdapterSignature<A extends Adapters[AdapterNames]> = (
-    ...args: Parameters<ResolveName<A>>
-) => ReturnType<ResolveName<A>>["handlerReturn"] extends undefined
-    ? Promise<void>
-    : NonNullable<ReturnType<ResolveName<A>>["handlerReturn"]>;
+type Adapter<A extends Adapters[AdapterNames]> = (
+    ...args: Parameters<A>
+) => ReturnType<A>["handlerReturn"] extends undefined ? Promise<void>
+    : NonNullable<ReturnType<A>["handlerReturn"]>;
 type WebhookAdapter<
     C extends Context = Context,
     A extends Adapters[AdapterNames] = Adapters[AdapterNames],
@@ -48,19 +45,19 @@ type WebhookAdapter<
     (
         bot: Bot<C>,
         webhookOptions?: WebhookOptions,
-    ): AdapterSignature<A>;
+    ): Adapter<A>;
     (
         bot: Bot<C>,
         onTimeout?: WebhookOptions["onTimeout"],
         timeoutMilliseconds?: WebhookOptions["timeoutMilliseconds"],
         secretToken?: WebhookOptions["secretToken"],
-    ): AdapterSignature<A>;
+    ): Adapter<A>;
 };
 
 function createWebhookAdapter<
     C extends Context = Context,
     A extends Adapters[AdapterNames] = Adapters[AdapterNames],
->(adapter: ResolveName<A>): WebhookAdapter<C, A> {
+>(adapter: A): WebhookAdapter<C, A> {
     return (
         bot: Bot<C>,
         onTimeout?:
@@ -118,6 +115,7 @@ export const webhookAdapters = {
     stdHttp: createWebhookAdapter(adapters.stdHttp),
     sveltekit: createWebhookAdapter(adapters.sveltekit),
     worktop: createWebhookAdapter(adapters.worktop),
+    callback: createWebhookAdapter(adapters.callback),
 };
 
 /**

--- a/src/convenience/webhook.ts
+++ b/src/convenience/webhook.ts
@@ -80,7 +80,7 @@ function createWebhookAdapter<
         return webhookCallback(bot, adapter, timeout, ms, token);
     };
 }
-// TODO: add docs exmaples for each adpter?
+// TODO: add docs examples for each adapter?
 /**
  * Contains factories of callback function that you can pass to a web framework
  * (such as express) if you want to run your bot via webhooks. Use it like this:

--- a/test/convenience/webhook.test.ts
+++ b/test/convenience/webhook.test.ts
@@ -11,7 +11,7 @@ import type bodyParser from "npm:@types/koa-bodyparser";
 import type Koa from "npm:@types/koa";
 import type { FastifyInstance } from "npm:fastify";
 import type { NextApiRequest, NextApiResponse } from "npm:next";
-import { Bot, BotError, webhookCallback } from "../../src/mod.ts";
+import { Bot, BotError, webhookAdapters } from "../../src/mod.ts";
 import type { UserFromGetMe } from "../../src/types.ts";
 import { assert, assertIsError, describe, it } from "../deps.test.ts";
 
@@ -20,7 +20,7 @@ describe("webhook", () => {
 
     it("AWS Lambda should be compatible with grammY adapter", () => {
         ((event: APIGatewayProxyEventV2, context: LambdaContext) =>
-            webhookCallback(bot, "aws-lambda-async")(
+            webhookAdapters.awsLambdaAsync(bot)(
                 event,
                 context,
             ));
@@ -33,7 +33,7 @@ describe("webhook", () => {
             },
         ) => object;
 
-        const handler = webhookCallback(bot, "bun");
+        const handler = webhookAdapters.bun(bot);
         const serve = (() => {}) as unknown as BunServe;
         serve({
             fetch: (request) => {
@@ -47,13 +47,13 @@ describe("webhook", () => {
             json: () => ({}),
             headers: { get: () => "" },
         } as unknown as Request;
-        const handler = webhookCallback(bot, "cloudflare-mod");
+        const handler = webhookAdapters.cloudflareModule(bot);
         const _res: Response = await handler(req);
     });
 
     it("Express should be compatible with grammY adapter", () => {
         const app = { post: () => {} } as unknown as Express;
-        const handler = webhookCallback(bot, "express");
+        const handler = webhookAdapters.express(bot);
         app.post("/", (req, res) => {
             return handler(req, res);
         });
@@ -61,7 +61,7 @@ describe("webhook", () => {
 
     it("Fastify should be compatible with grammY adapter", () => {
         const app = { post: () => {} } as unknown as FastifyInstance;
-        const handler = webhookCallback(bot, "fastify");
+        const handler = webhookAdapters.fastify(bot);
         app.post("/", (request, reply) => {
             return handler(request, reply);
         });
@@ -69,7 +69,7 @@ describe("webhook", () => {
 
     it("Hono should be compatible with grammY adapter", () => {
         const app = { post: () => {} } as unknown as Hono;
-        const handler = webhookCallback(bot, "hono");
+        const handler = webhookAdapters.hono(bot);
         app.post("/", (c) => {
             return handler(c);
         });
@@ -77,7 +77,7 @@ describe("webhook", () => {
 
     it("http/https should be compatible with grammY adapter", () => {
         const create = (() => {}) as unknown as typeof createServer;
-        const handler = webhookCallback(bot, "http");
+        const handler = webhookAdapters.http(bot);
         create((req, res) => {
             return handler(req, res);
         });
@@ -86,7 +86,7 @@ describe("webhook", () => {
     it("Koa should be compatible with grammY adapter", () => {
         const app = { use: () => {} } as unknown as Koa;
         const parser = (() => {}) as unknown as typeof bodyParser;
-        const handler = webhookCallback(bot, "koa");
+        const handler = webhookAdapters.koa(bot);
         app.use(parser());
         app.use((ctx) => {
             return handler(ctx);
@@ -99,13 +99,13 @@ describe("webhook", () => {
             body: { update: {} },
         } as unknown as NextApiRequest;
         const res = { end: () => {} } as NextApiResponse;
-        const handler = webhookCallback(bot, "next-js");
+        const handler = webhookAdapters.nextJs(bot);
         await handler(req, res);
     });
 
     it("NHttp should be compatible with grammY adapter", () => {
         const app = { post: () => {} } as unknown as NHttp;
-        const handler = webhookCallback(bot, "nhttp");
+        const handler = webhookAdapters.nhttp(bot);
         app.post("/", (rev) => {
             return handler(rev);
         });
@@ -113,7 +113,7 @@ describe("webhook", () => {
 
     it("Oak should be compatible with grammY adapter", () => {
         const app = { use: () => {} } as unknown as Application;
-        const handler = webhookCallback(bot, "oak");
+        const handler = webhookAdapters.oak(bot);
         app.use((ctx) => {
             return handler(ctx);
         });
@@ -127,13 +127,13 @@ describe("webhook", () => {
             }),
             respondWith: () => {},
         };
-        const handler = webhookCallback(bot, "serveHttp");
+        const handler = webhookAdapters.serveHttp(bot);
         await handler(event);
     });
 
     it("std/http should be compatible with grammY adapter", () => {
         const serve = (() => {}) as unknown as typeof Deno.serve;
-        const handler = webhookCallback(bot, "std/http");
+        const handler = webhookAdapters.stdHttp(bot);
         serve((req) => {
             return handler(req);
         });
@@ -150,7 +150,7 @@ describe("webhook", () => {
             throw new Error("Test Error");
         });
 
-        const handler = webhookCallback(bot, "std/http");
+        const handler = webhookAdapters.stdHttp(bot);
         const fakeReq = new Request("https://fake-api.com", {
             method: "POST",
             body: JSON.stringify({


### PR DESCRIPTION
PR aiming to close https://github.com/grammyjs/grammY/issues/695 and https://github.com/grammyjs/grammY/issues/696

I'm not good at typing, so I'm requesting help. There are couple "as" in a commit :)

I created a factory of factories to dynamically generate object with creators of callback handlers. I do not know how to document every object property in this case. If it is not necessary, we can just describe the main object.

Regarding the "return" type, I decided to rename it to "ignore" because it does not make any calls and leads to a safe logic branch. The user can pass an empty callback as an argument, and it will work pretty much the same, but with an unnecessary extra call.

So, if we want to slim down and simplify the API, we need to remove "ignore." If we want to gain a nano performance benefit, we should keep it.
