### PR TITLE
fix: allow videoHtml options to be omitted

### DIFF
--- a/src/convenience/inline_query.ts
+++ b/src/convenience/inline_query.ts
@@ -478,7 +478,7 @@ export interface InlineQueryResultBuilder {
         title: string,
         video_url: string | URL,
         thumbnail_url: string | URL,
-        options_: InlineQueryResultOptions<
+        options_?: InlineQueryResultOptions<
             InlineQueryResultVideo,
             "mime_type" | "title" | "video_url" | "thumbnail_url"
         >,

--- a/test/convenience/inline_query.test.ts
+++ b/test/convenience/inline_query.test.ts
@@ -1767,6 +1767,27 @@ describe("InlineQueryResultBuilder", () => {
                     },
                 });
             });
+            it("should build an HTML InlineQueryResultVideo without options", () => {
+                const video = InlineQueryResultBuilder.videoHtml(
+                    "id",
+                    "title",
+                    "https://grammy.dev/",
+                    "https://grammy.dev/thumb",
+                ).text("#Text", { parse_mode: "Markdown" });
+
+                assertObjectMatch(video, {
+                    type: "video",
+                    mime_type: "text/html",
+                    id: "id",
+                    title: "title",
+                    video_url: "https://grammy.dev/",
+                    thumbnail_url: "https://grammy.dev/thumb",
+                    input_message_content: {
+                        message_text: "#Text",
+                        parse_mode: "Markdown",
+                    },
+                });
+            });
             it("should build an HTML InlineQueryResultVideo from URLs", () => {
                 const video = InlineQueryResultBuilder.videoHtml(
                     "id",


### PR DESCRIPTION
Fixes #942.

Make the `videoHtml` type match its existing default for `options`, with coverage for the four-argument call.