### PR TITLE
build: update deno_emit from JSR

### DIFF
--- a/bundling/bundle-web.ts
+++ b/bundling/bundle-web.ts
@@ -1,5 +1,5 @@
-import { bundle } from "https://deno.land/x/emit@0.28.0/mod.ts";
-import { createCache } from "https://deno.land/x/deno_cache@0.6.0/mod.ts";
+import { createCache } from "jsr:@deno/cache-dir@0.13.2";
+import { bundle } from "jsr:@deno/emit@0.46.0";
 
 // Parse args
 const [release, source = `https://deno.land/x/grammy@${release}/mod.ts`] =

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -3,13 +3,13 @@
     "nodeModulesDir": "none",
     "tasks": {
         "check": "deno cache --check=all --allow-import src/mod.ts",
-        "backport": "deno run --no-prompt --allow-read=. --allow-write=. https://deno.land/x/deno2node@v1.13.0/src/cli.ts tsconfig.json",
+        "backport": "deno --no-prompt --allow-read=. --allow-write=. https://deno.land/x/deno2node@v1.13.0/src/cli.ts tsconfig.json",
         "test": "deno test --seed=123456 --parallel --allow-import ./test/",
         "dev": "deno fmt && deno lint && deno task test && deno task check",
         "coverage": "rm -rf ./test/cov_profile && deno task test --coverage=./test/cov_profile && deno coverage --lcov --output=./coverage.lcov ./test/cov_profile",
         "report": "genhtml ./coverage.lcov --output-directory ./test/coverage/ && echo 'Point your browser to test/coverage/index.html to see the test coverage report.'",
-        "bundle-web": "mkdir -p out deno_cache && cd bundling && DENO_DIR=$PWD/../deno_cache deno run --unstable --quiet --allow-net --allow-read --allow-env=DENO_DIR,XDG_CACHE_HOME,HOME,DENO_AUTH_TOKENS --allow-write=../out,$PWD/../deno_cache bundle-web.ts dev ../src/mod.ts",
-        "contribs": "deno run --allow-env --allow-read --allow-write=. --allow-net=api.github.com --allow-sys npm:all-contributors-cli"
+        "bundle-web": "mkdir -p out deno_cache && cd bundling && deno -ENRW bundle-web.ts dev ../src/mod.ts",
+        "contribs": "deno -ERS --allow-write=. --allow-net=api.github.com npm:all-contributors-cli"
     },
     "exclude": [
         "./bundling/bundles",


### PR DESCRIPTION
The old deno_emit does not support JSR but it needs to do that after #802. We need to update the version, and thus change the registry.

This only affects the web build.
