### PR TITLE
fix: update type of BunAdapter json body

### DIFF
--- a/src/convenience/frameworks.ts
+++ b/src/convenience/frameworks.ts
@@ -97,7 +97,7 @@ export type AzureAdapterV4 = (
 
 export type BunAdapter = (request: {
     headers: Headers;
-    json: () => Promise<Update>;
+    json: () => Promise<unknown>;
 }) => ReqResHandler<Response>;
 
 export type CloudflareAdapter = (event: {


### PR DESCRIPTION
This code currently shows a typing error due to incompatible `request`s:
```ts
import { Bot, webhookCallback } from "grammy";

const bot = new Bot("");
Bun.serve({
  routes: {
    "/webhook": {
      POST: webhookCallback(bot, "bun"),
    },
  },
});
```
This pull request aligns the type of `json()` with bun.