### PR TITLE
build: remove workaround that strips source maps

### DIFF
--- a/bundling/bundle-web.ts
+++ b/bundling/bundle-web.ts
@@ -28,11 +28,7 @@ const { code: bundledCode } = await bundle(source, {
 });
 
 console.log("Emitting ...");
-// Strip the huge inline source map which is somehow generated anyway
-await Deno.writeTextFile(
-    "../out/web.mjs",
-    bundledCode.replace(/\/\/# sourceMappingURL=.*\n/, ""),
-);
+await Deno.writeTextFile("../out/web.mjs", bundledCode);
 await Deno.writeTextFile(
     "../out/web.d.ts",
     'export * from "./mod";\n',

--- a/bundling/bundle-web.ts
+++ b/bundling/bundle-web.ts
@@ -29,9 +29,6 @@ const { code: bundledCode } = await bundle(source, {
 
 console.log("Emitting ...");
 await Deno.writeTextFile("../out/web.mjs", bundledCode);
-await Deno.writeTextFile(
-    "../out/web.d.ts",
-    'export * from "./mod";\n',
-);
+await Deno.writeTextFile("../out/web.d.ts", 'export * from "./mod";\n');
 
 console.log("Done.");


### PR DESCRIPTION
There used to be a bug that source maps were generated even though we had disabled them. This was fixed, so we can remove the workaround.

Likely related to #804.