### PR TITLE
fix(platform): set default fetch duplex to "half" for all API requests

### DIFF
--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -199,7 +199,7 @@ export interface ApiClientOptions {
     /**
      * Base configuration for `fetch` calls. Specify any additional parameters
      * to use when fetching a method of the Telegram Bot API. Default: `{
-     * compress: true }` (Node), `{}` (Deno)
+     * compress: true, duplex: "half" }` (Node), `{ duplex: "half" }` (Deno, Web)
      */
     baseFetchConfig?: Omit<
         NonNullable<Parameters<typeof fetch>[1]>,

--- a/src/platform.deno.ts
+++ b/src/platform.deno.ts
@@ -23,7 +23,7 @@ export const itrToStream = (itr: AsyncIterable<Uint8Array>) =>
     ReadableStream.from(itr);
 
 // === Base configuration for `fetch` calls
-export const baseFetchConfig = (_apiRoot: string) => ({});
+export const baseFetchConfig = (_apiRoot: string) => ({ duplex: "half" });
 
 // === Default webhook adapter
 export const defaultAdapter = "oak";

--- a/src/platform.node.ts
+++ b/src/platform.node.ts
@@ -31,6 +31,7 @@ export function baseFetchConfig(apiRoot: string) {
                 apiRoot,
                 () => new HttpsAgent({ keepAlive: true }),
             ),
+            duplex: "half",
         };
     } else if (apiRoot.startsWith("http:")) {
         return {
@@ -39,8 +40,9 @@ export function baseFetchConfig(apiRoot: string) {
                 apiRoot,
                 () => new HttpAgent({ keepAlive: true }),
             ),
+            duplex: "half",
         };
-    } else return {};
+    } else return { duplex: "half" };
 }
 
 // === Default webhook adapter

--- a/src/platform.web.ts
+++ b/src/platform.web.ts
@@ -18,6 +18,6 @@ export const itrToStream = (itr: AsyncIterable<Uint8Array>) => {
 };
 
 // === Base configuration for `fetch` calls
-export const baseFetchConfig = (_apiRoot: string) => ({});
+export const baseFetchConfig = (_apiRoot: string) => ({ duplex: "half" });
 
 export const defaultAdapter = "cloudflare";


### PR DESCRIPTION
## Summary
Set `duplex: "half"` in `baseFetchConfig` defaults across all platform implementations to prevent streaming-body fetch errors in browsers.

Closes #910.

## Why
Issue [#910](https://github.com/grammyjs/grammY/issues/910) reports browser upload failures with:

- `TypeError: Failed to execute 'fetch' on 'Window': The 'duplex' member must be specified for a request with a streaming body`

Setting `duplex: "half"` is a strict WHATWG requirement if you try to pass a ReadableStream to the body of a fetch request.

## Changes
- Updated `src/platform.node.ts`:
  - Added `duplex: "half"` to all return paths of `baseFetchConfig`.
- Updated `src/platform.web.ts`:
  - `baseFetchConfig` now returns `{ duplex: "half" }`.
- Updated `src/platform.deno.ts`:
  - `baseFetchConfig` now returns `{ duplex: "half" }`.
- Updated API docs in `src/core/client.ts`:
  - `baseFetchConfig` default comment now reflects the new defaults for Node, Deno, and Web.

## Compatibility note
In browsers, `duplex` is required for streaming `fetch` bodies.  
In Node/Deno (Undici), the docs state `request.duplex` is set for streaming bodies and is treated as effectively full duplex, so adding this default has no effect on those runtimes, but would cover the case when these runtime are transpiled for the web.

- Undici docs (request.duplex behavior): [https://github.com/nodejs/undici#requestduplex](https://github.com/nodejs/undici#requestduplex)
