### PR TITLE
feat: fault tolerant body handling

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -6,7 +6,7 @@
     },
     "tasks": {
         "check": "deno check --all src/mod.ts",
-        "test": "deno test --seed=123456 test/",
+        "test": "deno test --allow-net --seed=123456 test/",
         "ok": "deno fmt --check && deno lint && deno task test && deno task check",
         "fix": "deno fmt && deno lint --fix",
         // TODO: bring back coverage reports

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -6,7 +6,7 @@
     },
     "tasks": {
         "check": "deno check --all src/mod.ts",
-        "test": "deno test --allow-net --seed=123456 test/",
+        "test": "deno test --seed=123456 test/",
         "ok": "deno fmt --check && deno lint && deno task test && deno task check",
         "fix": "deno fmt && deno lint --fix",
         // TODO: bring back coverage reports

--- a/src/convenience/frameworks.ts
+++ b/src/convenience/frameworks.ts
@@ -2,7 +2,8 @@ import type { Update } from "../types.ts";
 
 const SECRET_HEADER = "X-Telegram-Bot-Api-Secret-Token";
 const SECRET_HEADER_LOWERCASE = SECRET_HEADER.toLowerCase();
-const WRONG_TOKEN_ERROR = "secret token is wrong";
+export const WRONG_TOKEN_ERROR = "secret token is wrong";
+export const BAD_REQUEST_ERROR = "unable to parse request body";
 
 const ok = () => new Response(null, { status: 200 });
 const okJson = (json: string) =>
@@ -10,11 +11,9 @@ const okJson = (json: string) =>
         status: 200,
         headers: { "Content-Type": "application/json" },
     });
-const unauthorized = () =>
-    new Response('"unauthorized"', {
-        status: 401,
-        statusText: WRONG_TOKEN_ERROR,
-    });
+const unauthorized = () => new Response(WRONG_TOKEN_ERROR, { status: 401 });
+const badRequest = () => new Response(BAD_REQUEST_ERROR, { status: 400 });
+const empty = () => ({} as Update);
 
 /**
  * Abstraction over a request-response cycle, providing access to the update, as
@@ -46,6 +45,11 @@ export interface ReqResHandler<T = void> {
      * X-Telegram-Bot-Api-Secret-Token headers
      */
     unauthorized: () => unknown | Promise<unknown>;
+    /**
+     * Responds that the request is bad due to the body payload not being
+     * parsable or valid Update object
+     */
+    badRequest: () => unknown | Promise<unknown>;
     /**
      * Some frameworks (e.g. Deno's std/http `listenAndServe`) assume that
      * handler returns something
@@ -239,7 +243,7 @@ export type WorktopAdapter = (req: {
 
 /** AWS lambda serverless functions */
 const awsLambda: LambdaAdapter = (event, _context, callback) => ({
-    update: JSON.parse(event.body ?? "{}"),
+    update: Promise.resolve(JSON.parse(event.body ?? "{}")).catch(empty),
     header: event.headers[SECRET_HEADER],
     end: () => callback(null, { statusCode: 200 }),
     respond: (json) =>
@@ -249,6 +253,7 @@ const awsLambda: LambdaAdapter = (event, _context, callback) => ({
             body: json,
         }),
     unauthorized: () => callback(null, { statusCode: 401 }),
+    badRequest: () => callback(null, { statusCode: 400 }),
 });
 
 /** AWS lambda async/await serverless functions */
