### PR TITLE
build: update all deps, ignore new linting rules

### DIFF
--- a/bundling/bundle-web.ts
+++ b/bundling/bundle-web.ts
@@ -1,4 +1,6 @@
-import { createCache } from "jsr:@deno/cache-dir@0.13.2";
+// deno-lint-ignore-file no-import-prefix
+
+import { createCache } from "jsr:@deno/cache-dir@0.25.0";
 import { bundle } from "jsr:@deno/emit@0.46.0";
 
 // Parse args

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -3,7 +3,7 @@
     "nodeModulesDir": "none",
     "tasks": {
         "check": "deno cache --allow-import src/mod.ts",
-        "backport": "deno --no-prompt --allow-read=. --allow-write=. https://deno.land/x/deno2node@v1.13.0/src/cli.ts tsconfig.json",
+        "backport": "deno --no-prompt --allow-read=. --allow-write=. https://deno.land/x/deno2node@v1.16.0/src/cli.ts tsconfig.json",
         "test": "deno test --seed=123456 --parallel --allow-import ./test/",
         "dev": "deno fmt && deno lint && deno task test && deno task check",
         "coverage": "rm -rf ./test/cov_profile && deno task test --coverage=./test/cov_profile && deno coverage --lcov --output=./coverage.lcov ./test/cov_profile",

--- a/package.json
+++ b/package.json
@@ -17,16 +17,16 @@
         "backport": "deno2node tsconfig.json"
     },
     "dependencies": {
-        "@grammyjs/types": "3.22.1",
+        "@grammyjs/types": "3.22.2",
         "abort-controller": "^3.0.0",
-        "debug": "^4.3.4",
+        "debug": "^4.4.3",
         "node-fetch": "^2.7.0"
     },
     "devDependencies": {
         "@types/debug": "^4.1.12",
         "@types/node": "^12.20.55",
-        "@types/node-fetch": "2.6.2",
-        "deno2node": "^1.13.0"
+        "@types/node-fetch": "2.6.13",
+        "deno2node": "^1.16.0"
     },
     "files": [
         "out/"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "devDependencies": {
         "@types/debug": "^4.1.12",
         "@types/node": "^12.20.55",
-        "@types/node-fetch": "2.6.13",
+        "@types/node-fetch": "2.6.2",
         "deno2node": "^1.16.0"
     },
     "files": [

--- a/src/platform.deno.ts
+++ b/src/platform.deno.ts
@@ -1,8 +1,10 @@
+// deno-lint-ignore-file no-import-prefix
+
 /** Are we running on Deno or in a web browser? */
 export const isDeno = typeof Deno !== "undefined";
 
 // === Export debug
-import debug from "https://cdn.skypack.dev/debug@4.3.4";
+import debug from "https://cdn.skypack.dev/debug@4.4.3";
 export { debug };
 const DEBUG = "DEBUG";
 if (isDeno) {

--- a/src/platform.web.ts
+++ b/src/platform.web.ts
@@ -1,4 +1,6 @@
-import d from "https://cdn.skypack.dev/debug@4.3.4";
+// deno-lint-ignore-file no-import-prefix
+
+import d from "https://cdn.skypack.dev/debug@4.4.3";
 export { d as debug };
 
 // === Export system-specific operations

--- a/src/types.deno.ts
+++ b/src/types.deno.ts
@@ -1,5 +1,7 @@
+// deno-lint-ignore-file no-import-prefix
+
 // === Needed imports
-import { basename } from "jsr:@std/path@1.0.9/basename";
+import { basename } from "jsr:@std/path@1.1.2/basename";
 
 import {
     type ApiMethods as ApiMethodsF,
@@ -20,13 +22,13 @@ import {
     type InputStoryContentPhoto as InputStoryContentPhotoF,
     type InputStoryContentVideo as InputStoryContentVideoF,
     type Opts as OptsF,
-} from "https://deno.land/x/grammy_types@v3.22.1/mod.ts";
+} from "https://deno.land/x/grammy_types@v3.22.2/mod.ts";
 import { debug as d, isDeno } from "./platform.deno.ts";
 
 const debug = d("grammy:warn");
 
 // === Export all API types
-export * from "https://deno.land/x/grammy_types@v3.22.1/mod.ts";
+export * from "https://deno.land/x/grammy_types@v3.22.2/mod.ts";
 
 /** A value, or a potentially async function supplying that value */
 type MaybeSupplier<T> = T | (() => T | Promise<T>);

--- a/src/types.web.ts
+++ b/src/types.web.ts
@@ -1,5 +1,7 @@
+// deno-lint-ignore-file no-import-prefix
+
 // === Needed imports
-import { basename } from "jsr:@std/path@1.0.9/basename";
+import { basename } from "jsr:@std/path@1.1.2/basename";
 
 import {
     type ApiMethods as ApiMethodsF,
@@ -20,10 +22,10 @@ import {
     type InputStoryContentPhoto as InputStoryContentPhotoF,
     type InputStoryContentVideo as InputStoryContentVideoF,
     type Opts as OptsF,
-} from "https://deno.land/x/grammy_types@v3.22.1/mod.ts";
+} from "https://deno.land/x/grammy_types@v3.22.2/mod.ts";
 
 // === Export all API types
-export * from "https://deno.land/x/grammy_types@v3.22.1/mod.ts";
+export * from "https://deno.land/x/grammy_types@v3.22.2/mod.ts";
 
 /** Something that looks like a URL. */
 interface URLLike {

--- a/test/convenience/webhook.test.ts
+++ b/test/convenience/webhook.test.ts
@@ -1,3 +1,5 @@
+// deno-lint-ignore-file no-unversioned-import no-import-prefix
+
 import type { Hono } from "jsr:@hono/hono";
 import type {
     APIGatewayProxyEventV2,


### PR DESCRIPTION
- updates all deps to latest of the same major version
- suppresses new linting rules that do not apply to libraries