### PR TITLE
fix: use correct options for chat permissions

### DIFF
--- a/src/convenience/constants.ts
+++ b/src/convenience/constants.ts
@@ -1,3 +1,5 @@
+import type { ChatPermissions } from "../types.ts";
+
 /**
  * List of update types a bot receives by default. Useful if you want to
  * receive all update types but `chat_member`, `message_reaction`, and
@@ -101,23 +103,24 @@ export const ALL_UPDATE_TYPES = [
  * await ctx.restrictAuthor(ALL_CHAT_PERMISSIONS);
  * ```
  *
- * See the [Bot API reference](https://core.telegram.org/bots/api#update)
+ * See the [Bot API reference](https://core.telegram.org/bots/api#chatpermissions)
  * for more information.
  */
 export const ALL_CHAT_PERMISSIONS = {
-    is_anonymous: true,
-    can_manage_chat: true,
-    can_delete_messages: true,
-    can_manage_video_chats: true,
-    can_restrict_members: true,
-    can_promote_members: true,
+    can_send_messages: true,
+    can_send_audios: true,
+    can_send_documents: true,
+    can_send_photos: true,
+    can_send_videos: true,
+    can_send_video_notes: true,
+    can_send_voice_notes: true,
+    can_send_polls: true,
+    can_send_other_messages: true,
+    can_add_web_page_previews: true,
+    can_react_to_messages: true,
     can_change_info: true,
     can_invite_users: true,
-    can_post_stories: true,
-    can_edit_stories: true,
-    can_delete_stories: true,
-    can_post_messages: true,
-    can_edit_messages: true,
+    can_edit_tag: true,
     can_pin_messages: true,
     can_manage_topics: true,
-} as const;
+} as const satisfies ChatPermissions;


### PR DESCRIPTION
> [!NOTE]
> This PR was primarily written by GPT-5.6 Sol xhigh in ChatGPT Work.

## Summary

Replace the administrator-right fields currently exported as `ALL_CHAT_PERMISSIONS` with the actual fields from `ChatPermissions`.

This also:

- includes the current `can_react_to_messages` and `can_edit_tag` permissions
- uses `satisfies ChatPermissions` to reject unrelated fields
- corrects the documentation link to the Bot API's `ChatPermissions` section

## Why

`ALL_CHAT_PERMISSIONS` is intended for calls such as `restrictChatMember` to lift all restrictions from a user. The v2 constant currently contains `ChatAdministratorRights` fields instead, so it does not grant the send permissions described by its documentation.

This was fixed on `main` in #874. This PR applies the same correction to v2 while matching the current set of chat permissions.

## Verification

- `deno fmt --check src/convenience/constants.ts`
- `deno lint src/convenience/constants.ts`
- `deno check --no-config src/convenience/constants.ts`
- verified that the constant contains exactly the 16 current chat-permission fields and that every value is `true`
