### PR TITLE
build: prefer jsr.io/@std over deno.land/std

### DIFF
--- a/src/types.deno.ts
+++ b/src/types.deno.ts
@@ -1,5 +1,5 @@
 // === Needed imports
-import { basename } from "https://deno.land/std@0.211.0/path/basename.ts";
+import { basename } from "jsr:@std/path@1.0.9";
 
 import {
     type ApiMethods as ApiMethodsF,

--- a/src/types.deno.ts
+++ b/src/types.deno.ts
@@ -1,5 +1,5 @@
 // === Needed imports
-import { basename } from "jsr:@std/path@1.0.9";
+import { basename } from "jsr:@std/path@1.0.9/basename";
 
 import {
     type ApiMethods as ApiMethodsF,

--- a/src/types.web.ts
+++ b/src/types.web.ts
@@ -1,5 +1,5 @@
 // === Needed imports
-import { basename } from "jsr:@std/path@1.0.9";
+import { basename } from "jsr:@std/path@1.0.9/basename";
 
 import {
     type ApiMethods as ApiMethodsF,

--- a/src/types.web.ts
+++ b/src/types.web.ts
@@ -1,5 +1,6 @@
 // === Needed imports
-import { basename } from "https://deno.land/std@0.211.0/path/basename.ts";
+import { basename } from "jsr:@std/path@1.0.9";
+
 import {
     type ApiMethods as ApiMethodsF,
     type InputMedia as InputMediaF,


### PR DESCRIPTION
The old std no longer compiles. We need to update the version, and thus change the registry.

This only affects Deno-specific code. The Node build output will be byte-identical.