### PR TITLE
fix: support Node timeout handles in backport

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -704,7 +704,7 @@ async function withRetries<T>(
  * rejects as soon as the given signal is aborted.
  */
 async function sleep(seconds: number, signal?: AbortSignal) {
-    let handle: number | undefined;
+    let handle: ReturnType<typeof setTimeout> | undefined;
     let reject: ((err: Error) => void) | undefined;
     function abort() {
         reject?.(new Error("Aborted delay"));

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -718,7 +718,7 @@ async function sleep(seconds: number, signal?: AbortSignal) {
                 return;
             }
             signal?.addEventListener("abort", abort);
-            handle = setTimeout(res, 1000 * seconds);
+            handle = setTimeout(() => res(), 1000 * seconds);
         });
     } finally {
         signal?.removeEventListener("abort", abort);


### PR DESCRIPTION
## Summary

- use `ReturnType<typeof setTimeout>` for the sleep timeout handle
- wrap the promise resolver passed to `setTimeout` so TypeScript selects the Node-compatible overload during deno2node backporting

## Root Cause

The backport build sees both DOM and Node timer typings. Passing the promise resolver directly to `setTimeout` caused TypeScript to resolve the call to the DOM overload returning `number`, while the handle was typed as the Node timer return type.

## Validation

- `npm run backport`
- `deno fmt --check src/bot.ts`
- `deno lint src/bot.ts`
- `deno task check`
- `deno task test`

## Attribution

This fix is written by GPT 5.5 xhigh on Codex CLI.