### PR TITLE
fix: bad subscription narrowing

### DIFF
--- a/src/filter.ts
+++ b/src/filter.ts
@@ -644,7 +644,7 @@ interface Shortcuts<U extends Update> {
     purchasedPaidMedia: [U["purchased_paid_media"]] extends [object]
         ? U["purchased_paid_media"]
         : undefined;
-    subscription: [U["subscription"]] extends [object] ? [U["subscription"]]
+    subscription: [U["subscription"]] extends [object] ? U["subscription"]
         : undefined;
     msg: [U["message"]] extends [object] ? U["message"]
         : [U["edited_message"]] extends [object] ? U["edited_message"]

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -1,6 +1,7 @@
 import { Context } from "../src/context.ts";
 import { Api } from "../src/mod.ts";
 import {
+    type BotSubscriptionUpdated,
     type BusinessConnection,
     type BusinessMessagesDeleted,
     type Chat,
@@ -35,6 +36,11 @@ describe("Context", () => {
         message_ids: [0, 1, 2],
         business_connection_id: "conn",
     } as BusinessMessagesDeleted;
+    const s = {
+        user: u,
+        invoice_payload: "payload",
+        state: "active",
+    } as BotSubscriptionUpdated;
     const update = {
         message: m,
         edited_message: m,
@@ -83,6 +89,7 @@ describe("Context", () => {
         chat_join_request: { date: 3, from: u, chat: c },
         chat_boost: { chat: c, boost: { boost_id: 3, source: { user: u } } },
         removed_chat_boost: { chat: c, boost_id: 3, source: { user: u } },
+        subscription: s,
     } as unknown as Update;
     const api = new Api("dummy-token");
     const me = { id: 42, username: "bot" } as UserFromGetMe;
@@ -122,6 +129,7 @@ describe("Context", () => {
         assertEquals(ctx.chatJoinRequest, update.chat_join_request);
         assertEquals(ctx.chatBoost, update.chat_boost);
         assertEquals(ctx.removedChatBoost, update.removed_chat_boost);
+        assertEquals(ctx.subscription, update.subscription);
     });
 
     it(".msg should aggregate messages", () => {
@@ -212,6 +220,9 @@ describe("Context", () => {
         up = { removed_chat_boost: update.removed_chat_boost } as Update;
         ctx = new Context(up, api, me);
         assertEquals(ctx.from, up.removed_chat_boost?.source?.user);
+        up = { subscription: update.subscription } as Update;
+        ctx = new Context(up, api, me);
+        assertEquals(ctx.from, up.subscription?.user);
         up = { callback_query: update.callback_query } as Update;
         ctx = new Context(up, api, me);
         assertEquals(ctx.from, up.callback_query?.from);

--- a/test/context.type.test.ts
+++ b/test/context.type.test.ts
@@ -53,3 +53,219 @@ describe("ctx.has* checks", () => {
         });
     });
 });
+
+describe("ctx update shortcuts", () => {
+    it("should narrow down all update aliases", () => {
+        const c = new Composer<Context>();
+        c.use((ctx) => {
+            if (ctx.has("message")) {
+                assertType<
+                    IsMutuallyAssignable<
+                        typeof ctx.message,
+                        typeof ctx.update.message
+                    >
+                >(true);
+            }
+            if (ctx.has("edited_message")) {
+                assertType<
+                    IsMutuallyAssignable<
+                        typeof ctx.editedMessage,
+                        typeof ctx.update.edited_message
+                    >
+                >(true);
+            }
+            if (ctx.has("channel_post")) {
+                assertType<
+                    IsMutuallyAssignable<
+                        typeof ctx.channelPost,
+                        typeof ctx.update.channel_post
+                    >
+                >(true);
+            }
+            if (ctx.has("edited_channel_post")) {
+                assertType<
+                    IsMutuallyAssignable<
+                        typeof ctx.editedChannelPost,
+                        typeof ctx.update.edited_channel_post
+                    >
+                >(true);
+            }
+            if (ctx.has("business_connection")) {
+                assertType<
+                    IsMutuallyAssignable<
+                        typeof ctx.businessConnection,
+                        typeof ctx.update.business_connection
+                    >
+                >(true);
+            }
+            if (ctx.has("business_message")) {
+                assertType<
+                    IsMutuallyAssignable<
+                        typeof ctx.businessMessage,
+                        typeof ctx.update.business_message
+                    >
+                >(true);
+            }
+            if (ctx.has("edited_business_message")) {
+                assertType<
+                    IsMutuallyAssignable<
+                        typeof ctx.editedBusinessMessage,
+                        typeof ctx.update.edited_business_message
+                    >
+                >(true);
+            }
+            if (ctx.has("deleted_business_messages")) {
+                assertType<
+                    IsMutuallyAssignable<
+                        typeof ctx.deletedBusinessMessages,
+                        typeof ctx.update.deleted_business_messages
+                    >
+                >(true);
+            }
+            if (ctx.has("guest_message")) {
+                assertType<
+                    IsMutuallyAssignable<
+                        typeof ctx.guestMessage,
+                        typeof ctx.update.guest_message
+                    >
+                >(true);
+            }
+            if (ctx.has("message_reaction")) {
+                assertType<
+                    IsMutuallyAssignable<
+                        typeof ctx.messageReaction,
+                        typeof ctx.update.message_reaction
+                    >
+                >(true);
+            }
+            if (ctx.has("message_reaction_count")) {
+                assertType<
+                    IsMutuallyAssignable<
+                        typeof ctx.messageReactionCount,
+                        typeof ctx.update.message_reaction_count
+                    >
+                >(true);
+            }
+            if (ctx.has("inline_query")) {
+                assertType<
+                    IsMutuallyAssignable<
+                        typeof ctx.inlineQuery,
+                        typeof ctx.update.inline_query
+                    >
+                >(true);
+            }
+            if (ctx.has("chosen_inline_result")) {
+                assertType<
+                    IsMutuallyAssignable<
+                        typeof ctx.chosenInlineResult,
+                        typeof ctx.update.chosen_inline_result
+                    >
+                >(true);
+            }
+            if (ctx.has("callback_query")) {
+                assertType<
+                    IsMutuallyAssignable<
+                        typeof ctx.callbackQuery,
+                        typeof ctx.update.callback_query
+                    >
+                >(true);
+            }
+            if (ctx.has("shipping_query")) {
+                assertType<
+                    IsMutuallyAssignable<
+                        typeof ctx.shippingQuery,
+                        typeof ctx.update.shipping_query
+                    >
+                >(true);
+            }
+            if (ctx.has("pre_checkout_query")) {
+                assertType<
+                    IsMutuallyAssignable<
+                        typeof ctx.preCheckoutQuery,
+                        typeof ctx.update.pre_checkout_query
+                    >
+                >(true);
+            }
+            if (ctx.has("poll")) {
+                assertType<
+                    IsMutuallyAssignable<
+                        typeof ctx.poll,
+                        typeof ctx.update.poll
+                    >
+                >(true);
+            }
+            if (ctx.has("poll_answer")) {
+                assertType<
+                    IsMutuallyAssignable<
+                        typeof ctx.pollAnswer,
+                        typeof ctx.update.poll_answer
+                    >
+                >(true);
+            }
+            if (ctx.has("my_chat_member")) {
+                assertType<
+                    IsMutuallyAssignable<
+                        typeof ctx.myChatMember,
+                        typeof ctx.update.my_chat_member
+                    >
+                >(true);
+            }
+            if (ctx.has("chat_member")) {
+                assertType<
+                    IsMutuallyAssignable<
+                        typeof ctx.chatMember,
+                        typeof ctx.update.chat_member
+                    >
+                >(true);
+            }
+            if (ctx.has("managed_bot")) {
+                assertType<
+                    IsMutuallyAssignable<
+                        typeof ctx.managedBot,
+                        typeof ctx.update.managed_bot
+                    >
+                >(true);
+            }
+            if (ctx.has("chat_join_request")) {
+                assertType<
+                    IsMutuallyAssignable<
+                        typeof ctx.chatJoinRequest,
+                        typeof ctx.update.chat_join_request
+                    >
+                >(true);
+            }
+            if (ctx.has("chat_boost")) {
+                assertType<
+                    IsMutuallyAssignable<
+                        typeof ctx.chatBoost,
+                        typeof ctx.update.chat_boost
+                    >
+                >(true);
+            }
+            if (ctx.has("removed_chat_boost")) {
+                assertType<
+                    IsMutuallyAssignable<
+                        typeof ctx.removedChatBoost,
+                        typeof ctx.update.removed_chat_boost
+                    >
+                >(true);
+            }
+            if (ctx.has("purchased_paid_media")) {
+                assertType<
+                    IsMutuallyAssignable<
+                        typeof ctx.purchasedPaidMedia,
+                        typeof ctx.update.purchased_paid_media
+                    >
+                >(true);
+            }
+            if (ctx.has("subscription")) {
+                assertType<
+                    IsMutuallyAssignable<
+                        typeof ctx.subscription,
+                        typeof ctx.update.subscription
+                    >
+                >(true);
+            }
+        });
+    });
+});


### PR DESCRIPTION
#922 was done hastily, we overlooked that the type was narrowed down incorrectly.

This fixes that, and also adds type tests so it cannot happen again in the future.