### PR TITLE
test: reproduce Node 25 upload duplex failure

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -31,3 +31,16 @@ jobs:
                   cache: true
             - uses: actions/checkout@v6
             - run: deno task test
+    node-upload-reproduction:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: denoland/setup-deno@v2
+              with:
+                  deno-version: v2.x
+                  cache: true
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 25
+            - uses: actions/checkout@v6
+            - run: deno bundle test/node-upload.repro.ts --output=/tmp/node-upload.repro.mjs
+            - run: node /tmp/node-upload.repro.mjs

--- a/test/node-upload.repro.ts
+++ b/test/node-upload.repro.ts
@@ -1,0 +1,9 @@
+import { Api } from "../src/api.ts";
+import { InputFile } from "../src/types.ts";
+
+const api = new Api("not-a-real-token");
+
+await api.sendDocument(
+    1,
+    new InputFile(new URL("https://grammy.dev/images/Y.svg")),
+);


### PR DESCRIPTION
> [!NOTE]
> This PR was primarily written by GPT-5.6 Sol xhigh in ChatGPT Work.

## Summary

This test-only draft PR adds a Node 25 CI reproduction for file uploads through the public API:

- constructs a normal `Api` instance
- calls `api.sendDocument`
- supplies `https://grammy.dev/images/Y.svg` through `InputFile`
- does not use a fetch stub, mock server, real bot token, or real chat identifier

The local TypeScript source is bundled first so that the request itself is executed by Node 25 rather than Deno.

## Current result

The `sendDocument` call fails before making a network request:

```text
HttpError: Network request for 'sendDocument' failed!
RequestInit: duplex option is required when sending a body.
```

Node rejects the multipart `ReadableStream` request body because the generated `RequestInit` does not contain `duplex: "half"`.

## Why this reproduction matters

The v2 branch changed from `node-fetch` to Node's native `fetch` implementation backed by Undici. It might therefore appear that the previous duplex handling is no longer necessary or that Undici supplies it automatically.

This reproduction demonstrates that the runtime change did **not** solve the requirement. Node 25's Undici still rejects grammY's streaming multipart body unless `duplex: "half"` is present.

The corresponding default was added on `main` by https://github.com/grammyjs/grammY/pull/913. The behavior covered by that fix remains necessary in v2 despite the fetch implementation change.

The placeholder token and chat identifier are never validated because request construction fails before any connection is attempted.

## Purpose

This PR intentionally contains no production fix. It exists so CI can record the failure through the normal `Api.sendDocument` path and so the appropriate v2 fix can be discussed separately. It should not be merged in its current failing state.
