### PR TITLE
fix: add missing update types to constants

### DIFF
--- a/src/convenience/constants.ts
+++ b/src/convenience/constants.ts
@@ -24,6 +24,7 @@ export const DEFAULT_UPDATE_TYPES = [
     "business_message",
     "edited_business_message",
     "deleted_business_messages",
+    "guest_message",
     "inline_query",
     "chosen_inline_result",
     "callback_query",
@@ -33,9 +34,11 @@ export const DEFAULT_UPDATE_TYPES = [
     "poll",
     "poll_answer",
     "my_chat_member",
+    "managed_bot",
     "chat_join_request",
     "chat_boost",
     "removed_chat_boost",
+    "subscription",
 ] as const;
 
 /**
@@ -68,6 +71,7 @@ export const ALL_UPDATE_TYPES = [
     "business_message",
     "edited_business_message",
     "deleted_business_messages",
+    "guest_message",
     "inline_query",
     "chosen_inline_result",
     "callback_query",
@@ -77,9 +81,11 @@ export const ALL_UPDATE_TYPES = [
     "poll",
     "poll_answer",
     "my_chat_member",
+    "managed_bot",
     "chat_join_request",
     "chat_boost",
     "removed_chat_boost",
+    "subscription",
     // ...DEFAULT_UPDATE_TYPES,
     // https://github.com/jsr-io/jsr/issues/1258
     "chat_member",


### PR DESCRIPTION
> [!NOTE]
> This pull request was primarily written by GPT-5.6 Sol xhigh in ChatGPT Work.

## Summary

Adds the three supported update types that were omitted from both v2 update-type constants:

- `guest_message`
- `managed_bot`
- `subscription`

The values are added to both `DEFAULT_UPDATE_TYPES` and `ALL_UPDATE_TYPES`. The latter currently duplicates the default list because of the existing JSR workaround.

## Main-branch reference

The values and their ordering match [`DEFAULT_UPDATE_TYPES` on `main`](https://github.com/grammyjs/grammY/blob/99c780f41679598986f1ff178f6265efa95a3121/src/bot.ts#L28-L52). On `main`, `ALL_UPDATE_TYPES` includes that list by spreading `DEFAULT_UPDATE_TYPES`.

## Verification

- `deno fmt --check` passes.
- `deno lint` passes.
- `deno check src/convenience/constants.ts` passes.
- A runtime assertion confirms that all three values occur in both exported arrays.

The complete test task could not resolve `@grammyjs/debug` from JSR in the local environment; CI can run the full suite.