### PR TITLE
fix: add "purchased_paid_media" to the list of default update types

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -39,6 +39,7 @@ export const DEFAULT_UPDATE_TYPES = [
     "callback_query",
     "shipping_query",
     "pre_checkout_query",
+    "purchased_paid_media",
     "poll",
     "poll_answer",
     "my_chat_member",


### PR DESCRIPTION
Follows the same order as defined in `Update`, therefore it's between `"pre_checkout_query"` and `"poll"`.