### PR TITLE
fix(http): reject malformed JSON in webhook adapter

### DIFF
--- a/src/convenience/webhook.ts
+++ b/src/convenience/webhook.ts
@@ -777,7 +777,11 @@ function makeAdapters(): WebhookAdapterMap {
                             const raw = globalThis.process
                                 .getBuiltinModule("node:buffer")
                                 .Buffer.concat(chunks).toString("utf-8");
-                            resolve(JSON.parse(raw));
+                            try {
+                                resolve(JSON.parse(raw));
+                            } catch (err) {
+                                reject(err);
+                            }
                         })
                         .once("error", reject);
                 }).catch(empty) as Promise<Update>,

--- a/test/convenience/webhook.test.ts
+++ b/test/convenience/webhook.test.ts
@@ -214,6 +214,54 @@ describe("webhook", () => {
 
             assertEquals(res.status, 400);
         });
+
+        it("http should respond with 400 for malformed JSON bodies", async () => {
+            class MockRequest {
+                headers: Record<string, string | string[] | undefined> = {};
+                dataListeners: Array<(chunk: unknown) => void> = [];
+                endListeners: Array<() => void> = [];
+                errorListeners: Array<() => void> = [];
+
+                on(event: string, listener: (chunk: unknown) => void) {
+                    if (event === "data") this.dataListeners.push(listener);
+                    return this;
+                }
+
+                once(event: string, listener: () => void) {
+                    if (event === "end") this.endListeners.push(listener);
+                    if (event === "error") this.errorListeners.push(listener);
+                    return this;
+                }
+            }
+
+            class MockResponse {
+                status?: number;
+
+                writeHead(
+                    status: number,
+                    _headers?: Record<string, string>,
+                ) {
+                    this.status = status;
+                    return this;
+                }
+
+                end(_json?: string) {}
+            }
+
+            const req = new MockRequest();
+            const res = new MockResponse();
+            const handler = webhookAdapters.http(bot);
+            const request = handler(req, res);
+
+            await Promise.resolve();
+            req.dataListeners.forEach((listener) =>
+                listener(new TextEncoder().encode("{"))
+            );
+            req.endListeners.forEach((listener) => listener());
+
+            await request;
+            assertEquals(res.status, 400);
+        });
     });
 });
 


### PR DESCRIPTION
> [!NOTE]
> This PR was primarily written by GPT-5.6 Sol xhigh in ChatGPT Work.

## Summary

Port the Node HTTP webhook adapter's malformed-JSON handling from `main` to v2.

This change:

- catches `JSON.parse` failures inside the request's asynchronous `end` listener
- rejects the adapter's update promise so the existing v2 error handling can convert the malformed update into a `400 Bad Request`
- adds regression coverage through the public Node HTTP webhook adapter

## Why

The `JSON.parse` call runs inside a later EventEmitter callback, after the Promise executor has returned. Without an explicit `try/catch`, a malformed request body throws outside the Promise, leaves it pending, and can surface as an uncaught exception.

This was fixed on `main` in https://github.com/grammyjs/grammY/pull/872. The v2 webhook refactor retained the older parsing code and therefore missed that fix.

## Verification

- reproduced the uncaught `SyntaxError` and pending handler before the change
- `deno fmt --check src/convenience/webhook.ts test/convenience/webhook.test.ts`
- `deno lint src/convenience/webhook.ts test/convenience/webhook.test.ts`
- focused Node 24.19.0 runtime probe against the modified source: malformed JSON returns HTTP 400 without an uncaught exception

The full Deno check and focused repository test could not load their dependency graph locally because the environment could not fetch JSR package manifests; CI can run the complete suite.
