### PR TITLE
Fix Deno 2.8 timeout handle type

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -704,7 +704,7 @@ async function withRetries<T>(
  * rejects as soon as the given signal is aborted.
  */
 async function sleep(seconds: number, signal?: AbortSignal) {
-    let handle: number | undefined;
+    let handle: ReturnType<typeof setTimeout> | undefined;
     let reject: ((err: Error) => void) | undefined;
     function abort() {
         reject?.(new Error("Aborted delay"));


### PR DESCRIPTION
## Description

Deno 2.8 changed `setTimeout` and `setInterval` to return Node-style `Timeout` objects instead of numbers. This updates the polling sleep helper to type the stored timeout handle as `ReturnType<typeof setTimeout>` so it works across Deno 2.8 and older runtimes.

Refs https://github.com/grammyjs/grammY/pull/907#issuecomment-4589629977

## Verification

- Reproduced the Deno 2.8.0 failure before the fix: `TS2322: Type 'Timeout' is not assignable to type 'number'` in `src/bot.ts`
- `/tmp/deno-2.8 task dev`