### PR TITLE
docs: fix broken All Contributors emoji key link

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ You can simply do `import { Bot } from "grammy/web"`.
 
 ## Contributors ✨
 
-Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/en/reference/emoji-key/)):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->


### PR DESCRIPTION
The old link returns a 404 error.