### PR TITLE
fix: migrate Skypack CDN to esm.sh

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,11 +19,10 @@
     "dependencies": {
         "@grammyjs/types": "3.28.0",
         "abort-controller": "^3.0.0",
-        "debug": "^4.4.3",
+        "obug": "^2.1.3",
         "node-fetch": "^2.7.0"
     },
     "devDependencies": {
-        "@types/debug": "^4.1.12",
         "@types/node": "^12.20.55",
         "@types/node-fetch": "2.6.2",
         "deno2node": "^1.16.0"

--- a/src/platform.deno.ts
+++ b/src/platform.deno.ts
@@ -4,7 +4,7 @@
 export const isDeno = typeof Deno !== "undefined";
 
 // === Export debug
-import debug from "https://cdn.skypack.dev/debug@4.4.3";
+import debug from "https://cdn.skypack.dev/obug@2.1.3";
 export { debug };
 const DEBUG = "DEBUG";
 if (isDeno) {

--- a/src/platform.deno.ts
+++ b/src/platform.deno.ts
@@ -4,7 +4,7 @@
 export const isDeno = typeof Deno !== "undefined";
 
 // === Export debug
-import debug from "https://cdn.skypack.dev/obug@2.1.3";
+import debug from "https://esm.sh/obug@2.1.3";
 export { debug };
 const DEBUG = "DEBUG";
 if (isDeno) {

--- a/src/platform.node.ts
+++ b/src/platform.node.ts
@@ -4,7 +4,7 @@ import { Agent as HttpsAgent } from "https";
 import { Readable } from "stream";
 
 // === Export debug
-export { debug } from "debug";
+export { debug } from "obug";
 
 // === Export system-specific operations
 // Turn an AsyncIterable<Uint8Array> into a stream

--- a/src/platform.web.ts
+++ b/src/platform.web.ts
@@ -1,6 +1,6 @@
 // deno-lint-ignore-file no-import-prefix
 
-import d from "https://cdn.skypack.dev/debug@4.4.3";
+import d from "https://cdn.skypack.dev/obug@2.1.3";
 export { d as debug };
 
 // === Export system-specific operations

--- a/src/platform.web.ts
+++ b/src/platform.web.ts
@@ -1,6 +1,6 @@
 // deno-lint-ignore-file no-import-prefix
 
-import d from "https://cdn.skypack.dev/obug@2.1.3";
+import d from "https://esm.sh/obug@2.1.3";
 export { d as debug };
 
 // === Export system-specific operations


### PR DESCRIPTION
Skypack has been in maintenance mode since 2024. Migrate to esm.sh which is actively maintained and more reliable.

Changes:
- platform.deno.ts: skypack.dev/obug → esm.sh/obug
- platform.web.ts: skypack.dev/obug → esm.sh/obug