### PR TITLE
test: reproduce TransformerComposer crash on unmatched methods

### DIFF
--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -1,11 +1,57 @@
+import { Api } from "../src/api.ts";
 import type { ApiCallFn } from "../src/client.ts";
 import { TransformerComposer } from "../src/transform.ts";
-import { assertEquals, describe, it } from "./deps.test.ts";
+import type { UserFromGetMe } from "../src/types.ts";
+import {
+    assertEquals,
+    assertSpyCalls,
+    describe,
+    it,
+    stub,
+} from "./deps.test.ts";
+
+const me: UserFromGetMe = {
+    id: 123456789,
+    is_bot: true,
+    first_name: "Test Bot",
+    username: "test_bot",
+    can_join_groups: true,
+    can_read_all_group_messages: false,
+    supports_guest_queries: false,
+    supports_inline_queries: false,
+    can_connect_to_business: false,
+    has_main_web_app: false,
+    has_topics_enabled: false,
+    allows_users_to_create_topics: false,
+    can_manage_bots: false,
+    supports_join_request_queries: false,
+};
 
 describe("TransformerComposer", () => {
+    it("should pass unscoped methods through an Api instance", async () => {
+        using fetchStub = stub(
+            globalThis,
+            "fetch",
+            () =>
+                Promise.resolve(
+                    new Response(JSON.stringify({ ok: true, result: me })),
+                ),
+        );
+        const api = new Api("secret-token");
+        const transformerComposer = new TransformerComposer();
+        const scoped = transformerComposer.on("sendMessage");
+        scoped.use((prev, data, signal) => prev(data, signal));
+        api.transform(transformerComposer);
+
+        const result = await api.getMe();
+
+        assertEquals(result, me);
+        assertSpyCalls(fetchStub, 1);
+    });
+
     it("should pass methods not matched by .on to the previous transformer", async () => {
-        const composer = new TransformerComposer();
-        const scoped = composer.on("sendMessage");
+        const transformerComposer = new TransformerComposer();
+        const scoped = transformerComposer.on("sendMessage");
         scoped.use((prev, data, signal) => prev(data, signal));
 
         let previousCalls = 0;
@@ -14,7 +60,7 @@ describe("TransformerComposer", () => {
             return Promise.resolve({ ok: true, result: undefined as never });
         };
 
-        await composer.transformer()(
+        await transformerComposer.transformer()(
             previous,
             { method: "getMe", payload: {} },
         );

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -1,0 +1,29 @@
+import type { ApiCallFn } from "../src/client.ts";
+import { TransformerComposer } from "../src/transform.ts";
+import {
+    assertEquals,
+    assertSpyCalls,
+    describe,
+    it,
+    spy,
+} from "./deps.test.ts";
+
+describe("TransformerComposer", () => {
+    it("should pass methods not matched by .on to the previous transformer", async () => {
+        const composer = new TransformerComposer();
+        const scoped = composer.on("sendMessage");
+        scoped.use((prev, data, signal) => prev(data, signal));
+
+        const previous = spy<ApiCallFn>(() =>
+            Promise.resolve({ ok: true, result: undefined as never })
+        );
+
+        const result = await composer.transformer()(
+            previous,
+            { method: "getMe", payload: {} },
+        );
+
+        assertEquals(result, { ok: true, result: undefined });
+        assertSpyCalls(previous, 1);
+    });
+});

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -1,12 +1,6 @@
 import type { ApiCallFn } from "../src/client.ts";
 import { TransformerComposer } from "../src/transform.ts";
-import {
-    assertEquals,
-    assertSpyCalls,
-    describe,
-    it,
-    spy,
-} from "./deps.test.ts";
+import { assertEquals, describe, it } from "./deps.test.ts";
 
 describe("TransformerComposer", () => {
     it("should pass methods not matched by .on to the previous transformer", async () => {
@@ -14,16 +8,17 @@ describe("TransformerComposer", () => {
         const scoped = composer.on("sendMessage");
         scoped.use((prev, data, signal) => prev(data, signal));
 
-        const previous = spy<ApiCallFn>(() =>
-            Promise.resolve({ ok: true, result: undefined as never })
-        );
+        let previousCalls = 0;
+        const previous: ApiCallFn = () => {
+            previousCalls++;
+            return Promise.resolve({ ok: true, result: undefined as never });
+        };
 
-        const result = await composer.transformer()(
+        await composer.transformer()(
             previous,
             { method: "getMe", payload: {} },
         );
 
-        assertEquals(result, { ok: true, result: undefined });
-        assertSpyCalls(previous, 1);
+        assertEquals(previousCalls, 1);
     });
 });


### PR DESCRIPTION
> [!NOTE]
> This PR was primarily written by GPT-5.6 Sol xhigh in ChatGPT Work.

## Summary

This test-only draft PR adds two regression tests for `TransformerComposer.on`:

- a direct test of the composed transformer function
- an integration-level test that installs the composer on a public `Api` instance and calls `api.getMe()` with `fetch` stubbed

Both tests scope a transformer to `sendMessage`, then invoke the nonmatching `getMe` method. A nonmatching call should bypass the scoped transformer and continue to the previous API call function. Through `Api`, it should proceed to the stubbed fetch and return the Bot API result.

## Current result

Both paths fail before the previous function or stubbed fetch is reached:

```text
TypeError: Cannot read properties of undefined (reading 'transformer')
```

The public-API stack passes through `Api.getMe` and `ApiClient.callApi` before failing in `src/transform.ts`.

## Purpose

This PR intentionally does not contain a production fix. It is a minimal reproducer so CI can record the failure and the behavior can be discussed separately. It should not be merged in its current failing state.
