### PR TITLE
fix: always default InlineQueryResultPhoto thumbnail to photo url

### DIFF
--- a/src/convenience/inline_query.ts
+++ b/src/convenience/inline_query.ts
@@ -666,8 +666,8 @@ export const InlineQueryResultBuilder: InlineQueryResultBuilder = {
             type: "photo",
             id,
             photo_url: photoUrl,
-            thumbnail_url: photoUrl,
             ...options,
+            thumbnail_url: options.thumbnail_url ?? photoUrl,
         });
     },
     photoCached(id, photo_file_id, options = {}) {

--- a/src/convenience/inline_query.ts
+++ b/src/convenience/inline_query.ts
@@ -37,6 +37,9 @@ export type OptionalKeys<T> = {
     [K in keyof T]-?: undefined extends T[K] ? K : never;
 };
 export type OptionalFields<T> = Pick<T, OptionalKeys<T>[keyof T]>;
+type MakeFieldsOptional<T, K extends keyof T> =
+    & Omit<T, K>
+    & Partial<Pick<T, K>>;
 export type WithInputMessageMethods<R extends InlineQueryResult> = {
     text(
         message_text: string,
@@ -404,7 +407,11 @@ export interface InlineQueryResultBuilder {
     photo(
         id: string,
         photo_url: string | URL,
-        options?: InlineQueryResultOptions<InlineQueryResultPhoto, "photo_url">,
+        options?: InlineQueryResultOptions<
+            // do not require thumbnail, default to the photo itself
+            MakeFieldsOptional<InlineQueryResultPhoto, "thumbnail_url">,
+            "photo_url"
+        >,
     ): WithInputMessageMethods<InlineQueryResultPhoto>;
     /**
      * Builds an InlineQueryResultCachedPhoto object as specified by
@@ -651,18 +658,15 @@ export const InlineQueryResultBuilder: InlineQueryResultBuilder = {
             { type: "mpeg4_gif", id, mpeg4_file_id, ...options },
         );
     },
-    photo(id, photo_url, options = {
-        // do not require thumbnail, default to the photo itself
-        thumbnail_url: typeof photo_url === "string"
+    photo(id, photo_url, options = {}) {
+        const photoUrl = typeof photo_url === "string"
             ? photo_url
-            : photo_url.href,
-    }) {
+            : photo_url.href;
         return inputMessage({
             type: "photo",
             id,
-            photo_url: typeof photo_url === "string"
-                ? photo_url
-                : photo_url.href,
+            photo_url: photoUrl,
+            thumbnail_url: photoUrl,
             ...options,
         });
     },

--- a/test/convenience/inline_query.test.ts
+++ b/test/convenience/inline_query.test.ts
@@ -1287,6 +1287,33 @@ describe("InlineQueryResultBuilder", () => {
                 thumbnail_url: "https://grammy.dev/",
             });
         });
+        it("should build an InlineQueryResultPhoto with photo url as a thumbnail when not provided", () => {
+            const photo = InlineQueryResultBuilder.photo(
+                "id",
+                "https://grammy.dev/",
+                { caption: "cap" },
+            );
+            assertObjectMatch(photo, {
+                type: "photo",
+                id: "id",
+                photo_url: "https://grammy.dev/",
+                thumbnail_url: "https://grammy.dev/",
+                caption: "cap",
+            });
+        });
+        it("should build an InlineQueryResultPhoto with explicitly provided thumbnail", () => {
+            const photo = InlineQueryResultBuilder.photo(
+                "id",
+                "https://grammy.dev/",
+                { thumbnail_url: "https://grammy.dev/thumb" },
+            );
+            assertObjectMatch(photo, {
+                type: "photo",
+                id: "id",
+                photo_url: "https://grammy.dev/",
+                thumbnail_url: "https://grammy.dev/thumb",
+            });
+        });
 
         describe("with text", () => {
             it("should build an InlineQueryResultPhoto with location in message content", () => {


### PR DESCRIPTION
> [!NOTE]
> This PR was primarily written by GPT-5.6 Sol xhigh in ChatGPT Work.

## Summary

Ensure that `InlineQueryResultBuilder.photo` always defaults `thumbnail_url` to the photo URL, including when callers supply other options.

The builder now:

- normalizes `photo_url` once
- sets `thumbnail_url` before spreading `options`, so an explicit thumbnail still overrides the default
- makes `thumbnail_url` optional in the builder's options type
- covers both defaulted and explicitly supplied thumbnails with regression tests

## Why

The existing implementation puts the default thumbnail inside the default value of the entire `options` parameter. JavaScript only evaluates that default when `options` is omitted completely. Passing an object such as `{ caption: "cap" }` therefore drops the documented default thumbnail.

This was fixed on `main` in #879. This PR ports the same implementation and regression coverage to v2.

## Verification

- reproduced the missing `thumbnail_url` before the change
- `deno fmt --check src/convenience/inline_query.ts test/convenience/inline_query.test.ts`
- `deno lint src/convenience/inline_query.ts test/convenience/inline_query.test.ts`
- `deno check --no-config src/convenience/inline_query.ts`
- type-checked and executed a standalone probe covering both default and explicit thumbnails
