### PR TITLE
fix: accept lowercase AWS Lambda secret headers on v2

### DIFF
--- a/src/convenience/webhook.ts
+++ b/src/convenience/webhook.ts
@@ -562,7 +562,8 @@ function makeAdapters(): WebhookAdapterMap {
     const awsLambda: WebhookAdapterLambda = (event, _context, callback) => ({
         // TODO: add safe parse workaround
         update: () => JSON.parse(event.body ?? "{}"),
-        header: event.headers[SECRET_HEADER],
+        header: event.headers[SECRET_HEADER] ??
+            event.headers[SECRET_HEADER_LOWERCASE],
         method: event.httpMethod,
         path: event.path,
         end: () => callback(null, { statusCode: 200 }),
@@ -585,7 +586,8 @@ function makeAdapters(): WebhookAdapterMap {
         return {
             // TODO: add safe parse workaround
             update: () => JSON.parse(event.body ?? "{}"),
-            header: event.headers[SECRET_HEADER],
+            header: event.headers[SECRET_HEADER] ??
+                event.headers[SECRET_HEADER_LOWERCASE],
             method: event.requestContext.http.method,
             path: event.requestContext.http.path,
             end: () => ret.resolve({ statusCode: 200 }),

--- a/test/convenience/webhook.test.ts
+++ b/test/convenience/webhook.test.ts
@@ -314,6 +314,53 @@ describe("webhook functionality", () => {
                 1,
             );
         });
+
+        it("should accept lowercase AWS Lambda secret headers", async () => {
+            const bot = createTestBot();
+            bot.handleUpdate = spy(() => Promise.resolve());
+            const handler = webhookAdapters.awsLambda(bot, {
+                secretToken: "correct-token",
+            });
+
+            await handler(
+                {
+                    body: JSON.stringify(testUpdate),
+                    headers: {
+                        "x-telegram-bot-api-secret-token": "correct-token",
+                    },
+                    httpMethod: "POST",
+                    path: "/",
+                },
+                undefined,
+                async () => {},
+            );
+
+            assertEquals(
+                (bot.handleUpdate as ReturnType<typeof spy>).calls.length,
+                1,
+            );
+        });
+
+        it("should accept lowercase AWS Lambda async secret headers", async () => {
+            const bot = createTestBot();
+            bot.handleUpdate = spy(() => Promise.resolve());
+            const handler = webhookAdapters.awsLambdaAsync(bot, {
+                secretToken: "correct-token",
+            });
+
+            await handler({
+                body: JSON.stringify(testUpdate),
+                headers: {
+                    "x-telegram-bot-api-secret-token": "correct-token",
+                },
+                requestContext: { http: { method: "POST", path: "/" } },
+            }, undefined);
+
+            assertEquals(
+                (bot.handleUpdate as ReturnType<typeof spy>).calls.length,
+                1,
+            );
+        });
     });
 
     describe("bot initialization", () => {

--- a/test/convenience/webhook.test.ts
+++ b/test/convenience/webhook.test.ts
@@ -314,53 +314,6 @@ describe("webhook functionality", () => {
                 1,
             );
         });
-
-        it("should accept lowercase AWS Lambda secret headers", async () => {
-            const bot = createTestBot();
-            bot.handleUpdate = spy(() => Promise.resolve());
-            const handler = webhookAdapters.awsLambda(bot, {
-                secretToken: "correct-token",
-            });
-
-            await handler(
-                {
-                    body: JSON.stringify(testUpdate),
-                    headers: {
-                        "x-telegram-bot-api-secret-token": "correct-token",
-                    },
-                    httpMethod: "POST",
-                    path: "/",
-                },
-                undefined,
-                async () => {},
-            );
-
-            assertEquals(
-                (bot.handleUpdate as ReturnType<typeof spy>).calls.length,
-                1,
-            );
-        });
-
-        it("should accept lowercase AWS Lambda async secret headers", async () => {
-            const bot = createTestBot();
-            bot.handleUpdate = spy(() => Promise.resolve());
-            const handler = webhookAdapters.awsLambdaAsync(bot, {
-                secretToken: "correct-token",
-            });
-
-            await handler({
-                body: JSON.stringify(testUpdate),
-                headers: {
-                    "x-telegram-bot-api-secret-token": "correct-token",
-                },
-                requestContext: { http: { method: "POST", path: "/" } },
-            }, undefined);
-
-            assertEquals(
-                (bot.handleUpdate as ReturnType<typeof spy>).calls.length,
-                1,
-            );
-        });
     });
 
     describe("bot initialization", () => {


### PR DESCRIPTION
> [!NOTE]
> This pull request was primarily written by GPT-5.6 Sol xhigh in ChatGPT Work.

## Summary

Ports the AWS Lambda secret-header fix from main-branch PR #900 to the `v2` branch.

API Gateway HTTP API lowercases inbound header names. The v2 `awsLambda` and `awsLambdaAsync` adapters only looked up `X-Telegram-Bot-Api-Secret-Token` with title casing, so valid webhook requests using the lowercase key were rejected with HTTP 401.

## Changes

- Retain the existing title-cased lookup for integrations that preserve header casing.
- Fall back to `x-telegram-bot-api-secret-token` for integrations that lowercase headers.
- Keep the port source-only, matching the scope of the main-branch fix.

## Main-branch fix

This is the v2 adaptation of:

- #900

The underlying behavior and fallback order are intentionally the same; the change is adapted to v2's combined webhook implementation in `src/convenience/webhook.ts`.

## Verification

- Formatting passes for the changed source file.
- Linting passes for the changed source file.
- All v2 source files type-check with the local debug import shim.
