### PR TITLE
fix: unhandled rejections from lazy promise handling

### DIFF
--- a/src/convenience/frameworks.ts
+++ b/src/convenience/frameworks.ts
@@ -52,7 +52,7 @@ export interface ReqResHandler<T = void> {
      * Some frameworks (e.g. Deno's std/http `listenAndServe`) assume that
      * handler returns something
      */
-    handlerReturn?: MaybePromise<T>;
+    handlerReturn?: Promise<T>;
 }
 
 /**

--- a/src/convenience/frameworks.ts
+++ b/src/convenience/frameworks.ts
@@ -280,11 +280,7 @@ const awsLambdaAsync: LambdaAsyncAdapter = (event, _context) => {
                 body: json,
             }),
         unauthorized: () => resolveResponse({ statusCode: 401 }),
-        get handlerReturn() {
-            return new Promise<void>((resolve) => {
-                resolveResponse = resolve;
-            });
-        },
+        handlerReturn: new Promise<void>((res) => resolveResponse = res),
     };
 };
 
@@ -320,11 +316,7 @@ const azureV4: AzureAdapterV4 = (request) => {
         respond: (json) => resolveResponse({ jsonBody: json }),
         unauthorized: () =>
             resolveResponse({ status: 401, body: WRONG_TOKEN_ERROR }),
-        get handlerReturn() {
-            return new Promise<Res>((resolve) => {
-                resolveResponse = resolve;
-            });
-        },
+        handlerReturn: new Promise<Res>((resolve) => resolveResponse = resolve),
     };
 };
 
@@ -345,11 +337,7 @@ const bun: BunAdapter = (request) => {
         unauthorized: () => {
             resolveResponse(unauthorized());
         },
-        get handlerReturn() {
-            return new Promise<Response>((resolve) => {
-                resolveResponse = resolve;
-            });
-        },
+        handlerReturn: new Promise<Response>((res) => resolveResponse = res),
     };
 };
 
@@ -395,11 +383,7 @@ const cloudflareModule: CloudflareModuleAdapter = (request) => {
         unauthorized: () => {
             resolveResponse(unauthorized());
         },
-        get handlerReturn() {
-            return new Promise<Response>((resolve) => {
-                resolveResponse = resolve;
-            });
-        },
+        handlerReturn: new Promise<Response>((res) => resolveResponse = res),
     };
 };
 
@@ -449,9 +433,7 @@ const hono: HonoAdapter = (c) => {
             c.status(401);
             resolveResponse(c.body(""));
         },
-        handlerReturn: new Promise<Response>((resolve) => {
-            resolveResponse = resolve;
-        }),
+        handlerReturn: new Promise<Response>((res) => resolveResponse = res),
     };
 };
 
@@ -572,11 +554,7 @@ const stdHttp: StdHttpAdapter = (req) => {
         unauthorized: () => {
             if (resolveResponse) resolveResponse(unauthorized());
         },
-        get handlerReturn() {
-            return new Promise<Response>((resolve) => {
-                resolveResponse = resolve;
-            });
-        },
+        handlerReturn: new Promise<Response>((res) => resolveResponse = res),
     };
 };
 
@@ -597,11 +575,7 @@ const sveltekit: SveltekitAdapter = ({ request }) => {
         unauthorized: () => {
             if (resolveResponse) resolveResponse(unauthorized());
         },
-        get handlerReturn() {
-            return new Promise<Response>((resolve) => {
-                resolveResponse = resolve;
-            });
-        },
+        handlerReturn: new Promise<Response>((res) => resolveResponse = res),
     };
 };
 /** worktop Cloudflare workers framework */
@@ -619,7 +593,7 @@ const elysia: ElysiaAdapter = (ctx) => {
     // @note upgrade target to use modern code?
     // const { promise, resolve } = Promise.withResolvers<string>();
 
-    let resolve: (result: string) => void;
+    let resolveResponse: (result: string) => void;
 
     return {
         // @note technically the type shouldn't be limited to Promise, because it's fine to await plain values as well
@@ -628,20 +602,18 @@ const elysia: ElysiaAdapter = (ctx) => {
         },
         header: ctx.headers[SECRET_HEADER_LOWERCASE],
         end() {
-            resolve("");
+            resolveResponse("");
         },
         respond(json) {
             // @note since json is passed as string here, we gotta define proper content-type
             ctx.set.headers["content-type"] = "application/json";
-            resolve(json);
+            resolveResponse(json);
         },
         unauthorized() {
             ctx.set.status = 401;
-            resolve("");
+            resolveResponse("");
         },
-        get handlerReturn() {
-            return new Promise<string>((res) => resolve = res);
-        },
+        handlerReturn: new Promise<string>((res) => resolveResponse = res),
     };
 };
 

--- a/src/convenience/frameworks.ts
+++ b/src/convenience/frameworks.ts
@@ -16,6 +16,8 @@ const unauthorized = () =>
         statusText: WRONG_TOKEN_ERROR,
     });
 
