### PR TITLE
fix(aws-lambda): accept lowercased secret-token header for HTTP API

### DIFF
--- a/src/convenience/frameworks.ts
+++ b/src/convenience/frameworks.ts
@@ -262,7 +262,8 @@ const awsLambda: LambdaAdapter = (event, _context, callback) => ({
     get update() {
         return JSON.parse(event.body ?? "{}");
     },
-    header: event.headers[SECRET_HEADER],
+    header: event.headers[SECRET_HEADER] ??
+        event.headers[SECRET_HEADER_LOWERCASE],
     end: () => callback(null, { statusCode: 200 }),
     respond: (json) =>
         callback(null, {
@@ -282,7 +283,8 @@ const awsLambdaAsync: LambdaAsyncAdapter = (event, _context) => {
         get update() {
             return JSON.parse(event.body ?? "{}");
         },
-        header: event.headers[SECRET_HEADER],
+        header: event.headers[SECRET_HEADER] ??
+            event.headers[SECRET_HEADER_LOWERCASE],
         end: () => resolveResponse({ statusCode: 200 }),
         respond: (json) =>
             resolveResponse({


### PR DESCRIPTION
## Summary

Follow-up to #896. The `awsLambda` and `awsLambdaAsync` adapters in `src/convenience/frameworks.ts` read the `X-Telegram-Bot-Api-Secret-Token` header with a case-sensitive lookup against the title-case constant. That works under API Gateway **REST API** (payload 1.0), which preserves the original client header case, but fails under API Gateway **HTTP API** (payload 1.0 or 2.0), which lowercases every inbound header name. Users on HTTP API with a configured `secretToken` had every update rejected 401, because `event.headers["X-Telegram-Bot-Api-Secret-Token"]` is `undefined` when the actual key is `"x-telegram-bot-api-secret-token"`.

AWS documents the HTTP API lowercasing in the [payload format structure](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html):

> The following examples show the structure of each payload format version. **All headernames are lowercased.**

REST API users were and are fine; I need them to stay fine.

## What changed

```diff
 const awsLambda: LambdaAdapter = (event, _context, callback) => ({
     get update() {
         return JSON.parse(event.body ?? "{}");
     },
-    header: event.headers[SECRET_HEADER],
+    header: event.headers[SECRET_HEADER] ??
+        event.headers[SECRET_HEADER_LOWERCASE],
```

Identical change in `awsLambdaAsync`. Title-case lookup first (REST API), lowercase fallback second (HTTP API). Both constants already exist at the top of the file and are used by other adapters.

No type changes — `LambdaAdapter` / `LambdaAsyncAdapter` already declare `headers: Record<string, string | undefined>`.

## Coverage matrix

| Integration | Payload | Header casing delivered | Before | After |
|---|---|---|---|---|
| REST API | 1.0 | `X-Telegram-Bot-Api-Secret-Token` | works | works |
| HTTP API | 1.0 | `x-telegram-bot-api-secret-token` | 401 | works |
| HTTP API | 2.0 | `x-telegram-bot-api-secret-token` | 401 | works |

## Test plan

- [x] `deno check --allow-import src/mod.ts` — clean
- [x] `deno task test` — 38 suites, 443 steps, all pass
- [x] Manual smoke for both adapters:
  - title-case key → returns value (REST API path)
  - lowercase key → returns value (HTTP API path)
  - missing header → returns `undefined`
- [ ] Verified on a live Lambda deployment (not required for merge; happy to do so if you want).

## Context

cc @KnorpelSenf — you green-lit this follow-up in #896. Same reasoning, different adapter pair.
