### PR TITLE
fix(azure): read secret-token header from request, not response

### DIFF
--- a/src/convenience/frameworks.ts
+++ b/src/convenience/frameworks.ts
@@ -87,7 +87,10 @@ export type AzureAdapter = (context: {
         // deno-lint-ignore no-explicit-any
         [key: string]: any;
     };
-}, request: { body?: unknown }) => ReqResHandler;
+}, request: {
+    body?: unknown;
+    headers?: Record<string, string | undefined>;
+}) => ReqResHandler;
 export type AzureAdapterV4 = (
     request: {
         headers: { get(name: string): string | null };
@@ -297,7 +300,7 @@ const azure: AzureAdapter = (context, request) => ({
     get update() {
         return request.body as Update;
     },
-    header: context.res?.headers?.[SECRET_HEADER],
+    header: request.headers?.[SECRET_HEADER_LOWERCASE],
     end: () => (context.res = {
         status: 200,
         body: "",


### PR DESCRIPTION
## Summary

The Azure Functions v3 webhook adapter reads the `X-Telegram-Bot-Api-Secret-Token` header from `context.res?.headers` — the **outgoing response** object, which is always unset on the way in. Any Azure-v3 user who configured `secretToken` on `webhookCallback` had every update rejected with **401**, because the adapter always returned `header: undefined` and `compareSecretToken` rejects when a token is configured but no header is present.

Users who do not configure `secretToken` are unaffected, which is why this has gone unnoticed.

## What changed

\`\`\`diff
-}, request: { body?: unknown }) => ReqResHandler;
+}, request: {
+    body?: unknown;
+    headers?: Record<string, string | undefined>;
+}) => ReqResHandler;
\`\`\`

\`\`\`diff
-    header: context.res?.headers?.[SECRET_HEADER],
+    header: request.headers?.[SECRET_HEADER_LOWERCASE],
\`\`\`

- Reads from the incoming `request.headers` (second handler parameter) instead of the outgoing response object.
- Uses `SECRET_HEADER_LOWERCASE` because the Azure Functions v3 Node runtime lowercases all inbound header keys (see [Azure/azure-functions-nodejs-worker#274](https://github.com/Azure/azure-functions-nodejs-worker/issues/274)). This matches the pattern already used by the `fastify`, `http`, `next-js`, and `elysia` adapters in the same file.
- Widens the `AzureAdapter` type so `request.headers` is declared rather than accessed via an assertion.

The outgoing-response side of the adapter (`end` / `respond` / `unauthorized`, which writes to `context.res`) is correct and untouched. Azure v4 adapter is unaffected — it uses the Fetch `Headers.get()` interface.

## Test plan

- [x] `deno task check` passes
- [x] `deno check --allow-import src/mod.ts` passes
- [x] `deno task test` — 38 suites, 443 steps, all pass
- [x] Manual smoke: lowercased `x-telegram-bot-api-secret-token` header is returned; missing/undefined headers return `undefined` without throwing
- [ ] Verified on a live Azure v3 function (not required for merge but confirming here would be ideal)

## Adjacent follow-up (not in this PR)

While auditing, the AWS Lambda adapters (`awsLambda`, `awsLambdaAsync`) read the header case-sensitively via `event.headers[SECRET_HEADER]`. API Gateway's HTTP API (payload format v2) lowercases headers, so users on v2 likely have the same class of bug. Happy to open a separate PR for that after this one lands.