### PR TITLE
feat: support getting boosts for current chat

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -1820,9 +1820,9 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#getuserchatboosts
      */
-    getUserChatBoosts(chat_id: number | string, signal?: AbortSignal) {
+    getUserChatBoosts(chat_id?: number | string, signal?: AbortSignal) {
         return this.api.getUserChatBoosts(
-            chat_id,
+            chat_id ?? orThrow(this.chatId, "getUserChatBoosts"),
             orThrow(this.from, "getUserChatBoosts").id,
             signal,
         );


### PR DESCRIPTION
Currently `getUserChatBoosts` can get the boosts for the current user and a specific chat. What if you want to get the boosts for the current user in the current chat, such as in a group chat?

This PQ makes the `chat_id` an optional parameter that defaults to `ctx.chatId`.