### PR TITLE
fix: reduce `NotUndefined` to `{}`

### DIFF
--- a/src/filter.ts
+++ b/src/filter.ts
@@ -452,7 +452,8 @@ export type FilterQuery = ComputeFilterQueryList;
  * Any kind of value that appears in the Telegram Bot API. When intersected with
  * an optional field, it effectively removes `| undefined`.
  */
-type NotUndefined = string | number | boolean | object;
+// deno-lint-ignore ban-types
+type NotUndefined = {};
 
 /**
  * Given a FilterQuery, returns an object that, when intersected with an Update,


### PR DESCRIPTION
The filter queries were still written with TS pre-3.5 in mind. `{}` actually means “anything except null or undefined” nowadays (for a long time already) so we should be able to rely on this in order to remove undefined.

Reported in https://t.me/grammyjs/296604