### PR TITLE
fix: set duplex for streaming uploads

### DIFF
--- a/src/payload.ts
+++ b/src/payload.ts
@@ -79,6 +79,7 @@ export function createFormDataPayload(
             connection: "keep-alive",
         },
         body: stream,
+        duplex: "half" as const,
     };
 }
 


### PR DESCRIPTION
> [!NOTE]
> This PR was primarily written by GPT-5.6 Sol xhigh in ChatGPT Work.

## Summary

Add `duplex: "half"` to the request configuration produced for streaming multipart uploads.

The value is kept as a string literal with `as const`, and JSON-only API calls remain unchanged.

## Why

The v2 branch changed from `node-fetch` to Node's native, Undici-backed `fetch`. That change did not automatically solve the streaming request requirement: Node 25 still rejects grammY's multipart `ReadableStream` body unless `duplex: "half"` is supplied.

Draft PR #949 reproduces the failure through a normal `Api` instance and `api.sendDocument`. The corresponding fix on `main` was made in #913.

Closes #949

## Verification

- `deno fmt --check src/payload.ts`
- `deno lint src/payload.ts`
- type-checked the resulting request configuration through `src/client.ts`
- confirmed on Node 25.9.0 that `Api.sendDocument` completes and reaches a local HTTP endpoint exactly once without a caller-provided `baseFetchConfig.duplex`
