### PR TITLE
chore: update Deno automatically

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -35,7 +35,7 @@ jobs:
 
             - uses: denoland/setup-deno@v2
               with:
-                  deno-version: v2.5.x
+                  deno-version: v2.x
 
             - name: Check Format
               run: deno fmt --check
@@ -56,7 +56,7 @@ jobs:
 
             - uses: denoland/setup-deno@v2
               with:
-                  deno-version: v2.5.x
+                  deno-version: v2.x
 
             - name: Cache Dependencies
               run: deno task check
@@ -74,7 +74,7 @@ jobs:
 
             - uses: denoland/setup-deno@v2
               with:
-                  deno-version: v2.5.x
+                  deno-version: v2.x
 
             - name: Create coverage files
               run: deno task coverage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
             - uses: denoland/setup-deno@v2
               with:
-                  deno-version: v2.5.x
+                  deno-version: v2.x
 
             - run: npm install
             - run: deno task bundle-web

--- a/.github/workflows/third_party.yml
+++ b/.github/workflows/third_party.yml
@@ -30,7 +30,7 @@ jobs:
         steps:
             - uses: denoland/setup-deno@v2
               with:
-                  deno-version: v2.5.x
+                  deno-version: v2.x
 
             - name: Create import_map.json
               run: |


### PR DESCRIPTION
We pinned it at 2.5.x due to a type bug, but that is fixed so now we can go back to using 2.x releases