### PR TITLE
fix: remove dead code in constant-time token comparison

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -2,7 +2,7 @@
     "lock": false,
     "nodeModulesDir": "none",
     "tasks": {
-        "check": "deno cache --allow-import src/mod.ts",
+        "check": "deno check --allow-import src/mod.ts",
         "backport": "deno --no-prompt --allow-read=. --allow-write=. https://deno.land/x/deno2node@v1.16.0/src/cli.ts tsconfig.json",
         "test": "deno test --seed=123456 --parallel --allow-import ./test/",
         "dev": "deno fmt && deno lint && deno task test && deno task check",

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -704,7 +704,7 @@ async function withRetries<T>(
  * rejects as soon as the given signal is aborted.
  */
 async function sleep(seconds: number, signal?: AbortSignal) {
-    let handle: number | undefined;
+    let handle: ReturnType<typeof setTimeout> | undefined;
     let reject: ((err: Error) => void) | undefined;
     function abort() {
         reject?.(new Error("Aborted delay"));

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -704,7 +704,7 @@ async function withRetries<T>(
  * rejects as soon as the given signal is aborted.
  */
 async function sleep(seconds: number, signal?: AbortSignal) {
-    let handle: ReturnType<typeof setTimeout> | undefined;
+    let handle: Parameters<typeof clearTimeout>[0];
     let reject: ((err: Error) => void) | undefined;
     function abort() {
         reject?.(new Error("Aborted delay"));

--- a/src/convenience/webhook.ts
+++ b/src/convenience/webhook.ts
@@ -56,12 +56,10 @@ function compareSecretToken(
     }
 
     let hasDifference = 0;
-    // Always iterate exactly tokenBytes.length times to prevent timing attacks
-    // that could reveal the secret token's length. The loop time is constant
-    // relative to the secret token length, not the attacker's input length.
+    // Constant-time byte comparison to prevent timing attacks that could
+    // reveal where bytes first differ.
     for (let i = 0; i < tokenBytes.length; i++) {
-        // If header is shorter than token, pad with 0 for comparison
-        const headerByte = i < headerBytes.length ? headerBytes[i] : 0;
+        const headerByte = headerBytes[i];
         const tokenByte = tokenBytes[i];
 
         // If bytes differ, mark that we found a difference


### PR DESCRIPTION
While reading this, I noticed an issue in `compareSecretToken` (that I introduced 😅 ):

The ternary `i < headerBytes.length ? headerBytes[i] : 0` is dead code. The length check above this already returns early if lengths differ, so `headerBytes[i]` is always safe to access directly.