+type MaybePromise<T> = T | Promise<T>;
+
 /**
  * Abstraction over a request-response cycle, providing access to the update, as
  * well as a mechanism for responding to the request and to end it.
@@ -25,7 +27,7 @@ export interface ReqResHandler<T = void> {
      * The update object sent from Telegram, usually resolves the request's JSON
      * body
      */
-    update: Promise<Update>;
+    update: MaybePromise<Update>;
     /**
      * X-Telegram-Bot-Api-Secret-Token header of the request, or undefined if
      * not present
@@ -50,7 +52,7 @@ export interface ReqResHandler<T = void> {
      * Some frameworks (e.g. Deno's std/http `listenAndServe`) assume that
      * handler returns something
      */
-    handlerReturn?: Promise<T>;
+    handlerReturn?: MaybePromise<T>;
 }
 
 /**
@@ -246,7 +248,9 @@ export type WorktopAdapter = (req: {
 
 /** AWS lambda serverless functions */
 const awsLambda: LambdaAdapter = (event, _context, callback) => ({
-    update: JSON.parse(event.body ?? "{}"),
+    get update() {
+        return JSON.parse(event.body ?? "{}");
+    },
     header: event.headers[SECRET_HEADER],
     end: () => callback(null, { statusCode: 200 }),
     respond: (json) =>
@@ -264,7 +268,9 @@ const awsLambdaAsync: LambdaAsyncAdapter = (event, _context) => {
     let resolveResponse: (response: any) => void;
 
     return {
-        update: JSON.parse(event.body ?? "{}"),
+        get update() {
+            return JSON.parse(event.body ?? "{}");
+        },
         header: event.headers[SECRET_HEADER],
         end: () => resolveResponse({ statusCode: 200 }),
         respond: (json) =>
@@ -274,15 +280,19 @@ const awsLambdaAsync: LambdaAsyncAdapter = (event, _context) => {
                 body: json,
             }),
         unauthorized: () => resolveResponse({ statusCode: 401 }),
-        handlerReturn: new Promise((resolve) => {
-            resolveResponse = resolve;
-        }),
+        get handlerReturn() {
+            return new Promise<void>((resolve) => {
+                resolveResponse = resolve;
+            });
+        },
     };
 };
 
 /** Azure Functions v3 and v4 */
 const azure: AzureAdapter = (context, request) => ({
-    update: Promise.resolve(request.body as Update),
+    get update() {
+        return request.body as Update;
+    },
     header: context.res?.headers?.[SECRET_HEADER],
     end: () => (context.res = {
         status: 200,
@@ -302,15 +312,19 @@ const azureV4: AzureAdapterV4 = (request) => {
     >;
     let resolveResponse: (response: Res) => void;
     return {
-        update: Promise.resolve(request.json()) as Promise<Update>,
+        get update() {
+            return request.json() as Promise<Update>;
+        },
         header: request.headers.get(SECRET_HEADER) || undefined,
         end: () => resolveResponse({ status: 204 }),
         respond: (json) => resolveResponse({ jsonBody: json }),
         unauthorized: () =>
             resolveResponse({ status: 401, body: WRONG_TOKEN_ERROR }),
-        handlerReturn: new Promise<Res>((resolve) => {
-            resolveResponse = resolve;
-        }),
+        get handlerReturn() {
+            return new Promise<Res>((resolve) => {
+                resolveResponse = resolve;
+            });
+        },
     };
 };
 
@@ -318,7 +332,9 @@ const azureV4: AzureAdapterV4 = (request) => {
 const bun: BunAdapter = (request) => {
     let resolveResponse: (response: Response) => void;
     return {
-        update: request.json(),
+        get update() {
+            return request.json() as Promise<Update>;
+        },
         header: request.headers.get(SECRET_HEADER) || undefined,
         end: () => {
             resolveResponse(ok());
@@ -329,9 +345,11 @@ const bun: BunAdapter = (request) => {
         unauthorized: () => {
             resolveResponse(unauthorized());
         },
-        handlerReturn: new Promise<Response>((resolve) => {
-            resolveResponse = resolve;
-        }),
+        get handlerReturn() {
+            return new Promise<Response>((resolve) => {
+                resolveResponse = resolve;
+            });
+        },
     };
 };
 
@@ -344,7 +362,9 @@ const cloudflare: CloudflareAdapter = (event) => {
         }),
     );
     return {
-        update: event.request.json(),
+        get update() {
+            return event.request.json() as Promise<Update>;
+        },
         header: event.request.headers.get(SECRET_HEADER) || undefined,
         end: () => {
             resolveResponse(ok());
@@ -362,7 +382,9 @@ const cloudflare: CloudflareAdapter = (event) => {
 const cloudflareModule: CloudflareModuleAdapter = (request) => {
     let resolveResponse: (res: Response) => void;
     return {
-        update: request.json(),
+        get update() {
+            return request.json() as Promise<Update>;
+        },
         header: request.headers.get(SECRET_HEADER) || undefined,
         end: () => {
             resolveResponse(ok());
@@ -373,15 +395,19 @@ const cloudflareModule: CloudflareModuleAdapter = (request) => {
         unauthorized: () => {
             resolveResponse(unauthorized());
         },
-        handlerReturn: new Promise<Response>((resolve) => {
-            resolveResponse = resolve;
-        }),
+        get handlerReturn() {
+            return new Promise<Response>((resolve) => {
+                resolveResponse = resolve;
+            });
+        },
     };
 };
 
 /** express web framework */
 const express: ExpressAdapter = (req, res) => ({
-    update: Promise.resolve(req.body),
+    get update() {
+        return req.body as Update;
+    },
     header: req.header(SECRET_HEADER),
     end: () => res.end(),
     respond: (json) => {
@@ -395,7 +421,9 @@ const express: ExpressAdapter = (req, res) => ({
 
 /** fastify web framework */
 const fastify: FastifyAdapter = (request, reply) => ({
-    update: Promise.resolve(request.body as Update),
+    get update() {
+        return request.body as Update;
+    },
     header: request.headers[SECRET_HEADER_LOWERCASE],
     end: () => reply.status(200).send(),
     respond: (json) =>
@@ -407,7 +435,9 @@ const fastify: FastifyAdapter = (request, reply) => ({
 const hono: HonoAdapter = (c) => {
     let resolveResponse: (response: Response) => void;
     return {
-        update: c.req.json(),
+        get update() {
+            return c.req.json() as Promise<Update>;
+        },
         header: c.req.header(SECRET_HEADER),
         end: () => {
             resolveResponse(c.body(""));
@@ -429,19 +459,21 @@ const hono: HonoAdapter = (c) => {
 const http: HttpAdapter = (req, res) => {
     const secretHeaderFromRequest = req.headers[SECRET_HEADER_LOWERCASE];
     return {
-        update: new Promise((resolve, reject) => {
-            // deno-lint-ignore no-explicit-any
-            type Chunk = any;
-            const chunks: Chunk[] = [];
-            req.on("data", (chunk: Chunk) => chunks.push(chunk))
-                .once("end", () => {
-                    // @ts-ignore `Buffer` is Node-only
-                    // deno-lint-ignore no-node-globals
-                    const raw = Buffer.concat(chunks).toString("utf-8");
-                    resolve(JSON.parse(raw));
-                })
-                .once("error", reject);
-        }),
+        get update() {
+            return new Promise((resolve, reject) => {
+                // deno-lint-ignore no-explicit-any
+                type Chunk = any;
+                const chunks: Chunk[] = [];
+                req.on("data", (chunk: Chunk) => chunks.push(chunk))
+                    .once("end", () => {
+                        // @ts-ignore `Buffer` is Node-only
+                        // deno-lint-ignore no-node-globals
+                        const raw = Buffer.concat(chunks).toString("utf-8");
+                        resolve(JSON.parse(raw));
+                    })
+                    .once("error", reject);
+            }) as Promise<Update>;
+        },
         header: Array.isArray(secretHeaderFromRequest)
             ? secretHeaderFromRequest[0]
             : secretHeaderFromRequest,
@@ -456,7 +488,9 @@ const http: HttpAdapter = (req, res) => {
 
 /** koa web framework */
 const koa: KoaAdapter = (ctx) => ({
-    update: Promise.resolve(ctx.request.body as Update),
+    get update() {
+        return ctx.request.body as Update;
+    },
     header: ctx.get(SECRET_HEADER) || undefined,
     end: () => {
         ctx.body = "";
@@ -472,7 +506,9 @@ const koa: KoaAdapter = (ctx) => ({
 
 /** Next.js Serverless Functions */
 const nextJs: NextAdapter = (request, response) => ({
-    update: Promise.resolve(request.body),
+    get update() {
+        return request.body as Update;
+    },
     header: request.headers[SECRET_HEADER_LOWERCASE] as string,
     end: () => response.end(),
     respond: (json) => response.status(200).json(json),
@@ -481,7 +517,9 @@ const nextJs: NextAdapter = (request, response) => ({
 
 /** nhttp web framework */
 const nhttp: NHttpAdapter = (rev) => ({
-    update: Promise.resolve(rev.body as Update),
+    get update() {
+        return rev.body as Update;
+    },
     header: rev.headers.get(SECRET_HEADER) || undefined,
     end: () => rev.response.sendStatus(200),
     respond: (json) => rev.response.status(200).send(json),
@@ -490,7 +528,9 @@ const nhttp: NHttpAdapter = (rev) => ({
 
 /** oak web framework */
 const oak: OakAdapter = (ctx) => ({
-    update: ctx.request.body.json(),
+    get update() {
+        return ctx.request.body.json() as Promise<Update>;
+    },
     header: ctx.request.headers.get(SECRET_HEADER) || undefined,
     end: () => {
         ctx.response.status = 200;
@@ -506,7 +546,9 @@ const oak: OakAdapter = (ctx) => ({
 
 /** Deno.serve */
 const serveHttp: ServeHttpAdapter = (requestEvent) => ({
-    update: requestEvent.request.json(),
+    get update() {
+        return requestEvent.request.json() as Promise<Update>;
+    },
     header: requestEvent.request.headers.get(SECRET_HEADER) || undefined,
     end: () => requestEvent.respondWith(ok()),
     respond: (json) => requestEvent.respondWith(okJson(json)),
@@ -517,7 +559,9 @@ const serveHttp: ServeHttpAdapter = (requestEvent) => ({
 const stdHttp: StdHttpAdapter = (req) => {
     let resolveResponse: (response: Response) => void;
     return {
-        update: req.json(),
+        get update() {
+            return req.json() as Promise<Update>;
+        },
         header: req.headers.get(SECRET_HEADER) || undefined,
         end: () => {
             if (resolveResponse) resolveResponse(ok());
@@ -528,9 +572,11 @@ const stdHttp: StdHttpAdapter = (req) => {
         unauthorized: () => {
             if (resolveResponse) resolveResponse(unauthorized());
         },
-        handlerReturn: new Promise((resolve) => {
-            resolveResponse = resolve;
-        }),
+        get handlerReturn() {
+            return new Promise<Response>((resolve) => {
+                resolveResponse = resolve;
+            });
+        },
     };
 };
 
@@ -538,7 +584,9 @@ const stdHttp: StdHttpAdapter = (req) => {
 const sveltekit: SveltekitAdapter = ({ request }) => {
     let resolveResponse: (res: Response) => void;
     return {
-        update: Promise.resolve(request.json()),
+        get update() {
+            return request.json() as Promise<Update>;
+        },
         header: request.headers.get(SECRET_HEADER) || undefined,
         end: () => {
             if (resolveResponse) resolveResponse(ok());
@@ -549,14 +597,18 @@ const sveltekit: SveltekitAdapter = ({ request }) => {
         unauthorized: () => {
             if (resolveResponse) resolveResponse(unauthorized());
         },
-        handlerReturn: new Promise((resolve) => {
-            resolveResponse = resolve;
-        }),
+        get handlerReturn() {
+            return new Promise<Response>((resolve) => {
+                resolveResponse = resolve;
+            });
+        },
     };
 };
 /** worktop Cloudflare workers framework */
 const worktop: WorktopAdapter = (req, res) => ({
-    update: Promise.resolve(req.json()),
+    get update() {
+        return req.json() as Promise<Update>;
+    },
     header: req.headers.get(SECRET_HEADER) ?? undefined,
     end: () => res.end(null),
     respond: (json) => res.send(200, json),
@@ -568,11 +620,12 @@ const elysia: ElysiaAdapter = (ctx) => {
     // const { promise, resolve } = Promise.withResolvers<string>();
 
     let resolve: (result: string) => void;
-    const handlerReturn = new Promise<string>((res) => resolve = res);
 
     return {
         // @note technically the type shouldn't be limited to Promise, because it's fine to await plain values as well
-        update: Promise.resolve(ctx.body as Update),
+        get update() {
+            return ctx.body as Update;
+        },
         header: ctx.headers[SECRET_HEADER_LOWERCASE],
         end() {
             resolve("");
@@ -586,7 +639,9 @@ const elysia: ElysiaAdapter = (ctx) => {
             ctx.set.status = 401;
             resolve("");
         },
-        handlerReturn,
+        get handlerReturn() {
+            return new Promise<string>((res) => resolve = res);
+        },
     };
 };
 


### PR DESCRIPTION
More explanation here: https://github.com/grammyjs/grammY/pull/816#issuecomment-3180716466

We turned `ReqResHandler::update` into a getter to allow handling update promises lazily without breaking API.