### PR TITLE
fix: resolve `ctx.from` for `managed_bot` updates

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -559,7 +559,7 @@ export class Context implements RenamedUpdate {
     }
     /**
      * Get the user object from wherever possible. Alias for
-     * `(this.businessConnection ?? this.messageReaction ??
+     * `(this.businessConnection ?? this.messageReaction ?? this.managedBot ??
      * (this.chatBoost?.boost ?? this.removedChatBoost)?.source)?.user ??
      * (this.callbackQuery ?? this.msg ?? this.inlineQuery ??
      * this.chosenInlineResult ?? this.shippingQuery ?? this.preCheckoutQuery ??
@@ -571,6 +571,7 @@ export class Context implements RenamedUpdate {
         return (
             this.businessConnection ??
                 this.messageReaction ??
+                this.managedBot ??
                 (this.chatBoost?.boost ?? this.removedChatBoost)?.source
         )?.user ??
             (

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -669,6 +669,7 @@ interface Shortcuts<U extends Update> {
         ? U["business_connection"]["user"]
         : [U["message_reaction"]] extends [object]
             ? U["message_reaction"]["user"]
+        : [U["managed_bot"]] extends [object] ? U["managed_bot"]["user"]
         : [U["chat_boost"]] extends [object]
             ? U["chat_boost"]["boost"]["source"]["user"]
         : [U["removed_chat_boost"]] extends [object]

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -203,6 +203,9 @@ describe("Context", () => {
         up = { message_reaction: update.message_reaction } as Update;
         ctx = new Context(up, api, me);
         assertEquals(ctx.from, up.message_reaction?.user);
+        up = { managed_bot: update.managed_bot } as Update;
+        ctx = new Context(up, api, me);
+        assertEquals(ctx.from, up.managed_bot?.user);
         up = { chat_boost: update.chat_boost } as Update;
         ctx = new Context(up, api, me);
         assertEquals(ctx.from, up.chat_boost?.boost.source.user);


### PR DESCRIPTION
## Summary

Bot API 9.6 introduced the `managed_bot` update type. `ManagedBotUpdated.user` is a required `User` field per the [spec](https://core.telegram.org/bots/api#managedbotupdated). The `ctx.managedBot` alias, the `managed_bot` filter key, and the API/keyboard helpers were wired up in #892, but `ctx.from` was not updated:

- Runtime (`src/context.ts`): the `from` getter's `.user` resolution group only covers `businessConnection`, `messageReaction`, `chatBoost.boost.source`, and `removedChatBoost.source` — so inside `bot.on("managed_bot", ctx => ctx.from)` the getter returns `undefined`.
- Type-level (`src/filter.ts`): `Shortcuts.from` has no branch for `U["managed_bot"]`, so the filtered context types `ctx.from` as `undefined` too.

## Changes

- Add `this.managedBot` to the `.user` fallback chain in the `from` getter, and update its JSDoc.
- Add a matching conditional for `U["managed_bot"]["user"]` in `Shortcuts.from`.
- Add an assertion in `test/context.test.ts` that `ctx.from === update.managed_bot.user` (the `managed_bot` fixture was already there).

## Test plan

- [x] `deno task test` — 38 suites / 443 steps pass
- [x] `deno fmt --check`
- [x] `deno lint`
- [x] `deno task check`