### PR TITLE
chore: add explicit return types to public API for JSR slow-type checks

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,6 +1,9 @@
 {
+    "name": "@grammyjs/grammy",
+    "version": "1.45.1",
     "lock": false,
     "minimumDependencyAge": 0,
+    "exports": "./src/mod.ts",
     "nodeModulesDir": "none",
     "tasks": {
         "check": "deno check --allow-import src/mod.ts",

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -291,7 +291,7 @@ export class Bot<
      *
      * @returns true if the bot is initialized, and false otherwise
      */
-    isInited() {
+    isInited(): boolean {
         return this.me !== undefined;
     }
 
@@ -516,7 +516,7 @@ a known bot info object.",
      * before `bot.isInited()` returns true). By extension, this method
      * returns true before `onStart` callback of `bot.start()` is invoked.
      */
-    isRunning() {
+    isRunning(): boolean {
         return this.pollingRunning;
     }
 

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -201,7 +201,7 @@ export class Composer<C extends Context> implements MiddlewareObj<C> {
             : middleware.map(flatten).reduce(concat);
     }
 
-    middleware() {
+    middleware(): MiddlewareFn<C> {
         return this.handler;
     }
 
@@ -224,7 +224,7 @@ export class Composer<C extends Context> implements MiddlewareObj<C> {
      *
      * @param middleware The middleware to register
      */
-    use(...middleware: Array<Middleware<C>>) {
+    use(...middleware: Array<Middleware<C>>): Composer<C> {
         const composer = new Composer(...middleware);
         this.handler = concat(this.handler, flatten(composer));
         return composer;
@@ -715,7 +715,7 @@ export class Composer<C extends Context> implements MiddlewareObj<C> {
     drop(
         predicate: (ctx: C) => MaybePromise<boolean>,
         ...middleware: Array<Middleware<C>>
-    ) {
+    ): Composer<C> {
         return this.filter(
             async (ctx: C) => !(await predicate(ctx)),
             ...middleware,
@@ -750,7 +750,7 @@ export class Composer<C extends Context> implements MiddlewareObj<C> {
      *
      * @param middleware The middleware to run concurrently
      */
-    fork(...middleware: Array<Middleware<C>>) {
+    fork(...middleware: Array<Middleware<C>>): Composer<C> {
         const composer = new Composer(...middleware);
         const fork = flatten(composer);
         this.use((ctx, next) => Promise.all([next(), run(fork, ctx)]));
@@ -858,7 +858,7 @@ export class Composer<C extends Context> implements MiddlewareObj<C> {
         predicate: (ctx: C) => MaybePromise<boolean>,
         trueMiddleware: MaybeArray<Middleware<C>>,
         falseMiddleware: MaybeArray<Middleware<C>>,
-    ) {
+    ): Composer<C> {
         return this.lazy(async (ctx) =>
             (await predicate(ctx)) ? trueMiddleware : falseMiddleware
         );
@@ -908,7 +908,7 @@ export class Composer<C extends Context> implements MiddlewareObj<C> {
             next: NextFunction,
         ) => MaybePromise<unknown>,
         ...middleware: Array<Middleware<C>>
-    ) {
+    ): Composer<C> {
         const composer = new Composer<C>(...middleware);
         const bound = flatten(composer);
         this.use(async (ctx, next) => {

--- a/src/context.ts
+++ b/src/context.ts
@@ -9,8 +9,27 @@ import {
 } from "./filter.ts";
 import {
     type AcceptedGiftTypes,
+    type BotAccessSettings,
+    type BotSubscriptionUpdated,
+    type BusinessConnection,
+    type BusinessMessagesDeleted,
+    type CallbackQuery,
     type Chat,
+    type ChatAdministratorRights,
+    type ChatBoostRemoved,
+    type ChatBoostUpdated,
+    type ChatFullInfo,
+    type ChatInviteLink,
+    type ChatJoinRequest,
+    type ChatMember,
+    type ChatMemberAdministrator,
+    type ChatMemberOwner,
+    type ChatMemberUpdated,
     type ChatPermissions,
+    type ChosenInlineResult,
+    type File,
+    type ForumTopic,
+    type InlineQuery,
     type InlineQueryResult,
     type InputChecklist,
     type InputFile,
@@ -29,14 +48,34 @@ import {
     type InputStoryContent,
     type KeyboardButton,
     type LabeledPrice,
+    type ManagedBotUpdated,
+    type MenuButton,
     type Message,
     type MessageEntity,
+    type MessageId,
+    type MessageReactionCountUpdated,
+    type MessageReactionUpdated,
+    type OwnedGifts,
+    type PaidMediaPurchased,
     type PassportElementError,
+    type Poll,
+    type PollAnswer,
+    type PreCheckoutQuery,
+    type PreparedInlineMessage,
+    type PreparedKeyboardButton,
     type ReactionType,
     type ReactionTypeEmoji,
+    type SentGuestMessage,
+    type ShippingQuery,
+    type StarAmount,
+    type Sticker,
+    type Story,
     type Update,
     type User,
+    type UserChatBoosts,
     type UserFromGetMe,
+    type UserProfileAudios,
+    type UserProfilePhotos,
 } from "./types.ts";
 
 // === Util types
@@ -417,107 +456,113 @@ export class Context implements RenamedUpdate {
 
     // Keep in sync with types in `filter.ts`.
     /** Alias for `ctx.update.message` */
-    get message() {
+    get message(): (Message & Update.NonChannel) | undefined {
         return this.update.message;
     }
     /** Alias for `ctx.update.edited_message` */
-    get editedMessage() {
+    get editedMessage():
+        | (Message & Update.Edited & Update.NonChannel)
+        | undefined {
         return this.update.edited_message;
     }
     /** Alias for `ctx.update.channel_post` */
-    get channelPost() {
+    get channelPost(): (Message & Update.Channel) | undefined {
         return this.update.channel_post;
     }
     /** Alias for `ctx.update.edited_channel_post` */
-    get editedChannelPost() {
+    get editedChannelPost():
+        | (Message & Update.Edited & Update.Channel)
+        | undefined {
         return this.update.edited_channel_post;
     }
     /** Alias for `ctx.update.business_connection` */
-    get businessConnection() {
+    get businessConnection(): BusinessConnection | undefined {
         return this.update.business_connection;
     }
     /** Alias for `ctx.update.business_message` */
-    get businessMessage() {
+    get businessMessage(): (Message & Update.Private) | undefined {
         return this.update.business_message;
     }
     /** Alias for `ctx.update.edited_business_message` */
-    get editedBusinessMessage() {
+    get editedBusinessMessage():
+        | (Message & Update.Edited & Update.Private)
+        | undefined {
         return this.update.edited_business_message;
     }
     /** Alias for `ctx.update.deleted_business_messages` */
-    get deletedBusinessMessages() {
+    get deletedBusinessMessages(): BusinessMessagesDeleted | undefined {
         return this.update.deleted_business_messages;
     }
     /** Alias for `ctx.update.guest_message` */
-    get guestMessage() {
+    get guestMessage(): (Message & Update.NonChannel) | undefined {
         return this.update.guest_message;
     }
     /** Alias for `ctx.update.message_reaction` */
-    get messageReaction() {
+    get messageReaction(): MessageReactionUpdated | undefined {
         return this.update.message_reaction;
     }
     /** Alias for `ctx.update.message_reaction_count` */
-    get messageReactionCount() {
+    get messageReactionCount(): MessageReactionCountUpdated | undefined {
         return this.update.message_reaction_count;
     }
     /** Alias for `ctx.update.inline_query` */
-    get inlineQuery() {
+    get inlineQuery(): InlineQuery | undefined {
         return this.update.inline_query;
     }
     /** Alias for `ctx.update.chosen_inline_result` */
-    get chosenInlineResult() {
+    get chosenInlineResult(): ChosenInlineResult | undefined {
         return this.update.chosen_inline_result;
     }
     /** Alias for `ctx.update.callback_query` */
-    get callbackQuery() {
+    get callbackQuery(): CallbackQuery | undefined {
         return this.update.callback_query;
     }
     /** Alias for `ctx.update.shipping_query` */
-    get shippingQuery() {
+    get shippingQuery(): ShippingQuery | undefined {
         return this.update.shipping_query;
     }
     /** Alias for `ctx.update.pre_checkout_query` */
-    get preCheckoutQuery() {
+    get preCheckoutQuery(): PreCheckoutQuery | undefined {
         return this.update.pre_checkout_query;
     }
     /** Alias for `ctx.update.poll` */
-    get poll() {
+    get poll(): Poll | undefined {
         return this.update.poll;
     }
     /** Alias for `ctx.update.poll_answer` */
-    get pollAnswer() {
+    get pollAnswer(): PollAnswer | undefined {
         return this.update.poll_answer;
     }
     /** Alias for `ctx.update.my_chat_member` */
-    get myChatMember() {
+    get myChatMember(): ChatMemberUpdated | undefined {
         return this.update.my_chat_member;
     }
     /** Alias for `ctx.update.chat_member` */
-    get chatMember() {
+    get chatMember(): ChatMemberUpdated | undefined {
         return this.update.chat_member;
     }
     /** Alias for `ctx.update.managed_bot` */
-    get managedBot() {
+    get managedBot(): ManagedBotUpdated | undefined {
         return this.update.managed_bot;
     }
     /** Alias for `ctx.update.chat_join_request` */
-    get chatJoinRequest() {
+    get chatJoinRequest(): ChatJoinRequest | undefined {
         return this.update.chat_join_request;
     }
     /** Alias for `ctx.update.chat_boost` */
-    get chatBoost() {
+    get chatBoost(): ChatBoostUpdated | undefined {
         return this.update.chat_boost;
     }
     /** Alias for `ctx.update.removed_chat_boost` */
-    get removedChatBoost() {
+    get removedChatBoost(): ChatBoostRemoved | undefined {
         return this.update.removed_chat_boost;
     }
     /** Alias for `ctx.update.purchased_paid_media` */
-    get purchasedPaidMedia() {
+    get purchasedPaidMedia(): PaidMediaPurchased | undefined {
         return this.update.purchased_paid_media;
     }
     /** Alias for `ctx.update.subscription` */
-    get subscription() {
+    get subscription(): BotSubscriptionUpdated | undefined {
         return this.update.subscription;
     }
 
@@ -996,7 +1041,7 @@ export class Context implements RenamedUpdate {
         text: string,
         other?: Other<"sendMessage", "chat_id" | "text">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.TextMessage> {
         const msg = this.msg;
         return this.api.sendMessage(
             orThrow(this.chatId, "sendMessage"),
@@ -1026,7 +1071,7 @@ export class Context implements RenamedUpdate {
         rich_message: InputRichMessage,
         other?: Other<"sendRichMessage", "chat_id" | "rich_message">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.RichMessageMessage> {
         const msg = this.msg;
         return this.api.sendRichMessage(
             orThrow(this.chatId, "sendRichMessage"),
@@ -1059,7 +1104,7 @@ export class Context implements RenamedUpdate {
             "chat_id" | "from_chat_id" | "message_id"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message> {
         const msg = this.msg;
         return this.api.forwardMessage(
             chat_id,
@@ -1091,7 +1136,7 @@ export class Context implements RenamedUpdate {
             "chat_id" | "from_chat_id" | "message_ids"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<MessageId[]> {
         const msg = this.msg;
         return this.api.forwardMessages(
             chat_id,
@@ -1118,7 +1163,7 @@ export class Context implements RenamedUpdate {
         chat_id: number | string,
         other?: Other<"copyMessage", "chat_id" | "from_chat_id" | "message_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<MessageId> {
         const msg = this.msg;
         return this.api.copyMessage(
             chat_id,
@@ -1150,7 +1195,7 @@ export class Context implements RenamedUpdate {
             "chat_id" | "from_chat_id" | "message_ids"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<MessageId[]> {
         const msg = this.msg;
         return this.api.copyMessages(
             chat_id,
@@ -1177,7 +1222,7 @@ export class Context implements RenamedUpdate {
         photo: InputFile | string,
         other?: Other<"sendPhoto", "chat_id" | "photo">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.PhotoMessage> {
         const msg = this.msg;
         return this.api.sendPhoto(
             orThrow(this.chatId, "sendPhoto"),
@@ -1209,7 +1254,7 @@ export class Context implements RenamedUpdate {
         photo: InputFile | string,
         other?: Other<"sendLivePhoto", "chat_id" | "live_photo" | "photo">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.LivePhotoMessage> {
         const msg = this.msg;
         return this.api.sendLivePhoto(
             orThrow(this.chatId, "sendLivePhoto"),
@@ -1242,7 +1287,7 @@ export class Context implements RenamedUpdate {
         audio: InputFile | string,
         other?: Other<"sendAudio", "chat_id" | "audio">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.AudioMessage> {
         const msg = this.msg;
         return this.api.sendAudio(
             orThrow(this.chatId, "sendAudio"),
@@ -1272,7 +1317,7 @@ export class Context implements RenamedUpdate {
         document: InputFile | string,
         other?: Other<"sendDocument", "chat_id" | "document">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.DocumentMessage> {
         const msg = this.msg;
         return this.api.sendDocument(
             orThrow(this.chatId, "sendDocument"),
@@ -1302,7 +1347,7 @@ export class Context implements RenamedUpdate {
         video: InputFile | string,
         other?: Other<"sendVideo", "chat_id" | "video">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.VideoMessage> {
         const msg = this.msg;
         return this.api.sendVideo(
             orThrow(this.chatId, "sendVideo"),
@@ -1332,7 +1377,7 @@ export class Context implements RenamedUpdate {
         animation: InputFile | string,
         other?: Other<"sendAnimation", "chat_id" | "animation">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.AnimationMessage> {
         const msg = this.msg;
         return this.api.sendAnimation(
             orThrow(this.chatId, "sendAnimation"),
@@ -1362,7 +1407,7 @@ export class Context implements RenamedUpdate {
         voice: InputFile | string,
         other?: Other<"sendVoice", "chat_id" | "voice">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.VoiceMessage> {
         const msg = this.msg;
         return this.api.sendVoice(
             orThrow(this.chatId, "sendVoice"),
@@ -1393,7 +1438,7 @@ export class Context implements RenamedUpdate {
         video_note: InputFile | string,
         other?: Other<"sendVideoNote", "chat_id" | "video_note">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.VideoNoteMessage> {
         const msg = this.msg;
         return this.api.sendVideoNote(
             orThrow(this.chatId, "sendVideoNote"),
@@ -1411,7 +1456,9 @@ export class Context implements RenamedUpdate {
     }
 
     /** @deprecated Use `replyWithPaidMedia` instead. */
-    sendPaidMedia(...args: Parameters<Context["replyWithPaidMedia"]>) {
+    sendPaidMedia(
+        ...args: Parameters<Context["replyWithPaidMedia"]>
+    ): Promise<Message.PaidMediaMessage> {
         return this.replyWithPaidMedia(...args);
     }
 
@@ -1430,7 +1477,7 @@ export class Context implements RenamedUpdate {
         media: InputPaidMedia[],
         other?: Other<"sendPaidMedia", "chat_id" | "star_count" | "media">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.PaidMediaMessage> {
         const msg = this.msg;
         return this.api.sendPaidMedia(
             orThrow(this.chatId, "sendPaidMedia"),
@@ -1469,7 +1516,15 @@ export class Context implements RenamedUpdate {
             >,
         other?: Other<"sendMediaGroup", "chat_id" | "media">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<
+        (
+            | Message.AudioMessage
+            | Message.DocumentMessage
+            | Message.LivePhotoMessage
+            | Message.PhotoMessage
+            | Message.VideoMessage
+        )[]
+    > {
         const msg = this.msg;
         return this.api.sendMediaGroup(
             orThrow(this.chatId, "sendMediaGroup"),
@@ -1501,7 +1556,7 @@ export class Context implements RenamedUpdate {
         longitude: number,
         other?: Other<"sendLocation", "chat_id" | "latitude" | "longitude">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.LocationMessage> {
         const msg = this.msg;
         return this.api.sendLocation(
             orThrow(this.chatId, "sendLocation"),
@@ -1541,7 +1596,9 @@ export class Context implements RenamedUpdate {
             | "longitude"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<
+        true | (Update.Edited & Message.LocationMessage)
+    > {
         const inlineId = this.inlineMessageId;
         return inlineId !== undefined
             ? this.api.editMessageLiveLocationInline(
@@ -1575,7 +1632,9 @@ export class Context implements RenamedUpdate {
             "chat_id" | "message_id" | "inline_message_id"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<
+        true | (Update.Edited & Message.LocationMessage)
+    > {
         const inlineId = this.inlineMessageId;
         return inlineId !== undefined
             ? this.api.stopMessageLiveLocationInline(
@@ -1613,7 +1672,7 @@ export class Context implements RenamedUpdate {
             "chat_id" | "latitude" | "longitude" | "title" | "address"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.VenueMessage> {
         const msg = this.msg;
         return this.api.sendVenue(
             orThrow(this.chatId, "sendVenue"),
@@ -1648,7 +1707,7 @@ export class Context implements RenamedUpdate {
         first_name: string,
         other?: Other<"sendContact", "chat_id" | "phone_number" | "first_name">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.ContactMessage> {
         const msg = this.msg;
         return this.api.sendContact(
             orThrow(this.chatId, "sendContact"),
@@ -1681,7 +1740,7 @@ export class Context implements RenamedUpdate {
         options: (string | InputPollOption)[],
         other?: Other<"sendPoll", "chat_id" | "question" | "options">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.PollMessage> {
         const msg = this.msg;
         return this.api.sendPoll(
             orThrow(this.chatId, "sendPoll"),
@@ -1714,7 +1773,7 @@ export class Context implements RenamedUpdate {
             "business_connection_id" | "chat_id" | "checklist"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.ChecklistMessage> {
         return this.api.sendChecklist(
             orThrow(this.businessConnectionId, "sendChecklist"),
             orThrow(this.chatId, "sendChecklist"),
@@ -1740,7 +1799,7 @@ export class Context implements RenamedUpdate {
             "business_connection_id" | "chat_id" | "messaage_id" | "checklist"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.ChecklistMessage> {
         const msg = orThrow(this.msg, "editMessageChecklist");
         const target = msg.checklist_tasks_done?.checklist_message ??
             msg.checklist_tasks_added?.checklist_message ??
@@ -1775,7 +1834,7 @@ export class Context implements RenamedUpdate {
             | "🎰",
         other?: Other<"sendDice", "chat_id" | "emoji">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.DiceMessage> {
         const msg = this.msg;
         return this.api.sendDice(
             orThrow(this.chatId, "sendDice"),
@@ -1820,7 +1879,7 @@ export class Context implements RenamedUpdate {
             | "upload_video_note",
         other?: Other<"sendChatAction", "chat_id" | "action">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         const msg = this.msg;
         return this.api.sendChatAction(
             orThrow(this.chatId, "sendChatAction"),
@@ -1850,7 +1909,7 @@ export class Context implements RenamedUpdate {
             "chat_id" | "message_id" | "reaction"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.setMessageReaction(
             orThrow(this.chatId, "setMessageReaction"),
             orThrow(this.msgId, "setMessageReaction"),
@@ -1880,7 +1939,7 @@ export class Context implements RenamedUpdate {
         text: string,
         other?: Other<"sendMessageDraft", "chat_id" | "text">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         const msg = this.msg;
         return this.api.sendMessageDraft(
             orThrow(this.chatId, "sendMessageDraft"),
@@ -1912,7 +1971,7 @@ export class Context implements RenamedUpdate {
             "chat_id" | "rich_message"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         const msg = this.msg;
         return this.api.sendRichMessageDraft(
             orThrow(this.chatId, "sendMessageDraft"),
@@ -1939,7 +1998,7 @@ export class Context implements RenamedUpdate {
     getUserProfilePhotos(
         other?: Other<"getUserProfilePhotos", "user_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<UserProfilePhotos> {
         return this.api.getUserProfilePhotos(
             orThrow(this.from, "getUserProfilePhotos").id,
             other,
@@ -1958,7 +2017,7 @@ export class Context implements RenamedUpdate {
     getUserProfileAudios(
         other?: Other<"getUserProfileAudios", "user_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<UserProfileAudios> {
         return this.api.getUserProfileAudios(
             orThrow(this.from, "getUserProfileAudios").id,
             other,
@@ -1977,7 +2036,7 @@ export class Context implements RenamedUpdate {
     setUserEmojiStatus(
         other?: Other<"setUserEmojiStatus", "user_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.setUserEmojiStatus(
             orThrow(this.from, "setUserEmojiStatus").id,
             other,
@@ -1993,7 +2052,10 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#getuserchatboosts
      */
-    getUserChatBoosts(chat_id?: number | string, signal?: AbortSignal) {
+    getUserChatBoosts(
+        chat_id?: number | string,
+        signal?: AbortSignal,
+    ): Promise<UserChatBoosts> {
         return this.api.getUserChatBoosts(
             chat_id ?? orThrow(this.chatId, "getUserChatBoosts"),
             orThrow(this.from, "getUserChatBoosts").id,
@@ -2012,7 +2074,7 @@ export class Context implements RenamedUpdate {
     getUserGifts(
         other?: Other<"getUserGifts", "user_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<OwnedGifts> {
         return this.api.getUserGifts(
             orThrow(this.from, "getUserGifts").id,
             other,
@@ -2031,7 +2093,7 @@ export class Context implements RenamedUpdate {
     getChatGifts(
         other?: Other<"getChatGifts", "chat_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<OwnedGifts> {
         return this.api.getChatGifts(
             orThrow(this.chatId, "getChatGifts"),
             other,
@@ -2045,7 +2107,7 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#getbusinessconnection
      */
-    getBusinessConnection(signal?: AbortSignal) {
+    getBusinessConnection(signal?: AbortSignal): Promise<BusinessConnection> {
         return this.api.getBusinessConnection(
             orThrow(this.businessConnectionId, "getBusinessConnection"),
             signal,
@@ -2059,7 +2121,7 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#getmanagedbottoken
      */
-    getManagedBotToken(signal?: AbortSignal) {
+    getManagedBotToken(signal?: AbortSignal): Promise<string> {
         return this.api.getManagedBotToken(
             orThrow(this.managedBot, "getManagedBotToken").bot.id,
             signal,
@@ -2073,7 +2135,7 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#replacemanagedbottoken
      */
-    replaceManagedBotToken(signal?: AbortSignal) {
+    replaceManagedBotToken(signal?: AbortSignal): Promise<string> {
         return this.api.replaceManagedBotToken(
             orThrow(this.managedBot, "getManagedBotToken").bot.id,
             signal,
@@ -2087,7 +2149,9 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#getmanagedbotaccesssettings
      */
-    getManagedBotAccessSettings(signal?: AbortSignal) {
+    getManagedBotAccessSettings(
+        signal?: AbortSignal,
+    ): Promise<BotAccessSettings> {
         return this.api.getManagedBotAccessSettings(
             orThrow(this.managedBot, "getManagedBotAccessSettings").bot.id,
             signal,
@@ -2110,7 +2174,7 @@ export class Context implements RenamedUpdate {
             "user_id" | "is_access_restricted"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.setManagedBotAccessSettings(
             orThrow(this.managedBot, "setManagedBotAccessSettings").bot.id,
             is_access_restricted,
@@ -2128,7 +2192,7 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#getfile
      */
-    getFile(signal?: AbortSignal) {
+    getFile(signal?: AbortSignal): Promise<File> {
         const m = orThrow(this.msg, "getFile");
         const file = m.photo !== undefined // handles both photos and live photos
             ? m.photo[m.photo.length - 1]
@@ -2143,7 +2207,7 @@ export class Context implements RenamedUpdate {
     }
 
     /** @deprecated Use `banAuthor` instead. */
-    kickAuthor(...args: Parameters<Context["banAuthor"]>) {
+    kickAuthor(...args: Parameters<Context["banAuthor"]>): Promise<true> {
         return this.banAuthor(...args);
     }
 
@@ -2158,7 +2222,7 @@ export class Context implements RenamedUpdate {
     banAuthor(
         other?: Other<"banChatMember", "chat_id" | "user_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.banChatMember(
             orThrow(this.chatId, "banAuthor"),
             orThrow(this.from, "banAuthor").id,
@@ -2168,7 +2232,9 @@ export class Context implements RenamedUpdate {
     }
 
     /** @deprecated Use `banChatMember` instead. */
-    kickChatMember(...args: Parameters<Context["banChatMember"]>) {
+    kickChatMember(
+        ...args: Parameters<Context["banChatMember"]>
+    ): Promise<true> {
         return this.banChatMember(...args);
     }
 
@@ -2185,7 +2251,7 @@ export class Context implements RenamedUpdate {
         user_id: number,
         other?: Other<"banChatMember", "chat_id" | "user_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.banChatMember(
             orThrow(this.chatId, "banChatMember"),
             user_id,
@@ -2207,7 +2273,7 @@ export class Context implements RenamedUpdate {
         user_id: number,
         other?: Other<"unbanChatMember", "chat_id" | "user_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.unbanChatMember(
             orThrow(this.chatId, "unbanChatMember"),
             user_id,
@@ -2232,7 +2298,7 @@ export class Context implements RenamedUpdate {
             "chat_id" | "user_id" | "permissions"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.restrictChatMember(
             orThrow(this.chatId, "restrictAuthor"),
             orThrow(this.from, "restrictAuthor").id,
@@ -2260,7 +2326,7 @@ export class Context implements RenamedUpdate {
             "chat_id" | "user_id" | "permissions"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.restrictChatMember(
             orThrow(this.chatId, "restrictChatMember"),
             user_id,
@@ -2281,7 +2347,7 @@ export class Context implements RenamedUpdate {
     promoteAuthor(
         other?: Other<"promoteChatMember", "chat_id" | "user_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.promoteChatMember(
             orThrow(this.chatId, "promoteAuthor"),
             orThrow(this.from, "promoteAuthor").id,
@@ -2303,7 +2369,7 @@ export class Context implements RenamedUpdate {
         user_id: number,
         other?: Other<"promoteChatMember", "chat_id" | "user_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.promoteChatMember(
             orThrow(this.chatId, "promoteChatMember"),
             user_id,
@@ -2323,7 +2389,7 @@ export class Context implements RenamedUpdate {
     setChatAdministratorAuthorCustomTitle(
         custom_title: string,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.setChatAdministratorCustomTitle(
             orThrow(this.chatId, "setChatAdministratorAuthorCustomTitle"),
             orThrow(this.from, "setChatAdministratorAuthorCustomTitle").id,
@@ -2345,7 +2411,7 @@ export class Context implements RenamedUpdate {
         user_id: number,
         custom_title: string,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.setChatAdministratorCustomTitle(
             orThrow(this.chatId, "setChatAdministratorCustomTitle"),
             user_id,
@@ -2362,7 +2428,7 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#setChatMemberTag
      */
-    setAuthorTag(tag: string, signal?: AbortSignal) {
+    setAuthorTag(tag: string, signal?: AbortSignal): Promise<true> {
         return this.api.setChatMemberTag(
             orThrow(this.chatId, "setChatMemberTag"),
             orThrow(this.from, "setChatMemberTag").id,
@@ -2384,7 +2450,7 @@ export class Context implements RenamedUpdate {
         user_id: number,
         tag: string,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.setChatMemberTag(
             orThrow(this.chatId, "setChatMemberTag"),
             user_id,
@@ -2401,7 +2467,10 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#banchatsenderchat
      */
-    banChatSenderChat(sender_chat_id: number, signal?: AbortSignal) {
+    banChatSenderChat(
+        sender_chat_id: number,
+        signal?: AbortSignal,
+    ): Promise<true> {
         return this.api.banChatSenderChat(
             orThrow(this.chatId, "banChatSenderChat"),
             sender_chat_id,
@@ -2420,7 +2489,7 @@ export class Context implements RenamedUpdate {
     unbanChatSenderChat(
         sender_chat_id: number,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.unbanChatSenderChat(
             orThrow(this.chatId, "unbanChatSenderChat"),
             sender_chat_id,
@@ -2441,7 +2510,7 @@ export class Context implements RenamedUpdate {
         permissions: ChatPermissions,
         other?: Other<"setChatPermissions", "chat_id" | "permissions">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.setChatPermissions(
             orThrow(this.chatId, "setChatPermissions"),
             permissions,
@@ -2459,7 +2528,7 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#exportchatinvitelink
      */
-    exportChatInviteLink(signal?: AbortSignal) {
+    exportChatInviteLink(signal?: AbortSignal): Promise<string> {
         return this.api.exportChatInviteLink(
             orThrow(this.chatId, "exportChatInviteLink"),
             signal,
@@ -2477,7 +2546,7 @@ export class Context implements RenamedUpdate {
     createChatInviteLink(
         other?: Other<"createChatInviteLink", "chat_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<ChatInviteLink> {
         return this.api.createChatInviteLink(
             orThrow(this.chatId, "createChatInviteLink"),
             other,
@@ -2498,7 +2567,7 @@ export class Context implements RenamedUpdate {
         invite_link: string,
         other?: Other<"editChatInviteLink", "chat_id" | "invite_link">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<ChatInviteLink> {
         return this.api.editChatInviteLink(
             orThrow(this.chatId, "editChatInviteLink"),
             invite_link,
@@ -2525,7 +2594,7 @@ export class Context implements RenamedUpdate {
             "chat_id" | "subscription_period" | "subscription_price"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<ChatInviteLink> {
         return this.api.createChatSubscriptionInviteLink(
             orThrow(this.chatId, "createChatSubscriptionInviteLink"),
             subscription_period,
@@ -2551,7 +2620,7 @@ export class Context implements RenamedUpdate {
             "chat_id" | "invite_link"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<ChatInviteLink> {
         return this.api.editChatSubscriptionInviteLink(
             orThrow(this.chatId, "editChatSubscriptionInviteLink"),
             invite_link,
@@ -2568,7 +2637,10 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#revokechatinvitelink
      */
-    revokeChatInviteLink(invite_link: string, signal?: AbortSignal) {
+    revokeChatInviteLink(
+        invite_link: string,
+        signal?: AbortSignal,
+    ): Promise<ChatInviteLink> {
         return this.api.revokeChatInviteLink(
             orThrow(this.chatId, "editChatInviteLink"),
             invite_link,
@@ -2587,7 +2659,7 @@ export class Context implements RenamedUpdate {
     approveChatJoinRequest(
         user_id: number,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.approveChatJoinRequest(
             orThrow(this.chatId, "approveChatJoinRequest"),
             user_id,
@@ -2606,7 +2678,7 @@ export class Context implements RenamedUpdate {
     declineChatJoinRequest(
         user_id: number,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.declineChatJoinRequest(
             orThrow(this.chatId, "declineChatJoinRequest"),
             user_id,
@@ -2625,7 +2697,7 @@ export class Context implements RenamedUpdate {
     answerChatJoinRequestQuery(
         result: "approve" | "decline" | "queue",
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.answerChatJoinRequestQuery(
             orThrow(
                 this.chatJoinRequest?.query_id,
@@ -2644,7 +2716,10 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#sendchatjoinrequestwebapp
      */
-    replyWithChatJoinRequestWebApp(web_app_url: string, signal?: AbortSignal) {
+    replyWithChatJoinRequestWebApp(
+        web_app_url: string,
+        signal?: AbortSignal,
+    ): Promise<true> {
         return this.api.sendChatJoinRequestWebApp(
             orThrow(
                 this.chatJoinRequest?.query_id,
@@ -2666,7 +2741,7 @@ export class Context implements RenamedUpdate {
     approveSuggestedPost(
         other?: Other<"approveSuggestedPost", "chat_id" | "message_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.approveSuggestedPost(
             orThrow(this.chatId, "approveSuggestedPost"),
             orThrow(this.msgId, "approveSuggestedPost"),
@@ -2686,7 +2761,7 @@ export class Context implements RenamedUpdate {
     declineSuggestedPost(
         other?: Other<"declineSuggestedPost", "chat_id" | "message_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.declineSuggestedPost(
             orThrow(this.chatId, "declineSuggestedPost"),
             orThrow(this.msgId, "declineSuggestedPost"),
@@ -2703,7 +2778,7 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#setchatphoto
      */
-    setChatPhoto(photo: InputFile, signal?: AbortSignal) {
+    setChatPhoto(photo: InputFile, signal?: AbortSignal): Promise<true> {
         return this.api.setChatPhoto(
             orThrow(this.chatId, "setChatPhoto"),
             photo,
@@ -2718,7 +2793,7 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#deletechatphoto
      */
-    deleteChatPhoto(signal?: AbortSignal) {
+    deleteChatPhoto(signal?: AbortSignal): Promise<true> {
         return this.api.deleteChatPhoto(
             orThrow(this.chatId, "deleteChatPhoto"),
             signal,
@@ -2733,7 +2808,7 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#setchattitle
      */
-    setChatTitle(title: string, signal?: AbortSignal) {
+    setChatTitle(title: string, signal?: AbortSignal): Promise<true> {
         return this.api.setChatTitle(
             orThrow(this.chatId, "setChatTitle"),
             title,
@@ -2749,7 +2824,10 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#setchatdescription
      */
-    setChatDescription(description: string | undefined, signal?: AbortSignal) {
+    setChatDescription(
+        description: string | undefined,
+        signal?: AbortSignal,
+    ): Promise<true> {
         return this.api.setChatDescription(
             orThrow(this.chatId, "setChatDescription"),
             description,
@@ -2770,7 +2848,7 @@ export class Context implements RenamedUpdate {
         message_id: number,
         other?: Other<"pinChatMessage", "chat_id" | "message_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.pinChatMessage(
             orThrow(this.chatId, "pinChatMessage"),
             message_id,
@@ -2792,7 +2870,7 @@ export class Context implements RenamedUpdate {
         message_id?: number,
         other?: Other<"unpinChatMessage", "chat_id" | "message_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.unpinChatMessage(
             orThrow(this.chatId, "unpinChatMessage"),
             message_id,
@@ -2808,7 +2886,7 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#unpinallchatmessages
      */
-    unpinAllChatMessages(signal?: AbortSignal) {
+    unpinAllChatMessages(signal?: AbortSignal): Promise<true> {
         return this.api.unpinAllChatMessages(
             orThrow(this.chatId, "unpinAllChatMessages"),
             signal,
@@ -2822,7 +2900,7 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#leavechat
      */
-    leaveChat(signal?: AbortSignal) {
+    leaveChat(signal?: AbortSignal): Promise<true> {
         return this.api.leaveChat(orThrow(this.chatId, "leaveChat"), signal);
     }
 
@@ -2833,7 +2911,7 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#getchat
      */
-    getChat(signal?: AbortSignal) {
+    getChat(signal?: AbortSignal): Promise<ChatFullInfo> {
         return this.api.getChat(orThrow(this.chatId, "getChat"), signal);
     }
 
@@ -2848,7 +2926,7 @@ export class Context implements RenamedUpdate {
     getChatAdministrators(
         other?: Other<"getChatAdministrators", "chat_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<(ChatMemberOwner | ChatMemberAdministrator)[]> {
         return this.api.getChatAdministrators(
             orThrow(this.chatId, "getChatAdministrators"),
             other,
@@ -2857,7 +2935,9 @@ export class Context implements RenamedUpdate {
     }
 
     /** @deprecated Use `getChatMemberCount` instead. */
-    getChatMembersCount(...args: Parameters<Context["getChatMemberCount"]>) {
+    getChatMembersCount(
+        ...args: Parameters<Context["getChatMemberCount"]>
+    ): Promise<number> {
         return this.getChatMemberCount(...args);
     }
 
@@ -2868,7 +2948,7 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#getchatmembercount
      */
-    getChatMemberCount(signal?: AbortSignal) {
+    getChatMemberCount(signal?: AbortSignal): Promise<number> {
         return this.api.getChatMemberCount(
             orThrow(this.chatId, "getChatMemberCount"),
             signal,
@@ -2882,7 +2962,7 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#getchatmember
      */
-    getAuthor(signal?: AbortSignal) {
+    getAuthor(signal?: AbortSignal): Promise<ChatMember> {
         return this.api.getChatMember(
             orThrow(this.chatId, "getAuthor"),
             orThrow(this.from, "getAuthor").id,
@@ -2898,7 +2978,7 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#getchatmember
      */
-    getChatMember(user_id: number, signal?: AbortSignal) {
+    getChatMember(user_id: number, signal?: AbortSignal): Promise<ChatMember> {
         return this.api.getChatMember(
             orThrow(this.chatId, "getChatMember"),
             user_id,
@@ -2917,7 +2997,7 @@ export class Context implements RenamedUpdate {
     getUserPersonalChatMessages(
         limit: number,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message[]> {
         return this.api.getUserPersonalChatMessages(
             orThrow(this.from, "getUserPersonalChatMessages").id,
             limit,
@@ -2933,7 +3013,10 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#setchatstickerset
      */
-    setChatStickerSet(sticker_set_name: string, signal?: AbortSignal) {
+    setChatStickerSet(
+        sticker_set_name: string,
+        signal?: AbortSignal,
+    ): Promise<true> {
         return this.api.setChatStickerSet(
             orThrow(this.chatId, "setChatStickerSet"),
             sticker_set_name,
@@ -2948,7 +3031,7 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#deletechatstickerset
      */
-    deleteChatStickerSet(signal?: AbortSignal) {
+    deleteChatStickerSet(signal?: AbortSignal): Promise<true> {
         return this.api.deleteChatStickerSet(
             orThrow(this.chatId, "deleteChatStickerSet"),
             signal,
@@ -2968,7 +3051,7 @@ export class Context implements RenamedUpdate {
         name: string,
         other?: Other<"createForumTopic", "chat_id" | "name">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<ForumTopic> {
         return this.api.createForumTopic(
             orThrow(this.chatId, "createForumTopic"),
             name,
@@ -2988,7 +3071,7 @@ export class Context implements RenamedUpdate {
     editForumTopic(
         other?: Other<"editForumTopic", "chat_id" | "message_thread_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         const message = orThrow(this.msg, "editForumTopic");
         const thread = orThrow(message.message_thread_id, "editForumTopic");
         return this.api.editForumTopic(message.chat.id, thread, other, signal);
@@ -3001,7 +3084,7 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#closeforumtopic
      */
-    closeForumTopic(signal?: AbortSignal) {
+    closeForumTopic(signal?: AbortSignal): Promise<true> {
         const message = orThrow(this.msg, "closeForumTopic");
         const thread = orThrow(message.message_thread_id, "closeForumTopic");
         return this.api.closeForumTopic(message.chat.id, thread, signal);
@@ -3014,7 +3097,7 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#reopenforumtopic
      */
-    reopenForumTopic(signal?: AbortSignal) {
+    reopenForumTopic(signal?: AbortSignal): Promise<true> {
         const message = orThrow(this.msg, "reopenForumTopic");
         const thread = orThrow(message.message_thread_id, "reopenForumTopic");
         return this.api.reopenForumTopic(message.chat.id, thread, signal);
@@ -3027,7 +3110,7 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#deleteforumtopic
      */
-    deleteForumTopic(signal?: AbortSignal) {
+    deleteForumTopic(signal?: AbortSignal): Promise<true> {
         const message = orThrow(this.msg, "deleteForumTopic");
         const thread = orThrow(message.message_thread_id, "deleteForumTopic");
         return this.api.deleteForumTopic(message.chat.id, thread, signal);
@@ -3040,7 +3123,7 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#unpinallforumtopicmessages
      */
-    unpinAllForumTopicMessages(signal?: AbortSignal) {
+    unpinAllForumTopicMessages(signal?: AbortSignal): Promise<true> {
         const message = orThrow(this.msg, "unpinAllForumTopicMessages");
         const thread = orThrow(
             message.message_thread_id,
@@ -3061,7 +3144,7 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#editgeneralforumtopic
      */
-    editGeneralForumTopic(name: string, signal?: AbortSignal) {
+    editGeneralForumTopic(name: string, signal?: AbortSignal): Promise<true> {
         return this.api.editGeneralForumTopic(
             orThrow(this.chatId, "editGeneralForumTopic"),
             name,
@@ -3076,7 +3159,7 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#closegeneralforumtopic
      */
-    closeGeneralForumTopic(signal?: AbortSignal) {
+    closeGeneralForumTopic(signal?: AbortSignal): Promise<true> {
         return this.api.closeGeneralForumTopic(
             orThrow(this.chatId, "closeGeneralForumTopic"),
             signal,
@@ -3090,7 +3173,7 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#reopengeneralforumtopic
      */
-    reopenGeneralForumTopic(signal?: AbortSignal) {
+    reopenGeneralForumTopic(signal?: AbortSignal): Promise<true> {
         return this.api.reopenGeneralForumTopic(
             orThrow(this.chatId, "reopenGeneralForumTopic"),
             signal,
@@ -3104,7 +3187,7 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#hidegeneralforumtopic
      */
-    hideGeneralForumTopic(signal?: AbortSignal) {
+    hideGeneralForumTopic(signal?: AbortSignal): Promise<true> {
         return this.api.hideGeneralForumTopic(
             orThrow(this.chatId, "hideGeneralForumTopic"),
             signal,
@@ -3118,7 +3201,7 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#unhidegeneralforumtopic
      */
-    unhideGeneralForumTopic(signal?: AbortSignal) {
+    unhideGeneralForumTopic(signal?: AbortSignal): Promise<true> {
         return this.api.unhideGeneralForumTopic(
             orThrow(this.chatId, "unhideGeneralForumTopic"),
             signal,
@@ -3132,7 +3215,7 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#unpinallgeneralforumtopicmessages
      */
-    unpinAllGeneralForumTopicMessages(signal?: AbortSignal) {
+    unpinAllGeneralForumTopicMessages(signal?: AbortSignal): Promise<true> {
         return this.api.unpinAllGeneralForumTopicMessages(
             orThrow(this.chatId, "unpinAllGeneralForumTopicMessages"),
             signal,
@@ -3152,7 +3235,7 @@ export class Context implements RenamedUpdate {
     answerCallbackQuery(
         other?: string | Other<"answerCallbackQuery", "callback_query_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.answerCallbackQuery(
             orThrow(this.callbackQuery, "answerCallbackQuery").id,
             typeof other === "string" ? { text: other } : other,
@@ -3171,7 +3254,7 @@ export class Context implements RenamedUpdate {
     answerGuestQuery(
         result: InlineQueryResult,
         signal?: AbortSignal,
-    ) {
+    ): Promise<SentGuestMessage> {
         return this.api.answerGuestQuery(
             orThrow(this.guestMessage?.guest_query_id, "answerGuestQuery"),
             result,
@@ -3190,7 +3273,7 @@ export class Context implements RenamedUpdate {
     setChatMenuButton(
         other?: Other<"setChatMenuButton">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.setChatMenuButton(other, signal);
     }
 
@@ -3205,7 +3288,7 @@ export class Context implements RenamedUpdate {
     getChatMenuButton(
         other?: Other<"getChatMenuButton">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<MenuButton> {
         return this.api.getChatMenuButton(other, signal);
     }
 
@@ -3220,7 +3303,7 @@ export class Context implements RenamedUpdate {
     setMyDefaultAdministratorRights(
         other?: Other<"setMyDefaultAdministratorRights">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.setMyDefaultAdministratorRights(other, signal);
     }
 
@@ -3233,7 +3316,7 @@ export class Context implements RenamedUpdate {
     getMyDefaultAdministratorRights(
         other?: Other<"getMyDefaultAdministratorRights">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<ChatAdministratorRights> {
         return this.api.getMyDefaultAdministratorRights(other, signal);
     }
 
@@ -3257,7 +3340,14 @@ export class Context implements RenamedUpdate {
             | "rich_message"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<
+        | true
+        | (
+            & Update.Edited
+            & Message.TextMessage
+        )
+        | (Update.Edited & Message.RichMessageMessage)
+    > {
         const inlineId = this.inlineMessageId;
         return inlineId !== undefined
             ? this.api.editMessageTextInline(
@@ -3293,7 +3383,7 @@ export class Context implements RenamedUpdate {
             "chat_id" | "message_id" | "inline_message_id"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true | (Update.Edited & Message.CaptionableMessage)> {
         const inlineId = this.inlineMessageId;
         return inlineId !== undefined
             ? this.api.editMessageCaptionInline(
@@ -3329,7 +3419,7 @@ export class Context implements RenamedUpdate {
             "chat_id" | "message_id" | "inline_message_id" | "media"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true | (Update.Edited & Message)> {
         const inlineId = this.inlineMessageId;
         return inlineId !== undefined
             ? this.api.editMessageMediaInline(
@@ -3365,7 +3455,7 @@ export class Context implements RenamedUpdate {
             "chat_id" | "message_id" | "inline_message_id"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true | (Update.Edited & Message)> {
         const inlineId = this.inlineMessageId;
         return inlineId !== undefined
             ? this.api.editMessageReplyMarkupInline(
@@ -3396,7 +3486,7 @@ export class Context implements RenamedUpdate {
     stopPoll(
         other?: Other<"stopPoll", "chat_id" | "message_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Poll> {
         return this.api.stopPoll(
             orThrow(this.chatId, "stopPoll"),
             orThrow(
@@ -3425,7 +3515,7 @@ export class Context implements RenamedUpdate {
             "chat_id" | "receiver_user_id" | "ephemeral_message_id" | "text"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         const msg = orThrow(this.msg, "editEphemeralMessageText");
         return this.api.editEphemeralMessageText(
             msg.chat.id,
@@ -3453,7 +3543,7 @@ export class Context implements RenamedUpdate {
             "chat_id" | "receiver_user_id" | "ephemeral_message_id" | "media"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         const msg = orThrow(this.msg, "editEphemeralMessageMedia");
         return this.api.editEphemeralMessageMedia(
             msg.chat.id,
@@ -3481,7 +3571,7 @@ export class Context implements RenamedUpdate {
             "chat_id" | "receiver_user_id" | "ephemeral_message_id" | "caption"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         const msg = orThrow(this.msg, "editEphemeralMessageCaption");
         return this.api.editEphemeralMessageCaption(
             msg.chat.id,
@@ -3510,7 +3600,7 @@ export class Context implements RenamedUpdate {
             "chat_id" | "receiver_user_id" | "ephemeral_message_id"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         const msg = orThrow(this.msg, "editEphemeralMessageReplyMarkup");
         return this.api.editEphemeralMessageReplyMarkup(
             msg.chat.id,
@@ -3540,7 +3630,7 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#deletemessage
      */
-    deleteMessage(signal?: AbortSignal) {
+    deleteMessage(signal?: AbortSignal): Promise<true> {
         return this.api.deleteMessage(
             orThrow(this.chatId, "deleteMessage"),
             orThrow(
@@ -3561,7 +3651,7 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#deletemessages
      */
-    deleteMessages(message_ids: number[], signal?: AbortSignal) {
+    deleteMessages(message_ids: number[], signal?: AbortSignal): Promise<true> {
         return this.api.deleteMessages(
             orThrow(this.chatId, "deleteMessages"),
             message_ids,
@@ -3578,7 +3668,7 @@ export class Context implements RenamedUpdate {
      */
     deleteEphemeralMessage(
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         const msg = orThrow(this.msg, "deleteEphemeralMessage");
         return this.api.deleteEphemeralMessage(
             msg.chat.id,
@@ -3602,7 +3692,7 @@ export class Context implements RenamedUpdate {
             "chat_id" | "message_id" | "user_id" | "actor_chat_id"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         const reaction = orThrow(this.messageReaction, "deleteMessageReaction");
         if (reaction.user !== undefined) {
             return this.deleteMessageReactionUser(
@@ -3639,7 +3729,7 @@ export class Context implements RenamedUpdate {
             "chat_id" | "message_id" | "user_id"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.deleteMessageReactionUser(
             orThrow(this.chatId, "deleteMessageReactionUser"),
             orThrow(this.msgId, "deleteMessageReactionUser"),
@@ -3665,7 +3755,7 @@ export class Context implements RenamedUpdate {
             "chat_id" | "message_id" | "actor_chat_id"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.deleteMessageReactionChat(
             orThrow(this.chatId, "deleteMessageReactionChat"),
             orThrow(this.msgId, "deleteMessageReactionChat"),
@@ -3689,7 +3779,7 @@ export class Context implements RenamedUpdate {
             "chat_id" | "message_id" | "user_id" | "actor_chat_id"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         const chatId = orThrow(this.chatId, "deleteAllMessageReactions");
         const actor = this.messageReaction?.actor_chat ?? this.senderChat ??
             this.pollAnswer?.voter_chat;
@@ -3726,7 +3816,7 @@ export class Context implements RenamedUpdate {
             "chat_id" | "message_id" | "user_id"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.deleteAllMessageReactionsUser(
             orThrow(this.chatId, "deleteAllMessageReactionsUser"),
             user_id,
@@ -3751,7 +3841,7 @@ export class Context implements RenamedUpdate {
             "chat_id" | "message_id" | "actor_chat_id"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.deleteAllMessageReactionsChat(
             orThrow(this.chatId, "deleteAllMessageReactionsChat"),
             actor_chat_id,
@@ -3768,7 +3858,10 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#deletebusinessmessages
      */
-    deleteBusinessMessages(message_ids: number[], signal?: AbortSignal) {
+    deleteBusinessMessages(
+        message_ids: number[],
+        signal?: AbortSignal,
+    ): Promise<true> {
         return this.api.deleteBusinessMessages(
             orThrow(this.businessConnectionId, "deleteBusinessMessages"),
             message_ids,
@@ -3792,7 +3885,7 @@ export class Context implements RenamedUpdate {
             "business_connection_id" | "first_name"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.setBusinessAccountName(
             orThrow(this.businessConnectionId, "setBusinessAccountName"),
             first_name,
@@ -3809,7 +3902,10 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#setbusinessaccountusername
      */
-    setBusinessAccountUsername(username: string, signal?: AbortSignal) {
+    setBusinessAccountUsername(
+        username: string,
+        signal?: AbortSignal,
+    ): Promise<true> {
         return this.api.setBusinessAccountUsername(
             orThrow(this.businessConnectionId, "setBusinessAccountUsername"),
             username,
@@ -3825,7 +3921,7 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#setbusinessaccountbio
      */
-    setBusinessAccountBio(bio: string, signal?: AbortSignal) {
+    setBusinessAccountBio(bio: string, signal?: AbortSignal): Promise<true> {
         return this.api.setBusinessAccountBio(
             orThrow(this.businessConnectionId, "setBusinessAccountBio"),
             bio,
@@ -3849,7 +3945,7 @@ export class Context implements RenamedUpdate {
             "business_connection_id" | "photo"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.setBusinessAccountProfilePhoto(
             orThrow(
                 this.businessConnectionId,
@@ -3875,7 +3971,7 @@ export class Context implements RenamedUpdate {
             "business_connection_id"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.removeBusinessAccountProfilePhoto(
             orThrow(
                 this.businessConnectionId,
@@ -3899,7 +3995,7 @@ export class Context implements RenamedUpdate {
         show_gift_button: boolean,
         accepted_gift_types: AcceptedGiftTypes,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.setBusinessAccountGiftSettings(
             orThrow(
                 this.businessConnectionId,
@@ -3918,7 +4014,7 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#getbusinessaccountstarbalance
      */
-    getBusinessAccountStarBalance(signal?: AbortSignal) {
+    getBusinessAccountStarBalance(signal?: AbortSignal): Promise<StarAmount> {
         return this.api.getBusinessAccountStarBalance(
             orThrow(this.businessConnectionId, "getBusinessAccountStarBalance"),
             signal,
@@ -3933,7 +4029,10 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#transferbusinessaccountstars
      */
-    transferBusinessAccountStars(star_count: number, signal?: AbortSignal) {
+    transferBusinessAccountStars(
+        star_count: number,
+        signal?: AbortSignal,
+    ): Promise<true> {
         return this.api.transferBusinessAccountStars(
             orThrow(this.businessConnectionId, "transferBusinessAccountStars"),
             star_count,
@@ -3952,7 +4051,7 @@ export class Context implements RenamedUpdate {
     getBusinessAccountGifts(
         other: Other<"getBusinessAccountGifts", "business_connection_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<OwnedGifts> {
         return this.api.getBusinessAccountGifts(
             orThrow(this.businessConnectionId, "getBusinessAccountGifts"),
             other,
@@ -3971,7 +4070,7 @@ export class Context implements RenamedUpdate {
     convertGiftToStars(
         owned_gift_id: string,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.convertGiftToStars(
             orThrow(this.businessConnectionId, "convertGiftToStars"),
             owned_gift_id,
@@ -3995,7 +4094,7 @@ export class Context implements RenamedUpdate {
             "business_connection_id" | "owned_gift_id"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.upgradeGift(
             orThrow(this.businessConnectionId, "upgradeGift"),
             owned_gift_id,
@@ -4019,7 +4118,7 @@ export class Context implements RenamedUpdate {
         new_owner_chat_id: number,
         star_count: number,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.transferGift(
             orThrow(this.businessConnectionId, "transferGift"),
             owned_gift_id,
@@ -4047,7 +4146,7 @@ export class Context implements RenamedUpdate {
             "business_connection_id" | "content" | "active_period"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Story> {
         return this.api.postStory(
             orThrow(this.businessConnectionId, "postStory"),
             content,
@@ -4076,7 +4175,7 @@ export class Context implements RenamedUpdate {
             | "active_period"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Story> {
         const story = orThrow(this.msg?.story, "repostStory");
         return this.api.repostStory(
             orThrow(this.businessConnectionId, "repostStory"),
@@ -4106,7 +4205,7 @@ export class Context implements RenamedUpdate {
             "business_connection_id" | "story_id" | "content"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Story> {
         return this.api.editStory(
             orThrow(this.businessConnectionId, "editStory"),
             story_id,
@@ -4124,7 +4223,7 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#deletestory
      */
-    deleteStory(story_id: number, signal?: AbortSignal) {
+    deleteStory(story_id: number, signal?: AbortSignal): Promise<true> {
         return this.api.deleteStory(
             orThrow(this.businessConnectionId, "deleteStory"),
             story_id,
@@ -4145,7 +4244,7 @@ export class Context implements RenamedUpdate {
         sticker: InputFile | string,
         other?: Other<"sendSticker", "chat_id" | "sticker">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.StickerMessage> {
         const msg = this.msg;
         return this.api.sendSticker(
             orThrow(this.chatId, "sendSticker"),
@@ -4170,7 +4269,7 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#getcustomemojistickers
      */
-    getCustomEmojiStickers(signal?: AbortSignal) {
+    getCustomEmojiStickers(signal?: AbortSignal): Promise<Sticker[]> {
         type Emoji = MessageEntity.CustomEmojiMessageEntity;
         return this.api.getCustomEmojiStickers(
             (this.msg?.entities ?? [])
@@ -4193,7 +4292,7 @@ export class Context implements RenamedUpdate {
         gift_id: string,
         other?: Other<"sendGift", "user_id" | "chat_id" | "gift_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.sendGift(
             orThrow(this.from, "sendGift").id,
             gift_id,
@@ -4220,7 +4319,7 @@ export class Context implements RenamedUpdate {
             "user_id" | "month_count" | "star_count"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.giftPremiumSubscription(
             orThrow(this.from, "giftPremiumSubscription").id,
             month_count,
@@ -4243,7 +4342,7 @@ export class Context implements RenamedUpdate {
         gift_id: string,
         other?: Other<"sendGift", "user_id" | "chat_id" | "gift_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.sendGiftToChannel(
             orThrow(this.chat, "sendGift").id,
             gift_id,
@@ -4268,7 +4367,7 @@ export class Context implements RenamedUpdate {
         results: readonly InlineQueryResult[],
         other?: Other<"answerInlineQuery", "inline_query_id" | "results">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.answerInlineQuery(
             orThrow(this.inlineQuery, "answerInlineQuery").id,
             results,
@@ -4290,7 +4389,7 @@ export class Context implements RenamedUpdate {
         result: InlineQueryResult,
         other?: Other<"savePreparedInlineMessage", "user_id" | "result">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<PreparedInlineMessage> {
         return this.api.savePreparedInlineMessage(
             orThrow(this.from, "savePreparedInlineMessage").id,
             result,
@@ -4313,7 +4412,7 @@ export class Context implements RenamedUpdate {
             | KeyboardButton.RequestChatButton
             | KeyboardButton.RequestManagedBotButton,
         signal?: AbortSignal,
-    ) {
+    ): Promise<PreparedKeyboardButton> {
         return this.api.savePreparedKeyboardButton(
             orThrow(this.from, "savePreparedKeyboardButton").id,
             button,
@@ -4350,7 +4449,7 @@ export class Context implements RenamedUpdate {
             | "prices"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.InvoiceMessage> {
         const msg = this.msg;
         return this.api.sendInvoice(
             orThrow(this.chatId, "sendInvoice"),
@@ -4384,7 +4483,7 @@ export class Context implements RenamedUpdate {
         ok: boolean,
         other?: Other<"answerShippingQuery", "shipping_query_id" | "ok">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.answerShippingQuery(
             orThrow(this.shippingQuery, "answerShippingQuery").id,
             ok,
@@ -4408,7 +4507,7 @@ export class Context implements RenamedUpdate {
             | string
             | Other<"answerPreCheckoutQuery", "pre_checkout_query_id" | "ok">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.answerPreCheckoutQuery(
             orThrow(this.preCheckoutQuery, "answerPreCheckoutQuery").id,
             ok,
@@ -4424,7 +4523,7 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#refundstarpayment
      */
-    refundStarPayment(signal?: AbortSignal) {
+    refundStarPayment(signal?: AbortSignal): Promise<true> {
         return this.api.refundStarPayment(
             orThrow(this.from, "refundStarPayment").id,
             orThrow(this.msg?.successful_payment, "refundStarPayment")
@@ -4446,7 +4545,7 @@ export class Context implements RenamedUpdate {
         telegram_payment_charge_id: string,
         is_canceled: boolean,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.editUserStarSubscription(
             orThrow(this.from, "editUserStarSubscription").id,
             telegram_payment_charge_id,
@@ -4466,7 +4565,7 @@ export class Context implements RenamedUpdate {
     verifyUser(
         other?: Other<"verifyUser">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.verifyUser(
             orThrow(this.from, "verifyUser").id,
             other,
@@ -4485,7 +4584,7 @@ export class Context implements RenamedUpdate {
     verifyChat(
         other?: Other<"verifyChat">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.verifyChat(
             orThrow(this.chatId, "verifyChat"),
             other,
@@ -4500,7 +4599,7 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#removeuserverification
      */
-    removeUserVerification(signal?: AbortSignal) {
+    removeUserVerification(signal?: AbortSignal): Promise<true> {
         return this.api.removeUserVerification(
             orThrow(this.from, "removeUserVerification").id,
             signal,
@@ -4516,7 +4615,7 @@ export class Context implements RenamedUpdate {
      */
     removeChatVerification(
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.removeChatVerification(
             orThrow(this.chatId, "removeChatVerification"),
             signal,
@@ -4530,7 +4629,7 @@ export class Context implements RenamedUpdate {
      *
      * **Official reference:** https://core.telegram.org/bots/api#readbusinessmessage
      */
-    readBusinessMessage(signal?: AbortSignal) {
+    readBusinessMessage(signal?: AbortSignal): Promise<true> {
         return this.api.readBusinessMessage(
             orThrow(this.businessConnectionId, "readBusinessMessage"),
             orThrow(this.chatId, "readBusinessMessage"),
@@ -4552,7 +4651,7 @@ export class Context implements RenamedUpdate {
     setPassportDataErrors(
         errors: readonly PassportElementError[],
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.api.setPassportDataErrors(
             orThrow(this.from, "setPassportDataErrors").id,
             errors,
@@ -4573,7 +4672,7 @@ export class Context implements RenamedUpdate {
         game_short_name: string,
         other?: Other<"sendGame", "chat_id" | "game_short_name">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.GameMessage> {
         const msg = this.msg;
         return this.api.sendGame(
             orThrow(this.chatId, "sendGame"),

--- a/src/convenience/inline_query.ts
+++ b/src/convenience/inline_query.ts
@@ -1,4 +1,5 @@
 import {
+    type InlineKeyboardMarkup,
     type InlineQueryResult,
     type InlineQueryResultArticle,
     type InlineQueryResultAudio,
@@ -41,7 +42,49 @@ type PartialKeys<T, K extends keyof T> =
     & Omit<T, K>
     & Partial<Pick<T, K>>;
 
-function inputMessage<R extends InlineQueryResult>(queryTemplate: R) {
+/**
+ * Collection of methods that attach a custom `input_message_content` to an
+ * inline query result, each returning the completed result `R`.
+ */
+type InputMessageMethods<R extends InlineQueryResult> = {
+    text(
+        message_text: string,
+        options?: OptionalFields<InputTextMessageContent>,
+    ): R;
+    rich(
+        rich_message: InputRichMessage,
+        options?: OptionalFields<InputRichMessageContent>,
+    ): R;
+    location(
+        latitude: number,
+        longitude: number,
+        options?: OptionalFields<InputLocationMessageContent>,
+    ): R;
+    venue(
+        title: string,
+        latitude: number,
+        longitude: number,
+        address: string,
+        options: OptionalFields<InputVenueMessageContent>,
+    ): R;
+    contact(
+        first_name: string,
+        phone_number: string,
+        options?: OptionalFields<InputContactMessageContent>,
+    ): R;
+    invoice(
+        title: string,
+        description: string,
+        payload: string,
+        provider_token: string,
+        currency: string,
+        prices: LabeledPrice[],
+        options?: OptionalFields<InputInvoiceMessageContent>,
+    ): R;
+};
+function inputMessage<R extends InlineQueryResult>(
+    queryTemplate: R,
+): R & InputMessageMethods<R> {
     return {
         ...queryTemplate,
         ...inputMessageMethods<R>(queryTemplate),
@@ -49,7 +92,7 @@ function inputMessage<R extends InlineQueryResult>(queryTemplate: R) {
 }
 function inputMessageMethods<R extends InlineQueryResult>(
     queryTemplate: Omit<R, "input_message_content">,
-) {
+): InputMessageMethods<R> {
     return {
         text(
             message_text: string,
@@ -169,7 +212,229 @@ function inputMessageMethods<R extends InlineQueryResult>(
  * [documentation](https://core.telegram.org/bots/api#inline-mode) on inline
  * mode.
  */
-export const InlineQueryResultBuilder = {
+export const InlineQueryResultBuilder: {
+    article(
+        id: string,
+        title: string,
+        options?: InlineQueryResultOptions<InlineQueryResultArticle, "title">,
+    ): InputMessageMethods<InlineQueryResultArticle>;
+    audio(
+        id: string,
+        title: string,
+        audio_url: string | URL,
+        options?: InlineQueryResultOptions<
+            InlineQueryResultAudio,
+            "title" | "audio_url"
+        >,
+    ): InlineQueryResultAudio & InputMessageMethods<InlineQueryResultAudio>;
+    audioCached(
+        id: string,
+        audio_file_id: string,
+        options?: InlineQueryResultOptions<
+            InlineQueryResultCachedAudio,
+            "audio_file_id"
+        >,
+    ):
+        & InlineQueryResultCachedAudio
+        & InputMessageMethods<InlineQueryResultCachedAudio>;
+    contact(
+        id: string,
+        phone_number: string,
+        first_name: string,
+        options?: InlineQueryResultOptions<
+            InlineQueryResultContact,
+            "phone_number" | "first_name"
+        >,
+    ): InlineQueryResultContact & InputMessageMethods<InlineQueryResultContact>;
+    documentPdf(
+        id: string,
+        title: string,
+        document_url: string | URL,
+        options?: InlineQueryResultOptions<
+            InlineQueryResultDocument,
+            "mime_type" | "title" | "document_url"
+        >,
+    ):
+        & InlineQueryResultDocument
+        & InputMessageMethods<InlineQueryResultDocument>;
+    documentZip(
+        id: string,
+        title: string,
+        document_url: string | URL,
+        options?: InlineQueryResultOptions<
+            InlineQueryResultDocument,
+            "mime_type" | "title" | "document_url"
+        >,
+    ):
+        & InlineQueryResultDocument
+        & InputMessageMethods<InlineQueryResultDocument>;
+    documentCached(
+        id: string,
+        title: string,
+        document_file_id: string,
+        options?: InlineQueryResultOptions<
+            InlineQueryResultCachedDocument,
+            "title" | "document_file_id"
+        >,
+    ):
+        & InlineQueryResultCachedDocument
+        & InputMessageMethods<InlineQueryResultCachedDocument>;
+    game(
+        id: string,
+        game_short_name: string,
+        options?: InlineQueryResultOptions<
+            InlineQueryResultGame,
+            "game_short_name"
+        >,
+    ): {
+        reply_markup?: InlineKeyboardMarkup | undefined;
+        type: string;
+        id: string;
+        game_short_name: string;
+    };
+    gif(
+        id: string,
+        gif_url: string | URL,
+        thumbnail_url: string | URL,
+        options?: InlineQueryResultOptions<
+            InlineQueryResultGif,
+            "gif_url" | "thumbnail_url"
+        >,
+    ): InlineQueryResultGif & InputMessageMethods<InlineQueryResultGif>;
+    gifCached(
+        id: string,
+        gif_file_id: string,
+        options?: InlineQueryResultOptions<
+            InlineQueryResultCachedGif,
+            "gif_file_id"
+        >,
+    ):
+        & InlineQueryResultCachedGif
+        & InputMessageMethods<InlineQueryResultCachedGif>;
+    location(
+        id: string,
+        title: string,
+        latitude: number,
+        longitude: number,
+        options?: InlineQueryResultOptions<
+            InlineQueryResultLocation,
+            "title" | "latitude" | "longitude"
+        >,
+    ):
+        & InlineQueryResultLocation
+        & InputMessageMethods<InlineQueryResultLocation>;
+    mpeg4gif(
+        id: string,
+        mpeg4_url: string | URL,
+        thumbnail_url: string | URL,
+        options?: InlineQueryResultOptions<
+            InlineQueryResultMpeg4Gif,
+            "mpeg4_url" | "thumbnail_url"
+        >,
+    ):
+        & InlineQueryResultMpeg4Gif
+        & InputMessageMethods<InlineQueryResultMpeg4Gif>;
+    mpeg4gifCached(
+        id: string,
+        mpeg4_file_id: string,
+        options?: InlineQueryResultOptions<
+            InlineQueryResultCachedMpeg4Gif,
+            "mpeg4_file_id"
+        >,
+    ):
+        & InlineQueryResultCachedMpeg4Gif
+        & InputMessageMethods<InlineQueryResultCachedMpeg4Gif>;
+    photo(
+        id: string,
+        photo_url: string | URL,
+        options?: InlineQueryResultOptions<
+            PartialKeys<InlineQueryResultPhoto, "thumbnail_url">,
+            "photo_url"
+        >,
+    ): InlineQueryResultPhoto & InputMessageMethods<InlineQueryResultPhoto>;
+    photoCached(
+        id: string,
+        photo_file_id: string,
+        options?: InlineQueryResultOptions<
+            InlineQueryResultCachedPhoto,
+            "photo_file_id"
+        >,
+    ):
+        & InlineQueryResultCachedPhoto
+        & InputMessageMethods<InlineQueryResultCachedPhoto>;
+    stickerCached(
+        id: string,
+        sticker_file_id: string,
+        options?: InlineQueryResultOptions<
+            InlineQueryResultCachedSticker,
+            "sticker_file_id"
+        >,
+    ):
+        & InlineQueryResultCachedSticker
+        & InputMessageMethods<InlineQueryResultCachedSticker>;
+    venue(
+        id: string,
+        title: string,
+        latitude: number,
+        longitude: number,
+        address: string,
+        options?: InlineQueryResultOptions<
+            InlineQueryResultVenue,
+            "title" | "latitude" | "longitude" | "address"
+        >,
+    ): InlineQueryResultVenue & InputMessageMethods<InlineQueryResultVenue>;
+    videoHtml(
+        id: string,
+        title: string,
+        video_url: string | URL,
+        thumbnail_url: string | URL,
+        options?: InlineQueryResultOptions<
+            InlineQueryResultVideo,
+            "mime_type" | "title" | "video_url" | "thumbnail_url"
+        >,
+    ): InputMessageMethods<InlineQueryResultVideo>;
+    videoMp4(
+        id: string,
+        title: string,
+        video_url: string | URL,
+        thumbnail_url: string | URL,
+        options?: InlineQueryResultOptions<
+            InlineQueryResultVideo,
+            "mime_type" | "title" | "video_url" | "thumbnail_url"
+        >,
+    ): InlineQueryResultVideo & InputMessageMethods<InlineQueryResultVideo>;
+    videoCached(
+        id: string,
+        title: string,
+        video_file_id: string,
+        options?: InlineQueryResultOptions<
+            InlineQueryResultCachedVideo,
+            "title" | "video_file_id"
+        >,
+    ):
+        & InlineQueryResultCachedVideo
+        & InputMessageMethods<InlineQueryResultCachedVideo>;
+    voice(
+        id: string,
+        title: string,
+        voice_url: string | URL,
+        options?: InlineQueryResultOptions<
+            InlineQueryResultVoice,
+            "title" | "voice_url"
+        >,
+    ): InlineQueryResultVoice & InputMessageMethods<InlineQueryResultVoice>;
+    voiceCached(
+        id: string,
+        title: string,
+        voice_file_id: string,
+        options?: InlineQueryResultOptions<
+            InlineQueryResultCachedVoice,
+            "title" | "voice_file_id"
+        >,
+    ):
+        & InlineQueryResultCachedVoice
+        & InputMessageMethods<InlineQueryResultCachedVoice>;
+} = {
     /**
      * Builds an InlineQueryResultArticle object as specified by
      * https://core.telegram.org/bots/api#inlinequeryresultarticle. Requires you

--- a/src/convenience/input_media.ts
+++ b/src/convenience/input_media.ts
@@ -36,7 +36,28 @@ type InputMediaOptions<T> = Omit<T, "type" | "media">;
  * await bot.api.editMessageMedia(chatId, messageId, media)
  * ```
  */
-export const InputMediaBuilder = {
+export const InputMediaBuilder: {
+    photo(
+        media: string | InputFile,
+        options?: InputMediaOptions<InputMediaPhoto>,
+    ): InputMediaPhoto;
+    video(
+        media: string | InputFile,
+        options?: InputMediaOptions<InputMediaVideo>,
+    ): InputMediaVideo;
+    animation(
+        media: string | InputFile,
+        options?: InputMediaOptions<InputMediaAnimation>,
+    ): InputMediaAnimation;
+    audio(
+        media: string | InputFile,
+        options?: InputMediaOptions<InputMediaAudio>,
+    ): InputMediaAudio;
+    document(
+        media: string | InputFile,
+        options?: InputMediaOptions<InputMediaDocument>,
+    ): InputMediaDocument;
+} = {
     /**
      * Creates a new `InputMediaPhoto` object as specified by
      * https://core.telegram.org/bots/api#inputmediaphoto.

--- a/src/convenience/keyboard.ts
+++ b/src/convenience/keyboard.ts
@@ -94,7 +94,7 @@ export class Keyboard {
      *
      * @param buttons The buttons to add
      */
-    add(...buttons: KeyboardButton[]) {
+    add(...buttons: KeyboardButton[]): this {
         this.keyboard[this.keyboard.length - 1]?.push(...buttons);
         return this;
     }
@@ -108,7 +108,7 @@ export class Keyboard {
      *
      * @param buttons A number of buttons to add to the next row
      */
-    row(...buttons: KeyboardButton[]) {
+    row(...buttons: KeyboardButton[]): this {
         this.keyboard.push(buttons);
         return this;
     }
@@ -124,7 +124,7 @@ export class Keyboard {
         options?:
             | KeyboardButton.CommonButton["style"]
             | Omit<KeyboardButton.CommonButton, "text">,
-    ) {
+    ): this {
         return this.add(Keyboard.text(text, options));
     }
     /**
@@ -158,7 +158,7 @@ export class Keyboard {
         text: string | KeyboardButton.CommonButton,
         requestId: number,
         options: Omit<KeyboardButtonRequestUsers, "request_id"> = {},
-    ) {
+    ): this {
         return this.add(Keyboard.requestUsers(text, requestId, options));
     }
     /**
@@ -197,7 +197,7 @@ export class Keyboard {
         options: Omit<KeyboardButtonRequestChat, "request_id"> = {
             chat_is_channel: false,
         },
-    ) {
+    ): this {
         return this.add(Keyboard.requestChat(text, requestId, options));
     }
     /**
@@ -228,7 +228,7 @@ export class Keyboard {
      *
      * @param text The text to display, and optional styling information
      */
-    requestContact(text: string | KeyboardButton.CommonButton) {
+    requestContact(text: string | KeyboardButton.CommonButton): this {
         return this.add(Keyboard.requestContact(text));
     }
     /**
@@ -252,7 +252,7 @@ export class Keyboard {
      *
      * @param text The text to display, and optional styling information
      */
-    requestLocation(text: string | KeyboardButton.CommonButton) {
+    requestLocation(text: string | KeyboardButton.CommonButton): this {
         return this.add(Keyboard.requestLocation(text));
     }
     /**
@@ -281,7 +281,7 @@ export class Keyboard {
     requestPoll(
         text: string | KeyboardButton.CommonButton,
         type?: KeyboardButtonPollType["type"],
-    ) {
+    ): this {
         return this.add(Keyboard.requestPoll(text, type));
     }
     /**
@@ -315,7 +315,7 @@ export class Keyboard {
         text: string | KeyboardButton.CommonButton,
         requestId: number,
         options: Omit<KeyboardButtonRequestManagedBot, "request_id"> = {},
-    ) {
+    ): this {
         return this.add(Keyboard.requestManagedBot(text, requestId, options));
     }
     /**
@@ -345,7 +345,7 @@ export class Keyboard {
      * @param text The text to display, and optional styling information
      * @param url An HTTPS URL of a Web App to be opened with additional data
      */
-    webApp(text: string | KeyboardButton.CommonButton, url: string) {
+    webApp(text: string | KeyboardButton.CommonButton, url: string): this {
         return this.add(Keyboard.webApp(text, url));
     }
     /**
@@ -376,7 +376,7 @@ export class Keyboard {
      *
      * @param style Style of the button
      */
-    style(style: KeyboardButton.CommonButton["style"]) {
+    style(style: KeyboardButton.CommonButton["style"]): this {
         const rows = this.keyboard.length;
         if (rows === 0) {
             throw new Error("Need to add a button before applying a style!");
@@ -404,7 +404,7 @@ export class Keyboard {
      *   .danger()
      * ```
      */
-    danger() {
+    danger(): this {
         return this.style("danger");
     }
     /**
@@ -417,7 +417,7 @@ export class Keyboard {
      *   .success()
      * ```
      */
-    success() {
+    success(): this {
         return this.style("success");
     }
     /**
@@ -430,7 +430,7 @@ export class Keyboard {
      *   .primary()
      * ```
      */
-    primary() {
+    primary(): this {
         return this.style("primary");
     }
     /**
@@ -444,7 +444,7 @@ export class Keyboard {
      *
      * @param icon Unique identifier of the custom emoji shown before the text of the button
      */
-    icon(icon: KeyboardButton.CommonButton["icon_custom_emoji_id"]) {
+    icon(icon: KeyboardButton.CommonButton["icon_custom_emoji_id"]): this {
         const rows = this.keyboard.length;
         if (rows === 0) {
             throw new Error("Need to add a button before adding an icon!");
@@ -473,7 +473,7 @@ export class Keyboard {
      *
      * @param isEnabled `true` if the keyboard should persist, and `false` otherwise
      */
-    persistent(isEnabled = true) {
+    persistent(isEnabled = true): this {
         this.is_persistent = isEnabled;
         return this;
     }
@@ -488,7 +488,7 @@ export class Keyboard {
      *
      * @param isEnabled `true` if the keyboard should be selective, and `false` otherwise
      */
-    selected(isEnabled = true) {
+    selected(isEnabled = true): this {
         this.selective = isEnabled;
         return this;
     }
@@ -503,7 +503,7 @@ export class Keyboard {
      *
      * @param isEnabled `true` if the keyboard should be one-time, and `false` otherwise
      */
-    oneTime(isEnabled = true) {
+    oneTime(isEnabled = true): this {
         this.one_time_keyboard = isEnabled;
         return this;
     }
@@ -518,7 +518,7 @@ export class Keyboard {
      *
      * @param isEnabled `true` if the keyboard should be resized, and `false` otherwise
      */
-    resized(isEnabled = true) {
+    resized(isEnabled = true): this {
         this.resize_keyboard = isEnabled;
         return this;
     }
@@ -529,7 +529,7 @@ export class Keyboard {
      *
      * @param value The placeholder text
      */
-    placeholder(value: string) {
+    placeholder(value: string): this {
         this.input_field_placeholder = value;
         return this;
     }
@@ -562,7 +562,7 @@ export class Keyboard {
      * [d e f]     [  f  ]
      * ```
      */
-    toTransposed() {
+    toTransposed(): Keyboard {
         const original = this.keyboard;
         const transposed = transpose(original);
         return this.clone(transposed);
@@ -602,7 +602,7 @@ export class Keyboard {
      * @param columns Maximum number of buttons per row
      * @param options Optional flowing behavior
      */
-    toFlowed(columns: number, options: FlowOptions = {}) {
+    toFlowed(columns: number, options: FlowOptions = {}): Keyboard {
         const original = this.keyboard;
         const flowed = reflow(original, columns, options);
         return this.clone(flowed);
@@ -614,7 +614,7 @@ export class Keyboard {
      * specified, only the options will be cloned, and the given buttons will be
      * used instead.
      */
-    clone(keyboard: KeyboardButton[][] = this.keyboard) {
+    clone(keyboard: KeyboardButton[][] = this.keyboard): Keyboard {
         const clone = new Keyboard(keyboard.map((row) => row.slice()));
         clone.is_persistent = this.is_persistent;
         clone.selective = this.selective;
@@ -629,7 +629,7 @@ export class Keyboard {
      *
      * @param sources A number of keyboards to append
      */
-    append(...sources: KeyboardSource[]) {
+    append(...sources: KeyboardSource[]): this {
         for (const source of sources) {
             const keyboard = Keyboard.from(source);
             this.keyboard.push(...keyboard.keyboard.map((row) => row.slice()));
@@ -641,7 +641,7 @@ export class Keyboard {
      * `resize_keyboard` or other options that may be set. You don't usually
      * need to call this method. It is no longer useful.
      */
-    build() {
+    build(): KeyboardButton[][] {
         return this.keyboard;
     }
     /**
@@ -712,7 +712,7 @@ export class InlineKeyboard {
      *
      * @param buttons The buttons to add
      */
-    add(...buttons: InlineKeyboardButton[]) {
+    add(...buttons: InlineKeyboardButton[]): this {
         this.inline_keyboard[this.inline_keyboard.length - 1]?.push(...buttons);
         return this;
     }
@@ -726,7 +726,7 @@ export class InlineKeyboard {
      *
      * @param buttons A number of buttons to add to the next row
      */
-    row(...buttons: InlineKeyboardButton[]) {
+    row(...buttons: InlineKeyboardButton[]): this {
         this.inline_keyboard.push(buttons);
         return this;
     }
@@ -740,7 +740,7 @@ export class InlineKeyboard {
     url(
         text: string | InlineKeyboardButton.AbstractInlineKeyboardButton,
         url: string,
-    ) {
+    ): this {
         return this.add(InlineKeyboard.url(text, url));
     }
     /**
@@ -777,7 +777,7 @@ export class InlineKeyboard {
     text(
         text: string | InlineKeyboardButton.AbstractInlineKeyboardButton,
         data = typeof text === "string" ? text : text.text,
-    ) {
+    ): this {
         return this.add(InlineKeyboard.text(text, data));
     }
     /**
@@ -815,7 +815,7 @@ export class InlineKeyboard {
     webApp(
         text: string | InlineKeyboardButton.AbstractInlineKeyboardButton,
         url: string | WebAppInfo,
-    ) {
+    ): this {
         return this.add(InlineKeyboard.webApp(text, url));
     }
     /**
@@ -844,7 +844,7 @@ export class InlineKeyboard {
     login(
         text: string | InlineKeyboardButton.AbstractInlineKeyboardButton,
         loginUrl: string | LoginUrl,
-    ) {
+    ): this {
         return this.add(InlineKeyboard.login(text, loginUrl));
     }
     /**
@@ -884,7 +884,7 @@ export class InlineKeyboard {
     switchInline(
         text: string | InlineKeyboardButton.AbstractInlineKeyboardButton,
         query = "",
-    ) {
+    ): this {
         return this.add(InlineKeyboard.switchInline(text, query));
     }
     /**
@@ -928,7 +928,7 @@ export class InlineKeyboard {
     switchInlineCurrent(
         text: string | InlineKeyboardButton.AbstractInlineKeyboardButton,
         query = "",
-    ) {
+    ): this {
         return this.add(InlineKeyboard.switchInlineCurrent(text, query));
     }
     /**
@@ -972,7 +972,7 @@ export class InlineKeyboard {
     switchInlineChosen(
         text: string | InlineKeyboardButton.AbstractInlineKeyboardButton,
         query: SwitchInlineQueryChosenChat = {},
-    ) {
+    ): this {
         return this.add(InlineKeyboard.switchInlineChosen(text, query));
     }
     /**
@@ -1008,7 +1008,7 @@ export class InlineKeyboard {
     copyText(
         text: string | InlineKeyboardButton.AbstractInlineKeyboardButton,
         copyText: string | CopyTextButton,
-    ) {
+    ): this {
         return this.add(InlineKeyboard.copyText(text, copyText));
     }
     /**
@@ -1037,7 +1037,9 @@ export class InlineKeyboard {
      *
      * @param text The text to display, and optional styling information
      */
-    game(text: string | InlineKeyboardButton.AbstractInlineKeyboardButton) {
+    game(
+        text: string | InlineKeyboardButton.AbstractInlineKeyboardButton,
+    ): this {
         return this.add(InlineKeyboard.game(text));
     }
     /**
@@ -1065,7 +1067,9 @@ export class InlineKeyboard {
      *
      * @param text The text to display, and optional styling information. Substrings “⭐” and “XTR” in the buttons's text will be replaced with a Telegram Star icon.
      */
-    pay(text: string | InlineKeyboardButton.AbstractInlineKeyboardButton) {
+    pay(
+        text: string | InlineKeyboardButton.AbstractInlineKeyboardButton,
+    ): this {
         return this.add(InlineKeyboard.pay(text));
     }
     /**
@@ -1094,7 +1098,9 @@ export class InlineKeyboard {
      *
      * @param style Style of the button
      */
-    style(style: InlineKeyboardButton.AbstractInlineKeyboardButton["style"]) {
+    style(
+        style: InlineKeyboardButton.AbstractInlineKeyboardButton["style"],
+    ): this {
         const rows = this.inline_keyboard.length;
         if (rows === 0) {
             throw new Error("Need to add a button before applying a style!");
@@ -1117,7 +1123,7 @@ export class InlineKeyboard {
      *   .danger()
      * ```
      */
-    danger() {
+    danger(): this {
         return this.style("danger");
     }
     /**
@@ -1130,7 +1136,7 @@ export class InlineKeyboard {
      *   .success()
      * ```
      */
-    success() {
+    success(): this {
         return this.style("success");
     }
     /**
@@ -1143,7 +1149,7 @@ export class InlineKeyboard {
      *   .primary()
      * ```
      */
-    primary() {
+    primary(): this {
         return this.style("primary");
     }
     /**
@@ -1161,7 +1167,7 @@ export class InlineKeyboard {
         icon: InlineKeyboardButton.AbstractInlineKeyboardButton[
             "icon_custom_emoji_id"
         ],
-    ) {
+    ): this {
         const rows = this.inline_keyboard.length;
         if (rows === 0) {
             throw new Error("Need to add a button before adding an icon!");
@@ -1204,7 +1210,7 @@ export class InlineKeyboard {
      * [d e f]     [  f  ]
      * ```
      */
-    toTransposed() {
+    toTransposed(): InlineKeyboard {
         const original = this.inline_keyboard;
         const transposed = transpose(original);
         return new InlineKeyboard(transposed);
@@ -1244,7 +1250,7 @@ export class InlineKeyboard {
      * @param columns Maximum number of buttons per row
      * @param options Optional flowing behavior
      */
-    toFlowed(columns: number, options: FlowOptions = {}) {
+    toFlowed(columns: number, options: FlowOptions = {}): InlineKeyboard {
         const original = this.inline_keyboard;
         const flowed = reflow(original, columns, options);
         return new InlineKeyboard(flowed);
@@ -1252,7 +1258,7 @@ export class InlineKeyboard {
     /**
      * Creates and returns a deep copy of this inline keyboard.
      */
-    clone() {
+    clone(): InlineKeyboard {
         return new InlineKeyboard(
             this.inline_keyboard.map((row) => row.slice()),
         );
@@ -1262,7 +1268,7 @@ export class InlineKeyboard {
      *
      * @param sources A number of inline keyboards to append
      */
-    append(...sources: InlineKeyboardSource[]) {
+    append(...sources: InlineKeyboardSource[]): this {
         for (const source of sources) {
             const keyboard = InlineKeyboard.from(source);
             this.inline_keyboard.push(

--- a/src/convenience/session.ts
+++ b/src/convenience/session.ts
@@ -662,10 +662,11 @@ export class MemorySessionStorage<S> implements StorageAdapter<S> {
     /**
      * Internally used `Map` instance that stores the session data
      */
-    protected readonly storage = new Map<
-        string,
-        { session: S; expires?: number }
-    >();
+    protected readonly storage: Map<string, { session: S; expires?: number }> =
+        new Map<
+            string,
+            { session: S; expires?: number }
+        >();
 
     /**
      * Constructs a new memory session storage with the given time to live. Note
@@ -675,7 +676,7 @@ export class MemorySessionStorage<S> implements StorageAdapter<S> {
      */
     constructor(private readonly timeToLive?: number) {}
 
-    read(key: string) {
+    read(key: string): S | undefined {
         const value = this.storage.get(key);
         if (value === undefined) return undefined;
         if (value.expires !== undefined && value.expires < Date.now()) {
@@ -688,28 +689,28 @@ export class MemorySessionStorage<S> implements StorageAdapter<S> {
     /**
      * @deprecated Use {@link readAllValues} instead
      */
-    readAll() {
+    readAll(): S[] {
         return this.readAllValues();
     }
 
-    readAllKeys() {
+    readAllKeys(): string[] {
         return Array.from(this.storage.keys());
     }
 
-    readAllValues() {
+    readAllValues(): S[] {
         return Array
             .from(this.storage.keys())
             .map((key) => this.read(key))
             .filter((value): value is S => value !== undefined);
     }
 
-    readAllEntries() {
+    readAllEntries(): [string, S][] {
         return Array.from(this.storage.keys())
             .map((key) => [key, this.read(key)])
             .filter((pair): pair is [string, S] => pair[1] !== undefined);
     }
 
-    has(key: string) {
+    has(key: string): boolean {
         return this.storage.has(key);
     }
 

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -1,8 +1,23 @@
 // deno-lint-ignore-file camelcase
 import {
     type AcceptedGiftTypes,
+    type BotAccessSettings,
     type BotCommand,
+    type BotDescription,
+    type BotName,
+    type BotShortDescription,
+    type BusinessConnection,
+    type ChatAdministratorRights,
+    type ChatFullInfo,
+    type ChatInviteLink,
+    type ChatMember,
+    type ChatMemberAdministrator,
+    type ChatMemberOwner,
     type ChatPermissions,
+    type File,
+    type ForumTopic,
+    type GameHighScore,
+    type Gifts,
     type InlineQueryResult,
     type InputChecklist,
     type InputFile,
@@ -23,8 +38,28 @@ import {
     type KeyboardButton,
     type LabeledPrice,
     type MaskPosition,
+    type MenuButton,
+    type Message,
+    type MessageId,
+    type OwnedGifts,
     type PassportElementError,
+    type Poll,
+    type PreparedInlineMessage,
+    type PreparedKeyboardButton,
     type ReactionType,
+    type SentGuestMessage,
+    type SentWebAppMessage,
+    type StarAmount,
+    type StarTransactions,
+    type Sticker,
+    type StickerSet,
+    type Story,
+    type Update,
+    type UserChatBoosts,
+    type UserFromGetMe,
+    type UserProfileAudios,
+    type UserProfilePhotos,
+    type WebhookInfo,
 } from "../types.ts";
 import {
     type ApiClientOptions,
@@ -139,7 +174,10 @@ export class Api<R extends RawApi = RawApi> {
      *
      * **Official reference:** https://core.telegram.org/bots/api#getupdates
      */
-    getUpdates(other?: Other<R, "getUpdates">, signal?: AbortSignal) {
+    getUpdates(
+        other?: Other<R, "getUpdates">,
+        signal?: AbortSignal,
+    ): Promise<Update[]> {
         return this.raw.getUpdates({ ...other }, signal);
     }
 
@@ -165,7 +203,7 @@ export class Api<R extends RawApi = RawApi> {
         url: string,
         other?: Other<R, "setWebhook", "url">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.setWebhook({ url, ...other }, signal);
     }
 
@@ -177,7 +215,10 @@ export class Api<R extends RawApi = RawApi> {
      *
      * **Official reference:** https://core.telegram.org/bots/api#deletewebhook
      */
-    deleteWebhook(other?: Other<R, "deleteWebhook">, signal?: AbortSignal) {
+    deleteWebhook(
+        other?: Other<R, "deleteWebhook">,
+        signal?: AbortSignal,
+    ): Promise<true> {
         return this.raw.deleteWebhook({ ...other }, signal);
     }
 
@@ -188,7 +229,7 @@ export class Api<R extends RawApi = RawApi> {
      *
      * **Official reference:** https://core.telegram.org/bots/api#getwebhookinfo
      */
-    getWebhookInfo(signal?: AbortSignal) {
+    getWebhookInfo(signal?: AbortSignal): Promise<WebhookInfo> {
         return this.raw.getWebhookInfo(signal);
     }
 
@@ -199,7 +240,7 @@ export class Api<R extends RawApi = RawApi> {
      *
      * **Official reference:** https://core.telegram.org/bots/api#getme
      */
-    getMe(signal?: AbortSignal) {
+    getMe(signal?: AbortSignal): Promise<UserFromGetMe> {
         return this.raw.getMe(signal);
     }
 
@@ -210,7 +251,7 @@ export class Api<R extends RawApi = RawApi> {
      *
      * **Official reference:** https://core.telegram.org/bots/api#logout
      */
-    logOut(signal?: AbortSignal) {
+    logOut(signal?: AbortSignal): Promise<true> {
         return this.raw.logOut(signal);
     }
 
@@ -221,7 +262,7 @@ export class Api<R extends RawApi = RawApi> {
      *
      * **Official reference:** https://core.telegram.org/bots/api#close
      */
-    close(signal?: AbortSignal) {
+    close(signal?: AbortSignal): Promise<true> {
         return this.raw.close(signal);
     }
 
@@ -240,7 +281,7 @@ export class Api<R extends RawApi = RawApi> {
         text: string,
         other?: Other<R, "sendMessage", "chat_id" | "text">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.TextMessage> {
         return this.raw.sendMessage({ chat_id, text, ...other }, signal);
     }
 
@@ -259,7 +300,7 @@ export class Api<R extends RawApi = RawApi> {
         rich_message: InputRichMessage,
         other?: Other<R, "sendRichMessage", "chat_id" | "rich_message">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.RichMessageMessage> {
         return this.raw.sendRichMessage(
             { chat_id, rich_message, ...other },
             signal,
@@ -287,7 +328,7 @@ export class Api<R extends RawApi = RawApi> {
             "chat_id" | "from_chat_id" | "message_id"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message> {
         return this.raw.forwardMessage(
             { chat_id, from_chat_id, message_id, ...other },
             signal,
@@ -315,7 +356,7 @@ export class Api<R extends RawApi = RawApi> {
             "chat_id" | "from_chat_id" | "message_ids"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<MessageId[]> {
         return this.raw.forwardMessages({
             chat_id,
             from_chat_id,
@@ -345,7 +386,7 @@ export class Api<R extends RawApi = RawApi> {
             "chat_id" | "from_chat_id" | "message_id"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<MessageId> {
         return this.raw.copyMessage(
             { chat_id, from_chat_id, message_id, ...other },
             signal,
@@ -373,7 +414,7 @@ export class Api<R extends RawApi = RawApi> {
             "chat_id" | "from_chat_id" | "message_ids"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<MessageId[]> {
         return this.raw.copyMessages({
             chat_id,
             from_chat_id,
@@ -397,7 +438,7 @@ export class Api<R extends RawApi = RawApi> {
         photo: InputFile | string,
         other?: Other<R, "sendPhoto", "chat_id" | "photo">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.PhotoMessage> {
         return this.raw.sendPhoto({ chat_id, photo, ...other }, signal);
     }
 
@@ -418,7 +459,7 @@ export class Api<R extends RawApi = RawApi> {
         photo: InputFile | string,
         other?: Other<R, "sendLivePhoto", "chat_id" | "live_photo" | "photo">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.LivePhotoMessage> {
         return this.raw.sendLivePhoto(
             { chat_id, live_photo, photo, ...other },
             signal,
@@ -442,7 +483,7 @@ export class Api<R extends RawApi = RawApi> {
         audio: InputFile | string,
         other?: Other<R, "sendAudio", "chat_id" | "audio">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.AudioMessage> {
         return this.raw.sendAudio({ chat_id, audio, ...other }, signal);
     }
 
@@ -461,7 +502,7 @@ export class Api<R extends RawApi = RawApi> {
         document: InputFile | string,
         other?: Other<R, "sendDocument", "chat_id" | "document">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.DocumentMessage> {
         return this.raw.sendDocument({ chat_id, document, ...other }, signal);
     }
 
@@ -480,7 +521,7 @@ export class Api<R extends RawApi = RawApi> {
         video: InputFile | string,
         other?: Other<R, "sendVideo", "chat_id" | "video">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.VideoMessage> {
         return this.raw.sendVideo({ chat_id, video, ...other }, signal);
     }
 
@@ -499,7 +540,7 @@ export class Api<R extends RawApi = RawApi> {
         animation: InputFile | string,
         other?: Other<R, "sendAnimation", "chat_id" | "animation">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.AnimationMessage> {
         return this.raw.sendAnimation({ chat_id, animation, ...other }, signal);
     }
 
@@ -518,7 +559,7 @@ export class Api<R extends RawApi = RawApi> {
         voice: InputFile | string,
         other?: Other<R, "sendVoice", "chat_id" | "voice">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.VoiceMessage> {
         return this.raw.sendVoice({ chat_id, voice, ...other }, signal);
     }
 
@@ -538,7 +579,7 @@ export class Api<R extends RawApi = RawApi> {
         video_note: InputFile | string,
         other?: Other<R, "sendVideoNote", "chat_id" | "video_note">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.VideoNoteMessage> {
         return this.raw.sendVideoNote(
             { chat_id, video_note, ...other },
             signal,
@@ -562,7 +603,7 @@ export class Api<R extends RawApi = RawApi> {
         media: InputPaidMedia[],
         other?: Other<R, "sendPaidMedia", "chat_id" | "star_count" | "media">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.PaidMediaMessage> {
         return this.raw.sendPaidMedia(
             { chat_id, star_count, media, ...other },
             signal,
@@ -591,7 +632,15 @@ export class Api<R extends RawApi = RawApi> {
             >,
         other?: Other<R, "sendMediaGroup", "chat_id" | "media">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<
+        (
+            | Message.AudioMessage
+            | Message.DocumentMessage
+            | Message.LivePhotoMessage
+            | Message.PhotoMessage
+            | Message.VideoMessage
+        )[]
+    > {
         return this.raw.sendMediaGroup({ chat_id, media, ...other }, signal);
     }
 
@@ -612,7 +661,7 @@ export class Api<R extends RawApi = RawApi> {
         longitude: number,
         other?: Other<R, "sendLocation", "chat_id" | "latitude" | "longitude">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.LocationMessage> {
         return this.raw.sendLocation(
             { chat_id, latitude, longitude, ...other },
             signal,
@@ -646,7 +695,9 @@ export class Api<R extends RawApi = RawApi> {
             | "longitude"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<
+        true | (Update.Edited & Message.LocationMessage)
+    > {
         return this.raw.editMessageLiveLocation(
             { chat_id, message_id, latitude, longitude, ...other },
             signal,
@@ -678,7 +729,9 @@ export class Api<R extends RawApi = RawApi> {
             | "longitude"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<
+        true | (Update.Edited & Message.LocationMessage)
+    > {
         return this.raw.editMessageLiveLocation(
             { inline_message_id, latitude, longitude, ...other },
             signal,
@@ -704,7 +757,9 @@ export class Api<R extends RawApi = RawApi> {
             "chat_id" | "message_id" | "inline_message_id"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<
+        true | (Update.Edited & Message.LocationMessage)
+    > {
         return this.raw.stopMessageLiveLocation(
             { chat_id, message_id, ...other },
             signal,
@@ -728,7 +783,9 @@ export class Api<R extends RawApi = RawApi> {
             "chat_id" | "message_id" | "inline_message_id"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<
+        true | (Update.Edited & Message.LocationMessage)
+    > {
         return this.raw.stopMessageLiveLocation(
             { inline_message_id, ...other },
             signal,
@@ -760,7 +817,7 @@ export class Api<R extends RawApi = RawApi> {
             "chat_id" | "latitude" | "longitude" | "title" | "address"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.VenueMessage> {
         return this.raw.sendVenue(
             { chat_id, latitude, longitude, title, address, ...other },
             signal,
@@ -788,7 +845,7 @@ export class Api<R extends RawApi = RawApi> {
             "chat_id" | "phone_number" | "first_name"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.ContactMessage> {
         return this.raw.sendContact(
             { chat_id, phone_number, first_name, ...other },
             signal,
@@ -812,7 +869,7 @@ export class Api<R extends RawApi = RawApi> {
         options: (string | InputPollOption)[],
         other?: Other<R, "sendPoll", "chat_id" | "question" | "options">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.PollMessage> {
         const opts = options.map((o) =>
             typeof o === "string" ? { text: o } : o
         );
@@ -843,7 +900,7 @@ export class Api<R extends RawApi = RawApi> {
             "business_connection_id" | "chat_id" | "checklist"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.ChecklistMessage> {
         return this.raw.sendChecklist({
             business_connection_id,
             chat_id,
@@ -875,7 +932,7 @@ export class Api<R extends RawApi = RawApi> {
             "business_connection_id" | "chat_id" | "messaage_id" | "checklist"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.ChecklistMessage> {
         return this.raw.editMessageChecklist({
             business_connection_id,
             chat_id,
@@ -907,7 +964,7 @@ export class Api<R extends RawApi = RawApi> {
             | "🎰",
         other?: Other<R, "sendDice", "chat_id" | "emoji">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.DiceMessage> {
         return this.raw.sendDice({ chat_id, emoji, ...other }, signal);
     }
 
@@ -932,7 +989,7 @@ export class Api<R extends RawApi = RawApi> {
             "chat_id" | "message_id" | "reaction"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.setMessageReaction({
             chat_id,
             message_id,
@@ -958,7 +1015,7 @@ export class Api<R extends RawApi = RawApi> {
         text: string,
         other?: Other<R, "sendMessageDraft", "chat_id" | "draft_id" | "text">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.sendMessageDraft(
             { chat_id, draft_id, text, ...other },
             signal,
@@ -986,7 +1043,7 @@ export class Api<R extends RawApi = RawApi> {
             "chat_id" | "draft_id" | "rich_message"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.sendRichMessageDraft(
             { chat_id, draft_id, rich_message, ...other },
             signal,
@@ -1023,7 +1080,7 @@ export class Api<R extends RawApi = RawApi> {
             | "upload_video_note",
         other?: Other<R, "sendChatAction", "chat_id" | "action">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.sendChatAction({ chat_id, action, ...other }, signal);
     }
 
@@ -1040,7 +1097,7 @@ export class Api<R extends RawApi = RawApi> {
         user_id: number,
         other?: Other<R, "getUserProfilePhotos", "user_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<UserProfilePhotos> {
         return this.raw.getUserProfilePhotos({ user_id, ...other }, signal);
     }
 
@@ -1057,7 +1114,7 @@ export class Api<R extends RawApi = RawApi> {
         user_id: number,
         other?: Other<R, "getUserProfileAudios", "user_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<UserProfileAudios> {
         return this.raw.getUserProfileAudios({ user_id, ...other }, signal);
     }
 
@@ -1074,7 +1131,7 @@ export class Api<R extends RawApi = RawApi> {
         user_id: number,
         other?: Other<R, "setUserEmojiStatus", "user_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.setUserEmojiStatus({ user_id, ...other }, signal);
     }
 
@@ -1091,7 +1148,7 @@ export class Api<R extends RawApi = RawApi> {
         chat_id: number | string,
         user_id: number,
         signal?: AbortSignal,
-    ) {
+    ): Promise<UserChatBoosts> {
         return this.raw.getUserChatBoosts({ chat_id, user_id }, signal);
     }
 
@@ -1108,7 +1165,7 @@ export class Api<R extends RawApi = RawApi> {
         user_id: number,
         other?: Other<R, "getUserGifts", "user_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<OwnedGifts> {
         return this.raw.getUserGifts({ user_id, ...other }, signal);
     }
 
@@ -1125,7 +1182,7 @@ export class Api<R extends RawApi = RawApi> {
         chat_id: number,
         other?: Other<R, "getChatGifts", "chat_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<OwnedGifts> {
         return this.raw.getChatGifts({ chat_id, ...other }, signal);
     }
 
@@ -1140,7 +1197,7 @@ export class Api<R extends RawApi = RawApi> {
     getBusinessConnection(
         business_connection_id: string,
         signal?: AbortSignal,
-    ) {
+    ): Promise<BusinessConnection> {
         return this.raw.getBusinessConnection(
             { business_connection_id },
             signal,
@@ -1155,7 +1212,7 @@ export class Api<R extends RawApi = RawApi> {
      *
      * **Official reference:** https://core.telegram.org/bots/api#getmanagedbottoken
      */
-    getManagedBotToken(user_id: number, signal?: AbortSignal) {
+    getManagedBotToken(user_id: number, signal?: AbortSignal): Promise<string> {
         return this.raw.getManagedBotToken({ user_id }, signal);
     }
 
@@ -1167,7 +1224,10 @@ export class Api<R extends RawApi = RawApi> {
      *
      * **Official reference:** https://core.telegram.org/bots/api#replacemanagedbottoken
      */
-    replaceManagedBotToken(user_id: number, signal?: AbortSignal) {
+    replaceManagedBotToken(
+        user_id: number,
+        signal?: AbortSignal,
+    ): Promise<string> {
         return this.raw.replaceManagedBotToken({ user_id }, signal);
     }
 
@@ -1179,7 +1239,10 @@ export class Api<R extends RawApi = RawApi> {
      *
      * **Official reference:** https://core.telegram.org/bots/api#getmanagedbotaccesssettings
      */
-    getManagedBotAccessSettings(user_id: number, signal?: AbortSignal) {
+    getManagedBotAccessSettings(
+        user_id: number,
+        signal?: AbortSignal,
+    ): Promise<BotAccessSettings> {
         return this.raw.getManagedBotAccessSettings({ user_id }, signal);
     }
 
@@ -1202,7 +1265,7 @@ export class Api<R extends RawApi = RawApi> {
             "user_id" | "is_access_restricted"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.setManagedBotAccessSettings({
             user_id,
             is_access_restricted,
@@ -1220,12 +1283,12 @@ export class Api<R extends RawApi = RawApi> {
      *
      * **Official reference:** https://core.telegram.org/bots/api#getfile
      */
-    getFile(file_id: string, signal?: AbortSignal) {
+    getFile(file_id: string, signal?: AbortSignal): Promise<File> {
         return this.raw.getFile({ file_id }, signal);
     }
 
     /** @deprecated Use `banChatMember` instead. */
-    kickChatMember(...args: Parameters<Api["banChatMember"]>) {
+    kickChatMember(...args: Parameters<Api["banChatMember"]>): Promise<true> {
         return this.banChatMember(...args);
     }
 
@@ -1244,7 +1307,7 @@ export class Api<R extends RawApi = RawApi> {
         user_id: number,
         other?: Other<R, "banChatMember", "chat_id" | "user_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.banChatMember({ chat_id, user_id, ...other }, signal);
     }
 
@@ -1263,7 +1326,7 @@ export class Api<R extends RawApi = RawApi> {
         user_id: number,
         other?: Other<R, "unbanChatMember", "chat_id" | "user_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.unbanChatMember({ chat_id, user_id, ...other }, signal);
     }
 
@@ -1288,7 +1351,7 @@ export class Api<R extends RawApi = RawApi> {
             "chat_id" | "user_id" | "permissions"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.restrictChatMember(
             { chat_id, user_id, permissions, ...other },
             signal,
@@ -1310,7 +1373,7 @@ export class Api<R extends RawApi = RawApi> {
         user_id: number,
         other?: Other<R, "promoteChatMember", "chat_id" | "user_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.promoteChatMember(
             { chat_id, user_id, ...other },
             signal,
@@ -1332,7 +1395,7 @@ export class Api<R extends RawApi = RawApi> {
         user_id: number,
         custom_title: string,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.setChatAdministratorCustomTitle(
             { chat_id, user_id, custom_title },
             signal,
@@ -1354,7 +1417,7 @@ export class Api<R extends RawApi = RawApi> {
         user_id: number,
         tag: string,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.setChatMemberTag({ chat_id, user_id, tag }, signal);
     }
 
@@ -1371,7 +1434,7 @@ export class Api<R extends RawApi = RawApi> {
         chat_id: number | string,
         sender_chat_id: number,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.banChatSenderChat({ chat_id, sender_chat_id }, signal);
     }
 
@@ -1388,7 +1451,7 @@ export class Api<R extends RawApi = RawApi> {
         chat_id: number | string,
         sender_chat_id: number,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.unbanChatSenderChat(
             { chat_id, sender_chat_id },
             signal,
@@ -1410,7 +1473,7 @@ export class Api<R extends RawApi = RawApi> {
         permissions: ChatPermissions,
         other?: Other<R, "setChatPermissions", "chat_id" | "permissions">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.setChatPermissions(
             { chat_id, permissions, ...other },
             signal,
@@ -1427,7 +1490,10 @@ export class Api<R extends RawApi = RawApi> {
      *
      * **Official reference:** https://core.telegram.org/bots/api#exportchatinvitelink
      */
-    exportChatInviteLink(chat_id: number | string, signal?: AbortSignal) {
+    exportChatInviteLink(
+        chat_id: number | string,
+        signal?: AbortSignal,
+    ): Promise<string> {
         return this.raw.exportChatInviteLink({ chat_id }, signal);
     }
 
@@ -1444,7 +1510,7 @@ export class Api<R extends RawApi = RawApi> {
         chat_id: number | string,
         other?: Other<R, "createChatInviteLink", "chat_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<ChatInviteLink> {
         return this.raw.createChatInviteLink({ chat_id, ...other }, signal);
     }
 
@@ -1463,7 +1529,7 @@ export class Api<R extends RawApi = RawApi> {
         invite_link: string,
         other?: Other<R, "editChatInviteLink", "chat_id" | "invite_link">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<ChatInviteLink> {
         return this.raw.editChatInviteLink(
             { chat_id, invite_link, ...other },
             signal,
@@ -1491,7 +1557,7 @@ export class Api<R extends RawApi = RawApi> {
             "chat_id" | "subscription_period" | "subscription_price"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<ChatInviteLink> {
         return this.raw.createChatSubscriptionInviteLink(
             { chat_id, subscription_period, subscription_price, ...other },
             signal,
@@ -1517,7 +1583,7 @@ export class Api<R extends RawApi = RawApi> {
             "chat_id" | "invite_link"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<ChatInviteLink> {
         return this.raw.editChatSubscriptionInviteLink(
             { chat_id, invite_link, ...other },
             signal,
@@ -1537,7 +1603,7 @@ export class Api<R extends RawApi = RawApi> {
         chat_id: number | string,
         invite_link: string,
         signal?: AbortSignal,
-    ) {
+    ): Promise<ChatInviteLink> {
         return this.raw.revokeChatInviteLink({ chat_id, invite_link }, signal);
     }
 
@@ -1554,7 +1620,7 @@ export class Api<R extends RawApi = RawApi> {
         chat_id: number | string,
         user_id: number,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.approveChatJoinRequest({ chat_id, user_id }, signal);
     }
 
@@ -1571,7 +1637,7 @@ export class Api<R extends RawApi = RawApi> {
         chat_id: number | string,
         user_id: number,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.declineChatJoinRequest({ chat_id, user_id }, signal);
     }
 
@@ -1588,7 +1654,7 @@ export class Api<R extends RawApi = RawApi> {
         chat_join_request_query_id: string,
         result: "approve" | "decline" | "queue",
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.answerChatJoinRequestQuery(
             { chat_join_request_query_id, result },
             signal,
@@ -1608,7 +1674,7 @@ export class Api<R extends RawApi = RawApi> {
         chat_join_request_query_id: string,
         web_app_url: string,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.sendChatJoinRequestWebApp(
             { chat_join_request_query_id, web_app_url },
             signal,
@@ -1630,7 +1696,7 @@ export class Api<R extends RawApi = RawApi> {
         message_id: number,
         other?: Other<R, "approveSuggestedPost", "chat_id" | "message_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.approveSuggestedPost(
             { chat_id, message_id, ...other },
             signal,
@@ -1652,7 +1718,7 @@ export class Api<R extends RawApi = RawApi> {
         message_id: number,
         other?: Other<R, "declineSuggestedPost", "chat_id" | "message_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.declineSuggestedPost(
             { chat_id, message_id, ...other },
             signal,
@@ -1672,7 +1738,7 @@ export class Api<R extends RawApi = RawApi> {
         chat_id: number | string,
         photo: InputFile,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.setChatPhoto({ chat_id, photo }, signal);
     }
 
@@ -1684,7 +1750,10 @@ export class Api<R extends RawApi = RawApi> {
      *
      * **Official reference:** https://core.telegram.org/bots/api#deletechatphoto
      */
-    deleteChatPhoto(chat_id: number | string, signal?: AbortSignal) {
+    deleteChatPhoto(
+        chat_id: number | string,
+        signal?: AbortSignal,
+    ): Promise<true> {
         return this.raw.deleteChatPhoto({ chat_id }, signal);
     }
 
@@ -1701,7 +1770,7 @@ export class Api<R extends RawApi = RawApi> {
         chat_id: number | string,
         title: string,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.setChatTitle({ chat_id, title }, signal);
     }
 
@@ -1718,7 +1787,7 @@ export class Api<R extends RawApi = RawApi> {
         chat_id: number | string,
         description?: string,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.setChatDescription({ chat_id, description }, signal);
     }
 
@@ -1737,7 +1806,7 @@ export class Api<R extends RawApi = RawApi> {
         message_id: number,
         other?: Other<R, "pinChatMessage", "chat_id" | "message_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.pinChatMessage(
             { chat_id, message_id, ...other },
             signal,
@@ -1759,7 +1828,7 @@ export class Api<R extends RawApi = RawApi> {
         message_id?: number,
         other?: Other<R, "unpinChatMessage", "chat_id" | "message_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.unpinChatMessage(
             { chat_id, message_id, ...other },
             signal,
@@ -1774,7 +1843,10 @@ export class Api<R extends RawApi = RawApi> {
      *
      * **Official reference:** https://core.telegram.org/bots/api#unpinallchatmessages
      */
-    unpinAllChatMessages(chat_id: number | string, signal?: AbortSignal) {
+    unpinAllChatMessages(
+        chat_id: number | string,
+        signal?: AbortSignal,
+    ): Promise<true> {
         return this.raw.unpinAllChatMessages({ chat_id }, signal);
     }
 
@@ -1786,7 +1858,7 @@ export class Api<R extends RawApi = RawApi> {
      *
      * **Official reference:** https://core.telegram.org/bots/api#leavechat
      */
-    leaveChat(chat_id: number | string, signal?: AbortSignal) {
+    leaveChat(chat_id: number | string, signal?: AbortSignal): Promise<true> {
         return this.raw.leaveChat({ chat_id }, signal);
     }
 
@@ -1798,7 +1870,10 @@ export class Api<R extends RawApi = RawApi> {
      *
      * **Official reference:** https://core.telegram.org/bots/api#getchat
      */
-    getChat(chat_id: number | string, signal?: AbortSignal) {
+    getChat(
+        chat_id: number | string,
+        signal?: AbortSignal,
+    ): Promise<ChatFullInfo> {
         return this.raw.getChat({ chat_id }, signal);
     }
 
@@ -1815,12 +1890,14 @@ export class Api<R extends RawApi = RawApi> {
         chat_id: number | string,
         other?: Other<R, "getChatAdministrators", "chat_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<(ChatMemberOwner | ChatMemberAdministrator)[]> {
         return this.raw.getChatAdministrators({ chat_id, ...other }, signal);
     }
 
     /** @deprecated Use `getChatMemberCount` instead. */
-    getChatMembersCount(...args: Parameters<Api["getChatMemberCount"]>) {
+    getChatMembersCount(
+        ...args: Parameters<Api["getChatMemberCount"]>
+    ): Promise<number> {
         return this.getChatMemberCount(...args);
     }
 
@@ -1832,7 +1909,10 @@ export class Api<R extends RawApi = RawApi> {
      *
      * **Official reference:** https://core.telegram.org/bots/api#getchatmembercount
      */
-    getChatMemberCount(chat_id: number | string, signal?: AbortSignal) {
+    getChatMemberCount(
+        chat_id: number | string,
+        signal?: AbortSignal,
+    ): Promise<number> {
         return this.raw.getChatMemberCount({ chat_id }, signal);
     }
 
@@ -1849,7 +1929,7 @@ export class Api<R extends RawApi = RawApi> {
         chat_id: number | string,
         user_id: number,
         signal?: AbortSignal,
-    ) {
+    ): Promise<ChatMember> {
         return this.raw.getChatMember({ chat_id, user_id }, signal);
     }
 
@@ -1866,7 +1946,7 @@ export class Api<R extends RawApi = RawApi> {
         user_id: number,
         limit: number,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message[]> {
         return this.raw.getUserPersonalChatMessages({ user_id, limit }, signal);
     }
 
@@ -1883,7 +1963,7 @@ export class Api<R extends RawApi = RawApi> {
         chat_id: number | string,
         sticker_set_name: string,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.setChatStickerSet(
             { chat_id, sticker_set_name },
             signal,
@@ -1898,7 +1978,10 @@ export class Api<R extends RawApi = RawApi> {
      *
      * **Official reference:** https://core.telegram.org/bots/api#deletechatstickerset
      */
-    deleteChatStickerSet(chat_id: number | string, signal?: AbortSignal) {
+    deleteChatStickerSet(
+        chat_id: number | string,
+        signal?: AbortSignal,
+    ): Promise<true> {
         return this.raw.deleteChatStickerSet({ chat_id }, signal);
     }
 
@@ -1909,7 +1992,7 @@ export class Api<R extends RawApi = RawApi> {
      *
      * **Official reference:** https://core.telegram.org/bots/api#getforumtopiciconstickers
      */
-    getForumTopicIconStickers(signal?: AbortSignal) {
+    getForumTopicIconStickers(signal?: AbortSignal): Promise<Sticker[]> {
         return this.raw.getForumTopicIconStickers(signal);
     }
 
@@ -1928,7 +2011,7 @@ export class Api<R extends RawApi = RawApi> {
         name: string,
         other?: Other<R, "createForumTopic", "chat_id" | "name">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<ForumTopic> {
         return this.raw.createForumTopic({ chat_id, name, ...other }, signal);
     }
 
@@ -1947,7 +2030,7 @@ export class Api<R extends RawApi = RawApi> {
         message_thread_id: number,
         other?: Other<R, "editForumTopic", "chat_id" | "message_thread_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.editForumTopic(
             { chat_id, message_thread_id, ...other },
             signal,
@@ -1967,7 +2050,7 @@ export class Api<R extends RawApi = RawApi> {
         chat_id: number | string,
         message_thread_id: number,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.closeForumTopic({ chat_id, message_thread_id }, signal);
     }
 
@@ -1984,7 +2067,7 @@ export class Api<R extends RawApi = RawApi> {
         chat_id: number | string,
         message_thread_id: number,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.reopenForumTopic(
             { chat_id, message_thread_id },
             signal,
@@ -2004,7 +2087,7 @@ export class Api<R extends RawApi = RawApi> {
         chat_id: number | string,
         message_thread_id: number,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.deleteForumTopic(
             { chat_id, message_thread_id },
             signal,
@@ -2024,7 +2107,7 @@ export class Api<R extends RawApi = RawApi> {
         chat_id: number | string,
         message_thread_id: number,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.unpinAllForumTopicMessages(
             { chat_id, message_thread_id },
             signal,
@@ -2044,7 +2127,7 @@ export class Api<R extends RawApi = RawApi> {
         chat_id: number | string,
         name: string,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.editGeneralForumTopic({ chat_id, name }, signal);
     }
 
@@ -2056,7 +2139,10 @@ export class Api<R extends RawApi = RawApi> {
      *
      * **Official reference:** https://core.telegram.org/bots/api#closegeneralforumtopic
      */
-    closeGeneralForumTopic(chat_id: number | string, signal?: AbortSignal) {
+    closeGeneralForumTopic(
+        chat_id: number | string,
+        signal?: AbortSignal,
+    ): Promise<true> {
         return this.raw.closeGeneralForumTopic({ chat_id }, signal);
     }
 
@@ -2068,7 +2154,10 @@ export class Api<R extends RawApi = RawApi> {
      *
      * **Official reference:** https://core.telegram.org/bots/api#reopengeneralforumtopic
      */
-    reopenGeneralForumTopic(chat_id: number | string, signal?: AbortSignal) {
+    reopenGeneralForumTopic(
+        chat_id: number | string,
+        signal?: AbortSignal,
+    ): Promise<true> {
         return this.raw.reopenGeneralForumTopic({ chat_id }, signal);
     }
 
@@ -2080,7 +2169,10 @@ export class Api<R extends RawApi = RawApi> {
      *
      * **Official reference:** https://core.telegram.org/bots/api#hidegeneralforumtopic
      */
-    hideGeneralForumTopic(chat_id: number | string, signal?: AbortSignal) {
+    hideGeneralForumTopic(
+        chat_id: number | string,
+        signal?: AbortSignal,
+    ): Promise<true> {
         return this.raw.hideGeneralForumTopic({ chat_id }, signal);
     }
 
@@ -2092,7 +2184,10 @@ export class Api<R extends RawApi = RawApi> {
      *
      * **Official reference:** https://core.telegram.org/bots/api#unhidegeneralforumtopic
      */
-    unhideGeneralForumTopic(chat_id: number | string, signal?: AbortSignal) {
+    unhideGeneralForumTopic(
+        chat_id: number | string,
+        signal?: AbortSignal,
+    ): Promise<true> {
         return this.raw.unhideGeneralForumTopic({ chat_id }, signal);
     }
 
@@ -2107,7 +2202,7 @@ export class Api<R extends RawApi = RawApi> {
     unpinAllGeneralForumTopicMessages(
         chat_id: number | string,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.unpinAllGeneralForumTopicMessages({ chat_id }, signal);
     }
 
@@ -2126,7 +2221,7 @@ export class Api<R extends RawApi = RawApi> {
         callback_query_id: string,
         other?: Other<R, "answerCallbackQuery", "callback_query_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.answerCallbackQuery(
             { callback_query_id, ...other },
             signal,
@@ -2146,7 +2241,7 @@ export class Api<R extends RawApi = RawApi> {
         guest_query_id: string,
         result: InlineQueryResult,
         signal?: AbortSignal,
-    ) {
+    ): Promise<SentGuestMessage> {
         return this.raw.answerGuestQuery({ guest_query_id, result }, signal);
     }
 
@@ -2163,7 +2258,7 @@ export class Api<R extends RawApi = RawApi> {
         name: string,
         other?: Other<R, "setMyName", "name">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.setMyName({ name, ...other }, signal);
     }
 
@@ -2175,7 +2270,10 @@ export class Api<R extends RawApi = RawApi> {
      *
      * **Official reference:** https://core.telegram.org/bots/api#getmyname
      */
-    getMyName(other?: Other<R, "getMyName">, signal?: AbortSignal) {
+    getMyName(
+        other?: Other<R, "getMyName">,
+        signal?: AbortSignal,
+    ): Promise<BotName> {
         return this.raw.getMyName(other ?? {}, signal);
     }
 
@@ -2192,7 +2290,7 @@ export class Api<R extends RawApi = RawApi> {
         commands: readonly BotCommand[],
         other?: Other<R, "setMyCommands", "commands">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.setMyCommands({ commands, ...other }, signal);
     }
 
@@ -2207,7 +2305,7 @@ export class Api<R extends RawApi = RawApi> {
     deleteMyCommands(
         other?: Other<R, "deleteMyCommands">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.deleteMyCommands({ ...other }, signal);
     }
 
@@ -2219,7 +2317,10 @@ export class Api<R extends RawApi = RawApi> {
      *
      * **Official reference:** https://core.telegram.org/bots/api#getmycommands
      */
-    getMyCommands(other?: Other<R, "getMyCommands">, signal?: AbortSignal) {
+    getMyCommands(
+        other?: Other<R, "getMyCommands">,
+        signal?: AbortSignal,
+    ): Promise<BotCommand[]> {
         return this.raw.getMyCommands({ ...other }, signal);
     }
 
@@ -2236,7 +2337,7 @@ export class Api<R extends RawApi = RawApi> {
         description: string,
         other?: Other<R, "setMyDescription", "description">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.setMyDescription({ description, ...other }, signal);
     }
 
@@ -2251,7 +2352,7 @@ export class Api<R extends RawApi = RawApi> {
     getMyDescription(
         other?: Other<R, "getMyDescription">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<BotDescription> {
         return this.raw.getMyDescription({ ...other }, signal);
     }
 
@@ -2268,7 +2369,7 @@ export class Api<R extends RawApi = RawApi> {
         short_description: string,
         other?: Other<R, "setMyShortDescription", "short_description">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.setMyShortDescription(
             { short_description, ...other },
             signal,
@@ -2286,7 +2387,7 @@ export class Api<R extends RawApi = RawApi> {
     getMyShortDescription(
         other?: Other<R, "getMyShortDescription">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<BotShortDescription> {
         return this.raw.getMyShortDescription({ ...other }, signal);
     }
 
@@ -2301,7 +2402,7 @@ export class Api<R extends RawApi = RawApi> {
     setMyProfilePhoto(
         photo: InputProfilePhoto,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.setMyProfilePhoto({ photo }, signal);
     }
 
@@ -2312,7 +2413,7 @@ export class Api<R extends RawApi = RawApi> {
      *
      * **Official reference:** https://core.telegram.org/bots/api#removemyprofilephoto
      */
-    removeMyProfilePhoto(signal?: AbortSignal) {
+    removeMyProfilePhoto(signal?: AbortSignal): Promise<true> {
         return this.raw.removeMyProfilePhoto(signal);
     }
 
@@ -2327,7 +2428,7 @@ export class Api<R extends RawApi = RawApi> {
     setChatMenuButton(
         other?: Other<R, "setChatMenuButton">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.setChatMenuButton({ ...other }, signal);
     }
 
@@ -2342,7 +2443,7 @@ export class Api<R extends RawApi = RawApi> {
     getChatMenuButton(
         other?: Other<R, "getChatMenuButton">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<MenuButton> {
         return this.raw.getChatMenuButton({ ...other }, signal);
     }
 
@@ -2357,7 +2458,7 @@ export class Api<R extends RawApi = RawApi> {
     setMyDefaultAdministratorRights(
         other?: Other<R, "setMyDefaultAdministratorRights">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.setMyDefaultAdministratorRights({ ...other }, signal);
     }
 
@@ -2372,7 +2473,7 @@ export class Api<R extends RawApi = RawApi> {
     getMyDefaultAdministratorRights(
         other?: Other<R, "getMyDefaultAdministratorRights">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<ChatAdministratorRights> {
         return this.raw.getMyDefaultAdministratorRights({ ...other }, signal);
     }
 
@@ -2383,7 +2484,7 @@ export class Api<R extends RawApi = RawApi> {
      *
      * **Official reference:** https://core.telegram.org/bots/api#getmystarbalance
      */
-    getMyStarBalance(signal?: AbortSignal) {
+    getMyStarBalance(signal?: AbortSignal): Promise<StarAmount> {
         return this.raw.getMyStarBalance(signal);
     }
 
@@ -2412,7 +2513,14 @@ export class Api<R extends RawApi = RawApi> {
             | "rich_message"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<
+        | true
+        | (
+            & Update.Edited
+            & Message.TextMessage
+        )
+        | (Update.Edited & Message.RichMessageMessage)
+    > {
         return this.raw.editMessageText(
             typeof text_or_rich_message === "string"
                 ? { chat_id, message_id, text: text_or_rich_message, ...other }
@@ -2449,7 +2557,14 @@ export class Api<R extends RawApi = RawApi> {
             | "rich_message"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<
+        | true
+        | (
+            & Update.Edited
+            & Message.TextMessage
+        )
+        | (Update.Edited & Message.RichMessageMessage)
+    > {
         return this.raw.editMessageText(
             typeof text_or_rich_message === "string"
                 ? { inline_message_id, text: text_or_rich_message, ...other }
@@ -2481,7 +2596,7 @@ export class Api<R extends RawApi = RawApi> {
             "chat_id" | "message_id" | "inline_message_id"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true | (Update.Edited & Message.CaptionableMessage)> {
         return this.raw.editMessageCaption(
             { chat_id, message_id, ...other },
             signal,
@@ -2505,7 +2620,7 @@ export class Api<R extends RawApi = RawApi> {
             "chat_id" | "message_id" | "inline_message_id"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true | (Update.Edited & Message.CaptionableMessage)> {
         return this.raw.editMessageCaption(
             { inline_message_id, ...other },
             signal,
@@ -2533,7 +2648,7 @@ export class Api<R extends RawApi = RawApi> {
             "chat_id" | "message_id" | "inline_message_id" | "media"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true | (Update.Edited & Message)> {
         return this.raw.editMessageMedia(
             { chat_id, message_id, media, ...other },
             signal,
@@ -2559,7 +2674,7 @@ export class Api<R extends RawApi = RawApi> {
             "chat_id" | "message_id" | "inline_message_id" | "media"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true | (Update.Edited & Message)> {
         return this.raw.editMessageMedia(
             { inline_message_id, media, ...other },
             signal,
@@ -2585,7 +2700,7 @@ export class Api<R extends RawApi = RawApi> {
             "chat_id" | "message_id" | "inline_message_id"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true | (Update.Edited & Message)> {
         return this.raw.editMessageReplyMarkup(
             { chat_id, message_id, ...other },
             signal,
@@ -2609,7 +2724,7 @@ export class Api<R extends RawApi = RawApi> {
             "chat_id" | "message_id" | "inline_message_id"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true | (Update.Edited & Message)> {
         return this.raw.editMessageReplyMarkup(
             { inline_message_id, ...other },
             signal,
@@ -2631,7 +2746,7 @@ export class Api<R extends RawApi = RawApi> {
         message_id: number,
         other?: Other<R, "stopPoll", "chat_id" | "message_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Poll> {
         return this.raw.stopPoll({ chat_id, message_id, ...other }, signal);
     }
 
@@ -2658,7 +2773,7 @@ export class Api<R extends RawApi = RawApi> {
             "chat_id" | "receiver_user_id" | "ephemeral_message_id" | "text"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.editEphemeralMessageText(
             { chat_id, receiver_user_id, ephemeral_message_id, text, ...other },
             signal,
@@ -2688,7 +2803,7 @@ export class Api<R extends RawApi = RawApi> {
             "chat_id" | "receiver_user_id" | "ephemeral_message_id" | "media"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.editEphemeralMessageMedia({
             chat_id,
             receiver_user_id,
@@ -2721,7 +2836,7 @@ export class Api<R extends RawApi = RawApi> {
             "chat_id" | "receiver_user_id" | "ephemeral_message_id" | "caption"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.editEphemeralMessageCaption({
             chat_id,
             receiver_user_id,
@@ -2752,7 +2867,7 @@ export class Api<R extends RawApi = RawApi> {
             "chat_id" | "receiver_user_id" | "ephemeral_message_id"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.editEphemeralMessageReplyMarkup(
             { chat_id, receiver_user_id, ephemeral_message_id, ...other },
             signal,
@@ -2781,7 +2896,7 @@ export class Api<R extends RawApi = RawApi> {
         chat_id: number | string,
         message_id: number,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.deleteMessage({ chat_id, message_id }, signal);
     }
 
@@ -2798,7 +2913,7 @@ export class Api<R extends RawApi = RawApi> {
         chat_id: number | string,
         message_ids: number[],
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.deleteMessages({ chat_id, message_ids }, signal);
     }
 
@@ -2817,7 +2932,7 @@ export class Api<R extends RawApi = RawApi> {
         receiver_user_id: number,
         ephemeral_message_id: number,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.deleteEphemeralMessage(
             { chat_id, receiver_user_id, ephemeral_message_id },
             signal,
@@ -2845,7 +2960,7 @@ export class Api<R extends RawApi = RawApi> {
             "chat_id" | "message_id" | "user_id"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.deleteMessageReaction({
             chat_id,
             message_id,
@@ -2875,7 +2990,7 @@ export class Api<R extends RawApi = RawApi> {
             "chat_id" | "message_id" | "actor_chat_id"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.deleteMessageReaction({
             chat_id,
             message_id,
@@ -2903,7 +3018,7 @@ export class Api<R extends RawApi = RawApi> {
             "chat_id" | "message_id" | "user_id"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.deleteAllMessageReactions({
             chat_id,
             user_id,
@@ -2930,7 +3045,7 @@ export class Api<R extends RawApi = RawApi> {
             "chat_id" | "message_id" | "actor_chat_id"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.deleteAllMessageReactions({
             chat_id,
             actor_chat_id,
@@ -2951,7 +3066,7 @@ export class Api<R extends RawApi = RawApi> {
         business_connection_id: string,
         message_ids: number[],
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.deleteBusinessMessages(
             { business_connection_id, message_ids },
             signal,
@@ -2977,7 +3092,7 @@ export class Api<R extends RawApi = RawApi> {
             "business_connection_id" | "first_name"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.setBusinessAccountName(
             { business_connection_id, first_name, ...other },
             signal,
@@ -2997,7 +3112,7 @@ export class Api<R extends RawApi = RawApi> {
         business_connection_id: string,
         username: string,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.setBusinessAccountUsername(
             { business_connection_id, username },
             signal,
@@ -3017,7 +3132,7 @@ export class Api<R extends RawApi = RawApi> {
         business_connection_id: string,
         bio: string,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.setBusinessAccountBio(
             { business_connection_id, bio },
             signal,
@@ -3043,7 +3158,7 @@ export class Api<R extends RawApi = RawApi> {
             "business_connection_id" | "photo"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.setBusinessAccountProfilePhoto(
             { business_connection_id, photo, ...other },
             signal,
@@ -3067,7 +3182,7 @@ export class Api<R extends RawApi = RawApi> {
             "business_connection_id"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.removeBusinessAccountProfilePhoto(
             { business_connection_id, ...other },
             signal,
@@ -3089,7 +3204,7 @@ export class Api<R extends RawApi = RawApi> {
         show_gift_button: boolean,
         accepted_gift_types: AcceptedGiftTypes,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.setBusinessAccountGiftSettings(
             { business_connection_id, show_gift_button, accepted_gift_types },
             signal,
@@ -3107,7 +3222,7 @@ export class Api<R extends RawApi = RawApi> {
     getBusinessAccountStarBalance(
         business_connection_id: string,
         signal?: AbortSignal,
-    ) {
+    ): Promise<StarAmount> {
         return this.raw.getBusinessAccountStarBalance(
             { business_connection_id },
             signal,
@@ -3127,7 +3242,7 @@ export class Api<R extends RawApi = RawApi> {
         business_connection_id: string,
         star_count: number,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.transferBusinessAccountStars(
             { business_connection_id, star_count },
             signal,
@@ -3147,7 +3262,7 @@ export class Api<R extends RawApi = RawApi> {
         business_connection_id: string,
         other: Other<R, "getBusinessAccountGifts", "business_connection_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<OwnedGifts> {
         return this.raw.getBusinessAccountGifts(
             { business_connection_id, ...other },
             signal,
@@ -3167,7 +3282,7 @@ export class Api<R extends RawApi = RawApi> {
         business_connection_id: string,
         owned_gift_id: string,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.convertGiftToStars(
             { business_connection_id, owned_gift_id },
             signal,
@@ -3193,7 +3308,7 @@ export class Api<R extends RawApi = RawApi> {
             "business_connection_id" | "owned_gift_id"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.upgradeGift(
             { business_connection_id, owned_gift_id, ...other },
             signal,
@@ -3217,7 +3332,7 @@ export class Api<R extends RawApi = RawApi> {
         new_owner_chat_id: number,
         star_count: number,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.transferGift({
             business_connection_id,
             owned_gift_id,
@@ -3247,7 +3362,7 @@ export class Api<R extends RawApi = RawApi> {
             "business_connection_id" | "content" | "active_period"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Story> {
         return this.raw.postStory(
             { business_connection_id, content, active_period, ...other },
             signal,
@@ -3280,7 +3395,7 @@ export class Api<R extends RawApi = RawApi> {
             | "active_period"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Story> {
         return this.raw.repostStory({
             business_connection_id,
             from_chat_id,
@@ -3311,7 +3426,7 @@ export class Api<R extends RawApi = RawApi> {
             "business_connection_id" | "story_id" | "content"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Story> {
         return this.raw.editStory(
             { business_connection_id, story_id, content, ...other },
             signal,
@@ -3331,7 +3446,7 @@ export class Api<R extends RawApi = RawApi> {
         business_connection_id: string,
         story_id: number,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.deleteStory(
             { business_connection_id, story_id },
             signal,
@@ -3353,7 +3468,7 @@ export class Api<R extends RawApi = RawApi> {
         sticker: InputFile | string,
         other?: Other<R, "sendSticker", "chat_id" | "sticker">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.StickerMessage> {
         return this.raw.sendSticker({ chat_id, sticker, ...other }, signal);
     }
 
@@ -3365,7 +3480,7 @@ export class Api<R extends RawApi = RawApi> {
      *
      * **Official reference:** https://core.telegram.org/bots/api#getstickerset
      */
-    getStickerSet(name: string, signal?: AbortSignal) {
+    getStickerSet(name: string, signal?: AbortSignal): Promise<StickerSet> {
         return this.raw.getStickerSet({ name }, signal);
     }
 
@@ -3377,7 +3492,10 @@ export class Api<R extends RawApi = RawApi> {
      *
      * **Official reference:** https://core.telegram.org/bots/api#getcustomemojistickers
      */
-    getCustomEmojiStickers(custom_emoji_ids: string[], signal?: AbortSignal) {
+    getCustomEmojiStickers(
+        custom_emoji_ids: string[],
+        signal?: AbortSignal,
+    ): Promise<Sticker[]> {
         return this.raw.getCustomEmojiStickers({ custom_emoji_ids }, signal);
     }
 
@@ -3396,7 +3514,7 @@ export class Api<R extends RawApi = RawApi> {
         sticker_format: "static" | "animated" | "video",
         sticker: InputFile,
         signal?: AbortSignal,
-    ) {
+    ): Promise<File> {
         return this.raw.uploadStickerFile(
             { user_id, sticker_format, sticker },
             signal,
@@ -3430,7 +3548,7 @@ export class Api<R extends RawApi = RawApi> {
             | "stickers"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.createNewStickerSet(
             { user_id, name, title, stickers, ...other },
             signal,
@@ -3452,7 +3570,7 @@ export class Api<R extends RawApi = RawApi> {
         name: string,
         sticker: InputSticker,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.addStickerToSet(
             { user_id, name, sticker },
             signal,
@@ -3472,7 +3590,7 @@ export class Api<R extends RawApi = RawApi> {
         sticker: string,
         position: number,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.setStickerPositionInSet({ sticker, position }, signal);
     }
 
@@ -3484,7 +3602,7 @@ export class Api<R extends RawApi = RawApi> {
      *
      * **Official reference:** https://core.telegram.org/bots/api#deletestickerfromset
      */
-    deleteStickerFromSet(sticker: string, signal?: AbortSignal) {
+    deleteStickerFromSet(sticker: string, signal?: AbortSignal): Promise<true> {
         return this.raw.deleteStickerFromSet({ sticker }, signal);
     }
 
@@ -3505,7 +3623,7 @@ export class Api<R extends RawApi = RawApi> {
         old_sticker: string,
         sticker: InputSticker,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.replaceStickerInSet(
             { user_id, name, old_sticker, sticker },
             signal,
@@ -3525,7 +3643,7 @@ export class Api<R extends RawApi = RawApi> {
         sticker: string,
         emoji_list: string[],
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.setStickerEmojiList({ sticker, emoji_list }, signal);
     }
 
@@ -3542,7 +3660,7 @@ export class Api<R extends RawApi = RawApi> {
         sticker: string,
         keywords: string[],
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.setStickerKeywords({ sticker, keywords }, signal);
     }
 
@@ -3559,7 +3677,7 @@ export class Api<R extends RawApi = RawApi> {
         sticker: string,
         mask_position?: MaskPosition,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.setStickerMaskPosition(
             { sticker, mask_position },
             signal,
@@ -3575,7 +3693,11 @@ export class Api<R extends RawApi = RawApi> {
      *
      * **Official reference:** https://core.telegram.org/bots/api#setstickersettitle
      */
-    setStickerSetTitle(name: string, title: string, signal?: AbortSignal) {
+    setStickerSetTitle(
+        name: string,
+        title: string,
+        signal?: AbortSignal,
+    ): Promise<true> {
         return this.raw.setStickerSetTitle({ name, title }, signal);
     }
 
@@ -3587,7 +3709,7 @@ export class Api<R extends RawApi = RawApi> {
      *
      * **Official reference:** https://core.telegram.org/bots/api#deletestickerset
      */
-    deleteStickerSet(name: string, signal?: AbortSignal) {
+    deleteStickerSet(name: string, signal?: AbortSignal): Promise<true> {
         return this.raw.deleteStickerSet({ name }, signal);
     }
 
@@ -3608,7 +3730,7 @@ export class Api<R extends RawApi = RawApi> {
         thumbnail: InputFile | string | undefined,
         format: "static" | "animated" | "video",
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.setStickerSetThumbnail(
             { name, user_id, thumbnail, format },
             signal,
@@ -3628,7 +3750,7 @@ export class Api<R extends RawApi = RawApi> {
         name: string,
         custom_emoji_id: string,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.setCustomEmojiStickerSetThumbnail({
             name,
             custom_emoji_id,
@@ -3642,7 +3764,7 @@ export class Api<R extends RawApi = RawApi> {
      *
      * **Official reference:** https://core.telegram.org/bots/api#getavailablegifts
      */
-    getAvailableGifts(signal?: AbortSignal) {
+    getAvailableGifts(signal?: AbortSignal): Promise<Gifts> {
         return this.raw.getAvailableGifts(signal);
     }
 
@@ -3661,7 +3783,7 @@ export class Api<R extends RawApi = RawApi> {
         gift_id: string,
         other?: Other<R, "sendGift", "user_id" | "chat_id" | "gift_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.sendGift({ user_id, gift_id, ...other }, signal);
     }
 
@@ -3686,7 +3808,7 @@ export class Api<R extends RawApi = RawApi> {
             "user_id" | "month_count" | "star_count"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.giftPremiumSubscription(
             { user_id, month_count, star_count, ...other },
             signal,
@@ -3708,7 +3830,7 @@ export class Api<R extends RawApi = RawApi> {
         gift_id: string,
         other?: Other<R, "sendGift", "user_id" | "chat_id" | "gift_id">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.sendGift({ chat_id, gift_id, ...other }, signal);
     }
 
@@ -3730,7 +3852,7 @@ export class Api<R extends RawApi = RawApi> {
         results: readonly InlineQueryResult[],
         other?: Other<R, "answerInlineQuery", "inline_query_id" | "results">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.answerInlineQuery(
             { inline_query_id, results, ...other },
             signal,
@@ -3750,7 +3872,7 @@ export class Api<R extends RawApi = RawApi> {
         web_app_query_id: string,
         result: InlineQueryResult,
         signal?: AbortSignal,
-    ) {
+    ): Promise<SentWebAppMessage> {
         return this.raw.answerWebAppQuery({ web_app_query_id, result }, signal);
     }
 
@@ -3769,7 +3891,7 @@ export class Api<R extends RawApi = RawApi> {
         result: InlineQueryResult,
         other?: Other<R, "savePreparedInlineMessage", "user_id" | "result">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<PreparedInlineMessage> {
         return this.raw.savePreparedInlineMessage(
             { user_id, result, ...other },
             signal,
@@ -3792,7 +3914,7 @@ export class Api<R extends RawApi = RawApi> {
             | KeyboardButton.RequestChatButton
             | KeyboardButton.RequestManagedBotButton,
         signal?: AbortSignal,
-    ) {
+    ): Promise<PreparedKeyboardButton> {
         return this.raw.savePreparedKeyboardButton({ user_id, button }, signal);
     }
 
@@ -3828,7 +3950,7 @@ export class Api<R extends RawApi = RawApi> {
             | "prices"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.InvoiceMessage> {
         return this.raw.sendInvoice({
             chat_id,
             title,
@@ -3872,7 +3994,7 @@ export class Api<R extends RawApi = RawApi> {
             | "prices"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<string> {
         return this.raw.createInvoiceLink({
             title,
             description,
@@ -3899,7 +4021,7 @@ export class Api<R extends RawApi = RawApi> {
         ok: boolean,
         other?: Other<R, "answerShippingQuery", "shipping_query_id" | "ok">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.answerShippingQuery(
             { shipping_query_id, ok, ...other },
             signal,
@@ -3925,7 +4047,7 @@ export class Api<R extends RawApi = RawApi> {
             "pre_checkout_query_id" | "ok"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.answerPreCheckoutQuery(
             { pre_checkout_query_id, ok, ...other },
             signal,
@@ -3943,7 +4065,7 @@ export class Api<R extends RawApi = RawApi> {
     getStarTransactions(
         other?: Other<R, "getStarTransactions">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<StarTransactions> {
         return this.raw.getStarTransactions({ ...other }, signal);
     }
 
@@ -3960,7 +4082,7 @@ export class Api<R extends RawApi = RawApi> {
         user_id: number,
         telegram_payment_charge_id: string,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.refundStarPayment(
             { user_id, telegram_payment_charge_id },
             signal,
@@ -3982,7 +4104,7 @@ export class Api<R extends RawApi = RawApi> {
         telegram_payment_charge_id: string,
         is_canceled: boolean,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.editUserStarSubscription(
             { user_id, telegram_payment_charge_id, is_canceled },
             signal,
@@ -4002,7 +4124,7 @@ export class Api<R extends RawApi = RawApi> {
         user_id: number,
         other?: Other<R, "verifyUser">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.verifyUser({ user_id, ...other }, signal);
     }
 
@@ -4019,7 +4141,7 @@ export class Api<R extends RawApi = RawApi> {
         chat_id: number | string,
         other?: Other<R, "verifyChat">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.verifyChat({ chat_id, ...other }, signal);
     }
 
@@ -4031,7 +4153,10 @@ export class Api<R extends RawApi = RawApi> {
      *
      * **Official reference:** https://core.telegram.org/bots/api#removeuserverification
      */
-    removeUserVerification(user_id: number, signal?: AbortSignal) {
+    removeUserVerification(
+        user_id: number,
+        signal?: AbortSignal,
+    ): Promise<true> {
         return this.raw.removeUserVerification({ user_id }, signal);
     }
 
@@ -4046,7 +4171,7 @@ export class Api<R extends RawApi = RawApi> {
     removeChatVerification(
         chat_id: number | string,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.removeChatVerification({ chat_id }, signal);
     }
 
@@ -4065,7 +4190,7 @@ export class Api<R extends RawApi = RawApi> {
         chat_id: number,
         message_id: number,
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.readBusinessMessage(
             { business_connection_id, chat_id, message_id },
             signal,
@@ -4087,7 +4212,7 @@ export class Api<R extends RawApi = RawApi> {
         user_id: number,
         errors: readonly PassportElementError[],
         signal?: AbortSignal,
-    ) {
+    ): Promise<true> {
         return this.raw.setPassportDataErrors({ user_id, errors }, signal);
     }
 
@@ -4106,7 +4231,7 @@ export class Api<R extends RawApi = RawApi> {
         game_short_name: string,
         other?: Other<R, "sendGame", "chat_id" | "game_short_name">,
         signal?: AbortSignal,
-    ) {
+    ): Promise<Message.GameMessage> {
         return this.raw.sendGame(
             { chat_id, game_short_name, ...other },
             signal,
@@ -4136,7 +4261,9 @@ export class Api<R extends RawApi = RawApi> {
             "chat_id" | "message_id" | "inline_message_id" | "user_id" | "score"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<
+        true | (Update.Edited & Message.GameMessage)
+    > {
         return this.raw.setGameScore(
             { chat_id, message_id, user_id, score, ...other },
             signal,
@@ -4164,7 +4291,9 @@ export class Api<R extends RawApi = RawApi> {
             "chat_id" | "message_id" | "inline_message_id" | "user_id" | "score"
         >,
         signal?: AbortSignal,
-    ) {
+    ): Promise<
+        true | (Update.Edited & Message.GameMessage)
+    > {
         return this.raw.setGameScore(
             { inline_message_id, user_id, score, ...other },
             signal,
@@ -4188,7 +4317,7 @@ export class Api<R extends RawApi = RawApi> {
         message_id: number,
         user_id: number,
         signal?: AbortSignal,
-    ) {
+    ): Promise<GameHighScore[]> {
         return this.raw.getGameHighScores(
             { chat_id, message_id, user_id },
             signal,
@@ -4210,7 +4339,7 @@ export class Api<R extends RawApi = RawApi> {
         inline_message_id: string,
         user_id: number,
         signal?: AbortSignal,
-    ) {
+    ): Promise<GameHighScore[]> {
         return this.raw.getGameHighScores(
             { inline_message_id, user_id },
             signal,


### PR DESCRIPTION
> [!IMPORTANT]
> **This PR is entirely AI-generated.** Every code change here — the annotations, the codemod that produced them, and this description — was written by an AI agent (Claude Code). It has **not** been hand-reviewed line by line yet. Treat all ~450 generated type annotations as needing human review before merge.

## What this does

Adds explicit return types across the public API so JSR's **slow-type** checker passes (`deno publish --dry-run` went from **447** `missing-explicit-return-type` / `missing-explicit-type` errors to **0**).

Touched: `bot.ts`, `composer.ts`, `context.ts`, `core/api.ts`, `convenience/{keyboard,session,inline_query,input_media}.ts`. Plus a `deno.jsonc` commit adding the `name` / `version` / `exports` fields `deno publish` requires.

## How the annotations were produced

These were **not** hand-written. A [ts-morph](https://ts-morph.com) codemod did the bulk:

1. Ran `deno publish --dry-run --allow-dirty`, parsed the exact `file:line` of every slow-type error.
2. Loaded the source graph in ts-morph with the real `@grammyjs/types` resolved (via a temporary `bun install`), shimming the `jsr:` / `npm:` specifiers so inference saw the genuine types.
3. For each flagged member, wrote the **compiler-inferred** return type back as an explicit annotation (`type.getText(node, …)` with alias-preserving flags). So the annotations are, by construction, the types TypeScript already inferred — no behavior/API change intended.
4. `deno fmt` over the result.

A few things needed **manual** fixes on top of the codemod:

- **Missing imports.** Explicit annotations require the referenced types to be *imported* in each file (inference didn't). Added ~76 type imports across `context.ts` / `core/api.ts` / `inline_query.ts`, including the `Message` / `Update` namespaces and grammY's `File` (which shadows the DOM global — the `getFile` return type collided with `lib.dom`'s `File`).
- **Leaked internal helper.** The inferred text expanded some named message types into `Message.CommonMessage & MsgWith<"…">`, but `MsgWith` is an *unexported* internal of `@grammyjs/types`. Collapsed those back to the named `Message.*` aliases (`GameMessage`, `LocationMessage`, `RichMessageMessage`, `TextMessage`).
- **`InlineQueryResultBuilder`.** JSR requires an explicit type on an exported object-literal `const` (it never infers them). The fully-expanded type was ~22 KB and **crashed the deno type-checker**. Fixed structurally instead: extracted the shared input-message builder into a named `InputMessageMethods<R>` type and annotated the two helpers, so the const's explicit type stays compact (~5 KB).

## What's still missing / not done here

- **`deno publish` still fails a *later* phase** — public-API `.d.ts` generation (`Failed ensuring public API type output is valid`) — because `types.ts` surfaces `@grammyjs/types` purely via `export *` from an **npm** specifier, which deno's dts generator won't expand into named exports. `deno check` passes; only publish's dts-gen chokes. **Workaround for now: `deno publish --dry-run --no-check`.** The real fix is publishing `@grammyjs/types` to **JSR** and consuming it from there (not done — types aren't on JSR yet).
- **URL / `npm:` / `jsr:` imports not removed.** The `https://` (web variants), `npm:`, and `jsr:` specifiers still need to be cleaned up / replaced with JSR-friendly imports as part of the broader JSR migration.
- **No line-by-line human review** of the generated annotations yet.
- The `deno.jsonc` `name` / `version` / `exports` here are the minimum to run the dry-run; full publish config is out of scope.

## How to verify

```
deno publish --dry-run --allow-dirty --no-check   # Success
deno check --allow-import src/mod.ts               # passes (types are valid)
```

---

<details>
<summary><b>The codemod scripts (click to expand)</b></summary>

These are throwaway ts-morph scripts run against a local checkout (paths are absolute/hard-coded; a temporary `bun install` provided the real `@grammyjs/types` for type resolution). They are **not** part of the repo — included here only for transparency about how the annotations were generated.

**1. `codemod.ts` — the bulk: parse the dry-run error locations and write the compiler-inferred return type at each.**
```ts
import {
    Node,
    Project,
    ts,
    TypeFormatFlags,
} from "ts-morph";
import { readFileSync } from "node:fs";

const ROOT = "/Users/roziscoding/github.com/grammyjs/grammY";
const MODE = process.env.MODE ?? "preview"; // preview | write

const project = new Project({
    compilerOptions: {
        target: ts.ScriptTarget.ESNext,
        module: ts.ModuleKind.ESNext,
        moduleResolution: ts.ModuleResolutionKind.Bundler,
        allowImportingTsExtensions: true,
        noEmit: true,
        strict: true,
        skipLibCheck: true,
        esModuleInterop: true,
        forceConsistentCasingInFileNames: true,
    },
});

// Shim the deno/npm/jsr specifiers used by the .deno.ts graph so the real
// @grammyjs/types (and debug) types resolve from node_modules.
project.createSourceFile(
    `${ROOT}/src/__codemod_shims__.d.ts`,
    `
declare module "jsr:@std/path@1.1.2/basename" {
    export function basename(path: string, suffix?: string): string;
}
declare module "npm:debug@latest" {
    import debug from "debug";
    export = debug;
}
declare module "npm:@grammyjs/types@4.0.0/mod.ts" {
    export * from "@grammyjs/types";
}
declare module "npm:@grammyjs/types@latest/mod.ts" {
    export * from "@grammyjs/types";
}
`,
    { overwrite: true },
);

// Add the deno graph (exclude web variants which use https:// specifiers).
project.addSourceFilesAtPaths([
    `${ROOT}/src/**/*.ts`,
    `!${ROOT}/src/**/*.web.ts`,
]);

const FLAGS = TypeFormatFlags.UseAliasDefinedOutsideCurrentScope |
    TypeFormatFlags.NoTruncation |
    TypeFormatFlags.UseFullyQualifiedType;

const locs = readFileSync(`${import.meta.dir}/locs.txt`, "utf8")
    .trim()
    .split("\n")
    .map((l) => {
        const m = l.match(/^(.*\.ts):(\d+):(\d+)$/)!;
        return { file: m[1], line: +m[2], col: +m[3] };
    });

let ok = 0;
let bad = 0;
const samples: string[] = [];

// Group by file so we edit from the bottom up (stable positions).
const byFile = new Map<string, typeof locs>();
for (const loc of locs) {
    if (!byFile.has(loc.file)) byFile.set(loc.file, []);
    byFile.get(loc.file)!.push(loc);
}

for (const [file, fileLocs] of byFile) {
    const sf = project.getSourceFileOrThrow(file);
    // sort descending by position so inserts don't shift earlier targets
    const withPos = fileLocs.map((loc) => {
        const pos = sf.compilerNode.getPositionOfLineAndCharacter(
            loc.line - 1,
            loc.col - 1,
        );
        return { loc, pos };
    }).sort((a, b) => b.pos - a.pos);

    for (const { loc, pos } of withPos) {
        const node = sf.getDescendantAtPos(pos);
        if (!node) {
            bad++;
            samples.push(`NO NODE @ ${file}:${loc.line}:${loc.col}`);
            continue;
        }
        // Walk up to the declaration that owns this name.
        const decl = node.getFirstAncestor((a) =>
            Node.isMethodDeclaration(a) ||
            Node.isFunctionDeclaration(a) ||
            Node.isGetAccessorDeclaration(a) ||
            Node.isPropertyDeclaration(a) ||
            Node.isVariableDeclaration(a)
        ) ?? node;

        try {
            if (
                Node.isMethodDeclaration(decl) ||
                Node.isFunctionDeclaration(decl) ||
                Node.isGetAccessorDeclaration(decl)
            ) {
                if (decl.getReturnTypeNode()) continue; // already annotated
                const t = decl.getReturnType();
                const text = t.getText(decl, FLAGS);
                if (MODE === "write") decl.setReturnType(text);
                else {
                    samples.push(
                        `${basename(file)}:${loc.line} ${
                            decl.getName?.() ?? "?"
                        }(): ${text}`,
                    );
                }
                ok++;
            } else if (
                Node.isVariableDeclaration(decl) &&
                Node.isObjectLiteralExpression(decl.getInitializer())
            ) {
                // Object-literal const (e.g. InlineQueryResultBuilder): annotate
                // the inner builder methods' return types so the initializer
                // becomes a "fast" type, instead of inlining a giant object type
                // on the const symbol.
                const obj = decl.getInitializer() as import("ts-morph")
                    .ObjectLiteralExpression;
                for (const m of obj.getProperties()) {
                    if (!Node.isMethodDeclaration(m)) continue;
                    if (m.getReturnTypeNode()) continue;
                    const text = m.getReturnType().getText(m, FLAGS);
                    if (MODE === "write") m.setReturnType(text);
                    else {
                        samples.push(
                            `${basename(file)}:${loc.line} ${
                                decl.getName?.()
                            }.${m.getName()}(): ${text.slice(0, 80)}...`,
                        );
                    }
                    ok++;
                }
            } else if (
                Node.isPropertyDeclaration(decl) ||
                Node.isVariableDeclaration(decl)
            ) {
                if (decl.getTypeNode()) continue;
                const t = decl.getType();
                const text = t.getText(decl, FLAGS);
                if (MODE === "write") decl.setType(text);
                else {
                    samples.push(
                        `${basename(file)}:${loc.line} ${
                            decl.getName?.() ?? "?"
                        }: ${text}`,
                    );
                }
                ok++;
            } else {
                bad++;
                samples.push(
                    `UNHANDLED ${decl.getKindName()} @ ${basename(file)}:${loc.line}`,
                );
            }
        } catch (e) {
            bad++;
            samples.push(`ERR @ ${basename(file)}:${loc.line}: ${(e as Error).message}`);
        }
    }
}

function basename(p: string) {
    return p.replace(`${ROOT}/`, "");
}

if (MODE === "write") {
    project.getSourceFileOrThrow(`${ROOT}/src/__codemod_shims__.d.ts`).delete();
    await project.save();
}

console.log(samples.slice(0, 9999).join("\n"));
console.log(`\n--- ok=${ok} bad=${bad} total=${locs.length} ---`);
```

**2. `codemod2.ts` — add the type imports the new explicit annotations require** (fed by a `missing.tsv` of `file<TAB>TypeName` pairs extracted from the follow-up `TS2304/TS2305` errors).
```ts
import { Project } from "ts-morph";
import { readFileSync } from "node:fs";

const ROOT = "/Users/roziscoding/github.com/grammyjs/grammY";

// file (relative to ROOT) -> set of type names to ensure imported
const byFile = new Map<string, Set<string>>();
for (const line of readFileSync(`${import.meta.dir}/missing.tsv`, "utf8").trim().split("\n")) {
    const [file, name] = line.split("\t");
    if (!byFile.has(file)) byFile.set(file, new Set());
    byFile.get(file)!.add(name);
}

const project = new Project({ compilerOptions: { allowJs: false } });

for (const [relFile, names] of byFile) {
    const sf = project.addSourceFileAtPath(`${ROOT}/${relFile}`);
    // the import declaration that pulls types from the local types module
    const imp = sf.getImportDeclarations().find((d) =>
        /(^|\/)\.\.?\/types\.ts$/.test(d.getModuleSpecifierValue())
    );
    if (!imp) throw new Error(`no types import in ${relFile}`);

    // existing named imports, preserving per-specifier type-only flag
    const existing = imp.getNamedImports().map((n) => ({
        name: n.getName(),
        isTypeOnly: n.isTypeOnly(),
    }));
    const have = new Set(existing.map((e) => e.name));

    const merged = [...existing];
    for (const name of names) {
        if (!have.has(name)) {
            merged.push({ name, isTypeOnly: true });
            have.add(name);
        }
    }
    merged.sort((a, b) => a.name.localeCompare(b.name));

    imp.removeNamedImports();
    imp.addNamedImports(merged);

    console.log(`${relFile}: +${names.size - [...names].filter((n) => existing.some((e) => e.name === n)).length} names (now ${merged.length})`);
}

await project.save();
```

**3. `codemod3.ts` — set the explicit type on the two exported object-literal `const` builders.** (JSR never infers those. Run *after* the manual `InputMessageMethods<R>` refactor in `inline_query.ts`, which is what keeps the generated type compact instead of the ~22 KB blob that crashed the deno checker. The object-literal branch in `codemod.ts` above was an earlier, superseded attempt.)
```ts
import { Node, Project, ts, TypeFormatFlags } from "ts-morph";

const ROOT = "/Users/roziscoding/github.com/grammyjs/grammY";

const project = new Project({
    compilerOptions: {
        target: ts.ScriptTarget.ESNext,
        module: ts.ModuleKind.ESNext,
        moduleResolution: ts.ModuleResolutionKind.Bundler,
        allowImportingTsExtensions: true,
        noEmit: true,
        strict: true,
        skipLibCheck: true,
        esModuleInterop: true,
    },
});

project.createSourceFile(
    `${ROOT}/src/__codemod_shims__.d.ts`,
    `
declare module "jsr:@std/path@1.1.2/basename" {
    export function basename(path: string, suffix?: string): string;
}
declare module "npm:debug@latest" { import debug from "debug"; export = debug; }
declare module "npm:@grammyjs/types@4.0.0/mod.ts" { export * from "@grammyjs/types"; }
declare module "npm:@grammyjs/types@latest/mod.ts" { export * from "@grammyjs/types"; }
`,
    { overwrite: true },
);

project.addSourceFilesAtPaths([
    `${ROOT}/src/**/*.ts`,
    `!${ROOT}/src/**/*.web.ts`,
]);

const FLAGS = TypeFormatFlags.UseAliasDefinedOutsideCurrentScope |
    TypeFormatFlags.NoTruncation |
    TypeFormatFlags.UseFullyQualifiedType;

const targets = [
    { file: `${ROOT}/src/convenience/inline_query.ts`, name: "InlineQueryResultBuilder" },
    { file: `${ROOT}/src/convenience/input_media.ts`, name: "InputMediaBuilder" },
];

for (const { file, name } of targets) {
    const sf = project.getSourceFileOrThrow(file);
    const decl = sf.getVariableDeclarationOrThrow(name);
    if (!Node.isObjectLiteralExpression(decl.getInitializer())) {
        throw new Error(`${name} is not an object literal`);
    }
    const text = decl.getType().getText(decl, FLAGS);
    decl.setType(text);
    console.log(`${name}: annotated (${text.length} chars)`);
}

project.getSourceFileOrThrow(`${ROOT}/src/__codemod_shims__.d.ts`).delete();
await project.save();
```

</details>
