### PR TITLE
chore(ci): fix update-contributors workflow

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -18,7 +18,7 @@ jobs:
 
             - uses: denoland/setup-deno@v2
               with:
-                  deno-version: ac659a17c799c0e03530acd73524596f62f108fd
+                  deno-version: v2.x
 
             - name: Check for contributor changes
               id: check


### PR DESCRIPTION
- Pin released deno version instead of canary commit