### PR TITLE
fix: bad type for Other in copyMessages

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -1077,7 +1077,7 @@ export class Context implements RenamedUpdate {
         message_ids: number[],
         other?: Other<
             "copyMessages",
-            "chat_id" | "from_chat_id" | "message_id"
+            "chat_id" | "from_chat_id" | "message_ids"
         >,
         signal?: AbortSignal,
     ) {

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -343,7 +343,7 @@ export class Api<R extends RawApi = RawApi> {
         other?: Other<
             R,
             "copyMessages",
-            "chat_id" | "from_chat_id" | "message_id"
+            "chat_id" | "from_chat_id" | "message_ids"
         >,
         signal?: AbortSignal,
     ) {


### PR DESCRIPTION
Was uncaught because of structural typing.