@@ -257,7 +262,7 @@ const awsLambdaAsync: LambdaAsyncAdapter = (event, _context) => {
     let resolveResponse: (response: any) => void;
 
     return {
-        update: JSON.parse(event.body ?? "{}"),
+        update: Promise.resolve(JSON.parse(event.body ?? "{}")).catch(empty),
         header: event.headers[SECRET_HEADER],
         end: () => resolveResponse({ statusCode: 200 }),
         respond: (json) =>
@@ -267,6 +272,7 @@ const awsLambdaAsync: LambdaAsyncAdapter = (event, _context) => {
                 body: json,
             }),
         unauthorized: () => resolveResponse({ statusCode: 401 }),
+        badRequest: () => resolveResponse({ statusCode: 400 }),
         handlerReturn: new Promise((resolve) => {
             resolveResponse = resolve;
         }),
@@ -288,13 +294,16 @@ const azure: AzureAdapter = (request, context) => ({
     unauthorized: () => {
         context.res?.send?.(401, WRONG_TOKEN_ERROR);
     },
+    badRequest: () => {
+        context.res?.send?.(400, BAD_REQUEST_ERROR);
+    },
 });
 
 /** Bun.serve */
 const bun: BunAdapter = (request) => {
     let resolveResponse: (response: Response) => void;
     return {
-        update: request.json(),
+        update: request.json().catch(empty),
         header: request.headers.get(SECRET_HEADER) || undefined,
         end: () => {
             resolveResponse(ok());
@@ -304,6 +313,9 @@ const bun: BunAdapter = (request) => {
         },
         unauthorized: () => {
             resolveResponse(unauthorized());
+        },
+        badRequest: () => {
+            resolveResponse(badRequest());
         },
         handlerReturn: new Promise<Response>((resolve) => {
             resolveResponse = resolve;
@@ -320,7 +332,7 @@ const cloudflare: CloudflareAdapter = (event) => {
         }),
     );
     return {
-        update: event.request.json(),
+        update: event.request.json().catch(empty),
         header: event.request.headers.get(SECRET_HEADER) || undefined,
         end: () => {
             resolveResponse(ok());
@@ -331,6 +343,9 @@ const cloudflare: CloudflareAdapter = (event) => {
         unauthorized: () => {
             resolveResponse(unauthorized());
         },
+        badRequest: () => {
+            resolveResponse(badRequest());
+        },
     };
 };
 
@@ -338,7 +353,7 @@ const cloudflare: CloudflareAdapter = (event) => {
 const cloudflareModule: CloudflareModuleAdapter = (request) => {
     let resolveResponse: (res: Response) => void;
     return {
-        update: request.json(),
+        update: request.json().catch(empty),
         header: request.headers.get(SECRET_HEADER) || undefined,
         end: () => {
             resolveResponse(ok());
@@ -348,6 +363,9 @@ const cloudflareModule: CloudflareModuleAdapter = (request) => {
         },
         unauthorized: () => {
             resolveResponse(unauthorized());
+        },
+        badRequest: () => {
+            resolveResponse(badRequest());
         },
         handlerReturn: new Promise<Response>((resolve) => {
             resolveResponse = resolve;
@@ -367,6 +385,9 @@ const express: ExpressAdapter = (req, res) => ({
     unauthorized: () => {
         res.status(401).send(WRONG_TOKEN_ERROR);
     },
+    badRequest: () => {
+        res.status(400).send(BAD_REQUEST_ERROR);
+    },
 });
 
 /** fastify web framework */
@@ -377,13 +398,14 @@ const fastify: FastifyAdapter = (request, reply) => ({
     respond: (json) =>
         reply.headers({ "Content-Type": "application/json" }).send(json),
     unauthorized: () => reply.code(401).send(WRONG_TOKEN_ERROR),
+    badRequest: () => reply.code(400).send(BAD_REQUEST_ERROR),
 });
 
 /** hono web framework */
 const hono: HonoAdapter = (c) => {
     let resolveResponse: (response: Response) => void;
     return {
-        update: c.req.json(),
+        update: c.req.json<Update>().catch(empty),
         header: c.req.header(SECRET_HEADER),
         end: () => {
             resolveResponse(c.body(""));
@@ -393,7 +415,11 @@ const hono: HonoAdapter = (c) => {
         },
         unauthorized: () => {
             c.status(401);
-            resolveResponse(c.body(""));
+            resolveResponse(c.body(WRONG_TOKEN_ERROR));
+        },
+        badRequest: () => {
+            c.status(400);
+            resolveResponse(c.body(BAD_REQUEST_ERROR));
         },
         handlerReturn: new Promise<Response>((resolve) => {
             resolveResponse = resolve;
@@ -405,7 +431,7 @@ const hono: HonoAdapter = (c) => {
 const http: HttpAdapter = (req, res) => {
     const secretHeaderFromRequest = req.headers[SECRET_HEADER_LOWERCASE];
     return {
-        update: new Promise((resolve, reject) => {
+        update: new Promise<Update>((resolve, reject) => {
             // deno-lint-ignore no-explicit-any
             type Chunk = any;
             const chunks: Chunk[] = [];
@@ -417,7 +443,7 @@ const http: HttpAdapter = (req, res) => {
                     resolve(JSON.parse(raw));
                 })
                 .once("error", reject);
-        }),
+        }).catch(empty),
         header: Array.isArray(secretHeaderFromRequest)
             ? secretHeaderFromRequest[0]
             : secretHeaderFromRequest,
@@ -427,6 +453,7 @@ const http: HttpAdapter = (req, res) => {
                 .writeHead(200, { "Content-Type": "application/json" })
                 .end(json),
         unauthorized: () => res.writeHead(401).end(WRONG_TOKEN_ERROR),
+        badRequest: () => res.writeHead(400).end(BAD_REQUEST_ERROR),
     };
 };
 
@@ -444,6 +471,9 @@ const koa: KoaAdapter = (ctx) => ({
     unauthorized: () => {
         ctx.status = 401;
     },
+    badRequest: () => {
+        ctx.status = 400;
+    },
 });
 
 /** Next.js Serverless Functions */
@@ -453,6 +483,7 @@ const nextJs: NextAdapter = (request, response) => ({
     end: () => response.end(),
     respond: (json) => response.status(200).json(json),
     unauthorized: () => response.status(401).send(WRONG_TOKEN_ERROR),
+    badRequest: () => response.status(400).send(BAD_REQUEST_ERROR),
 });
 
 /** nhttp web framework */
@@ -462,11 +493,12 @@ const nhttp: NHttpAdapter = (rev) => ({
     end: () => rev.response.sendStatus(200),
     respond: (json) => rev.response.status(200).send(json),
     unauthorized: () => rev.response.status(401).send(WRONG_TOKEN_ERROR),
+    badRequest: () => rev.response.status(400).send(BAD_REQUEST_ERROR),
 });
 
 /** oak web framework */
 const oak: OakAdapter = (ctx) => ({
-    update: ctx.request.body.json(),
+    update: ctx.request.body.json().catch(empty),
     header: ctx.request.headers.get(SECRET_HEADER) || undefined,
     end: () => {
         ctx.response.status = 200;
@@ -478,22 +510,26 @@ const oak: OakAdapter = (ctx) => ({
     unauthorized: () => {
         ctx.response.status = 401;
     },
+    badRequest: () => {
+        ctx.response.status = 400;
+    },
 });
 
 /** Deno.serve */
 const serveHttp: ServeHttpAdapter = (requestEvent) => ({
-    update: requestEvent.request.json(),
+    update: requestEvent.request.json().catch(empty),
     header: requestEvent.request.headers.get(SECRET_HEADER) || undefined,
     end: () => requestEvent.respondWith(ok()),
     respond: (json) => requestEvent.respondWith(okJson(json)),
     unauthorized: () => requestEvent.respondWith(unauthorized()),
+    badRequest: () => requestEvent.respondWith(badRequest()),
 });
 
 /** std/http web server */
 const stdHttp: StdHttpAdapter = (req) => {
     let resolveResponse: (response: Response) => void;
     return {
-        update: req.json(),
+        update: req.json().catch(empty),
         header: req.headers.get(SECRET_HEADER) || undefined,
         end: () => {
             if (resolveResponse) resolveResponse(ok());
@@ -503,6 +539,9 @@ const stdHttp: StdHttpAdapter = (req) => {
         },
         unauthorized: () => {
             if (resolveResponse) resolveResponse(unauthorized());
+        },
+        badRequest: () => {
+            if (resolveResponse) resolveResponse(badRequest());
         },
         handlerReturn: new Promise((resolve) => {
             resolveResponse = resolve;
@@ -514,7 +553,7 @@ const stdHttp: StdHttpAdapter = (req) => {
 const sveltekit: SveltekitAdapter = ({ request }) => {
     let resolveResponse: (res: Response) => void;
     return {
-        update: Promise.resolve(request.json()),
+        update: request.json().catch(empty),
         header: request.headers.get(SECRET_HEADER) || undefined,
         end: () => {
             if (resolveResponse) resolveResponse(ok());
@@ -525,18 +564,23 @@ const sveltekit: SveltekitAdapter = ({ request }) => {
         unauthorized: () => {
             if (resolveResponse) resolveResponse(unauthorized());
         },
+        badRequest: () => {
+            if (resolveResponse) resolveResponse(badRequest());
+        },
         handlerReturn: new Promise((resolve) => {
             resolveResponse = resolve;
         }),
     };
 };
+
 /** worktop Cloudflare workers framework */
 const worktop: WorktopAdapter = (req, res) => ({
-    update: Promise.resolve(req.json()),
+    update: req.json().catch(empty),
     header: req.headers.get(SECRET_HEADER) ?? undefined,
     end: () => res.end(null),
     respond: (json) => res.send(200, json),
     unauthorized: () => res.send(401, WRONG_TOKEN_ERROR),
+    badRequest: () => res.send(400, BAD_REQUEST_ERROR),
 });
 
 // Please open a pull request if you want to add another adapter

--- a/src/convenience/frameworks.ts
+++ b/src/convenience/frameworks.ts
@@ -243,7 +243,8 @@ export type WorktopAdapter = (req: {
 
 /** AWS lambda serverless functions */
 const awsLambda: LambdaAdapter = (event, _context, callback) => ({
-    update: Promise.resolve(JSON.parse(event.body ?? "{}")).catch(empty),
+    // TODO: add safe parse workaround
+    update: JSON.parse(event.body ?? "{}"),
     header: event.headers[SECRET_HEADER],
     end: () => callback(null, { statusCode: 200 }),
     respond: (json) =>
@@ -262,7 +263,8 @@ const awsLambdaAsync: LambdaAsyncAdapter = (event, _context) => {
     let resolveResponse: (response: any) => void;
 
     return {
-        update: Promise.resolve(JSON.parse(event.body ?? "{}")).catch(empty),
+        // TODO: add safe parse workaround
+        update: JSON.parse(event.body ?? "{}"),
         header: event.headers[SECRET_HEADER],
         end: () => resolveResponse({ statusCode: 200 }),
         respond: (json) =>

--- a/src/convenience/webhook.ts
+++ b/src/convenience/webhook.ts
@@ -206,7 +206,7 @@ function webhookCallback<C extends Context = Context>(
             return handlerReturn;
         }
         const updateData = await update;
-        if (!updateData?.update_id) {
+        if (updateData?.update_id === undefined || updateData.update_id <= 0) {
             await badRequest();
             return handlerReturn;
         }

--- a/test/convenience/webhook.test.ts
+++ b/test/convenience/webhook.test.ts
@@ -14,10 +14,6 @@ import type { NextApiRequest, NextApiResponse } from "npm:next";
 import { Bot, BotError, webhookAdapters } from "../../src/mod.ts";
 import type { UserFromGetMe } from "../../src/types.ts";
 import { assert, assertIsError, describe, it } from "../deps.test.ts";
-import {
-    BAD_REQUEST_ERROR,
-    WRONG_TOKEN_ERROR,
-} from "../../src/convenience/frameworks.ts";
 
 describe("webhook", () => {
     const bot = new Bot("dummy", { me: {} as unknown as UserFromGetMe });
@@ -160,61 +156,43 @@ describe("webhook", () => {
         });
 
         const handler = webhookAdapters.stdHttp(bot);
-        const fakeReq = new Request("https://fake-api.com", {
-            method: "POST",
-            body: JSON.stringify({ update_id: 9696, message: {} }),
-        });
 
-        await handler(fakeReq);
+        await handler(
+            new Request("https://fake-api.com", {
+                method: "POST",
+                body: JSON.stringify({ update_id: 9696, message: {} }),
+            }),
+        );
 
         assert(called);
     });
 
     describe("server webhook errors", () => {
-        const TEST_PORT = 6969 as const;
-        const TEST_SERVER = `http://localhost:${TEST_PORT}` as const;
-
         it("should response with 401 unauthorized status", async () => {
             const handler = webhookAdapters.stdHttp(bot, {
                 secretToken: "wrong-token",
             });
-            const server = Deno.serve({
-                port: TEST_PORT,
-                onListen: () => {},
-            }, handler);
 
-            const res = await fetch(TEST_SERVER, {
-                method: "POST",
-                body: JSON.stringify({ update_id: 9696 }),
-                signal: AbortSignal.timeout(1000),
-            });
+            const res = await handler(
+                new Request("https://fake-api.com", {
+                    method: "POST",
+                    body: JSON.stringify({ update_id: 9696 }),
+                }),
+            );
 
             assert(res.status === 401);
-            assert(res.statusText === "Unauthorized");
-            assert(await res.text() === WRONG_TOKEN_ERROR);
-
-            await server.shutdown();
-            await new Promise((resolve) => setTimeout(resolve, 30)); // wait for server ending connection
         });
 
         it("should response with 400 bad request status", async () => {
             const handler = webhookAdapters.stdHttp(bot);
-            const server = Deno.serve({
-                port: TEST_PORT,
-                onListen: () => {},
-            }, handler);
 
-            const res = await fetch(TEST_SERVER, {
-                method: "POST",
-                signal: AbortSignal.timeout(1000),
-            });
+            const res = await handler(
+                new Request("https://fake-api.com", {
+                    method: "POST",
+                }),
+            );
 
             assert(res.status === 400);
-            assert(res.statusText === "Bad Request");
-            assert(await res.text() === BAD_REQUEST_ERROR);
-
-            await server.shutdown();
-            await new Promise((resolve) => setTimeout(resolve, 30)); // wait for server ending connection
         });
     });
 });


### PR DESCRIPTION
The issue was originally described here: https://github.com/grammyjs/grammY/issues/613

**Short Summary:**
We assume that the body will be valid JSON. However, it can be empty or contain invalid JSON in some unusual cases. This can cause the server to crash due to an uncaught error triggered by JSON parsing in some of the adapters.

It was suggested to wrap it in a function, but I think that is unnecessary. We already have a promise and just need to safely resolve it to a value that we can then validate.

I suggest catching all promises where a crash can occur and returning an empty object. In `webhookCallback`, we can perform basic validation by checking the `update_id` field. In the case of an invalid body, we should return a 400 status to the client. Here, we need to add an extra callback to the adapter interface.

I added some e2e test cases to check for 400 and 401 errors, but it takes some time (~300-350ms on my machine).

As of `TODO: investigate deno bug that happens when this console logging is removed` - I didn't notice any issues. Maybe it's fixed now?

Closes: https://github.com/grammyjs/grammY/issues/697