### PR TITLE
fix: read Azure secret header from request on v2

### DIFF
--- a/src/convenience/webhook.ts
+++ b/src/convenience/webhook.ts
@@ -318,6 +318,7 @@ export type WebhookAdapterAzure = (context: {
     };
 }, request: {
     body?: unknown;
+    headers?: Record<string, string | undefined>;
     method: string;
     url: string;
 }) => ReqResHandler;
@@ -605,7 +606,7 @@ function makeAdapters(): WebhookAdapterMap {
     /** Azure Functions v3 and v4 */
     const azure: WebhookAdapterAzure = (context, request) => ({
         update: () => request.body as Update,
-        header: context.res?.headers?.[SECRET_HEADER],
+        header: request.headers?.[SECRET_HEADER_LOWERCASE],
         method: request.method,
         path: new URL(request.url).pathname,
         end: () => (context.res = {

--- a/test/convenience/webhook.test.ts
+++ b/test/convenience/webhook.test.ts
@@ -314,6 +314,34 @@ describe("webhook functionality", () => {
                 1,
             );
         });
+
+        it("should read Azure v3 secret headers from the request", async () => {
+            const bot = createTestBot();
+            bot.handleUpdate = spy(() => Promise.resolve());
+            const handler = webhookAdapters.azure(bot, {
+                secretToken: "correct-token",
+            });
+            const context = {
+                res: {
+                    set: () => {},
+                    send: () => {},
+                },
+            };
+
+            await handler(context, {
+                body: testUpdate,
+                headers: {
+                    "x-telegram-bot-api-secret-token": "correct-token",
+                },
+                method: "POST",
+                url: "https://example.com/",
+            });
+
+            assertEquals(
+                (bot.handleUpdate as ReturnType<typeof spy>).calls.length,
+                1,
+            );
+        });
     });
 
     describe("bot initialization", () => {

--- a/test/convenience/webhook.test.ts
+++ b/test/convenience/webhook.test.ts
@@ -314,34 +314,6 @@ describe("webhook functionality", () => {
                 1,
             );
         });
-
-        it("should read Azure v3 secret headers from the request", async () => {
-            const bot = createTestBot();
-            bot.handleUpdate = spy(() => Promise.resolve());
-            const handler = webhookAdapters.azure(bot, {
-                secretToken: "correct-token",
-            });
-            const context = {
-                res: {
-                    set: () => {},
-                    send: () => {},
-                },
-            };
-
-            await handler(context, {
-                body: testUpdate,
-                headers: {
-                    "x-telegram-bot-api-secret-token": "correct-token",
-                },
-                method: "POST",
-                url: "https://example.com/",
-            });
-
-            assertEquals(
-                (bot.handleUpdate as ReturnType<typeof spy>).calls.length,
-                1,
-            );
-        });
     });
 
     describe("bot initialization", () => {


### PR DESCRIPTION
> [!NOTE]
> This pull request was primarily written by GPT-5.6 Sol xhigh in ChatGPT Work.

## Summary

Ports the Azure Functions v3 secret-header fix from main-branch PR #896 to the `v2` branch.

The v2 Azure adapter reads `X-Telegram-Bot-Api-Secret-Token` from `context.res.headers`, which represents response state, instead of reading the incoming request. As a result, a correctly authenticated webhook request is rejected with HTTP 401.

## Changes

- Add the optional incoming `headers` map to `WebhookAdapterAzure`'s request type.
- Read the lowercased secret-token header from `request.headers`.
- Keep the port source-only, matching the scope of the main-branch fix.

## Main-branch fix

This is the v2 adaptation of:

- #896

The behavior is intentionally the same as the merged main-branch fix, adapted to v2's combined webhook implementation in `src/convenience/webhook.ts`.

## Verification

- Formatting passes for the changed source file.
- Linting passes for the changed source file.
- All v2 source files type-check with the local debug import shim.
