### PR TITLE
test: reproduce Hono and Next.js webhook reply double encoding

### DIFF
--- a/test/convenience/webhook.test.ts
+++ b/test/convenience/webhook.test.ts
@@ -1,5 +1,5 @@
 // deno-lint-ignore-file no-unversioned-import no-import-prefix
-import type { Hono } from "jsr:@hono/hono";
+import { Hono } from "jsr:@hono/hono";
 import type { NHttp } from "jsr:@nhttp/nhttp";
 import type { Application } from "jsr:@oak/oak";
 import type { createServer } from "node:http";
@@ -418,6 +418,80 @@ describe("webhook functionality", () => {
     });
 
     describe("webhook reply handling", () => {
+        describe("adapter serialization", () => {
+            const webhookReply =
+                '{"method":"sendMessage","chat_id":1,"text":"hello"}';
+
+            const createReplyingBot = () => {
+                const bot = createTestBot();
+                bot.handleUpdate = spy(async (_update, envelope) => {
+                    await envelope?.send?.(webhookReply);
+                });
+                return bot;
+            };
+
+            it("stdHttp should preserve serialized webhook replies", async () => {
+                const handler = webhookAdapters.stdHttp(createReplyingBot());
+                const response = await handler(
+                    new Request("https://grammy.dev", {
+                        method: "POST",
+                        body: JSON.stringify(testUpdate),
+                    }),
+                );
+
+                assertEquals(await response.text(), webhookReply);
+            });
+
+            it("Hono should preserve serialized webhook replies", async () => {
+                const app = new Hono();
+                app.post("/", webhookAdapters.hono(createReplyingBot()));
+
+                const response = await app.request("/", {
+                    method: "POST",
+                    body: JSON.stringify(testUpdate),
+                });
+
+                assertEquals(await response.text(), webhookReply);
+            });
+
+            it("Next.js should preserve serialized webhook replies", async () => {
+                class MockNextResponse {
+                    body?: string;
+
+                    end() {
+                        return this;
+                    }
+
+                    status(_code: number) {
+                        return this;
+                    }
+
+                    // NextApiResponse.json serializes its argument before
+                    // sending it.
+                    json(value: unknown) {
+                        this.body = JSON.stringify(value);
+                        return this;
+                    }
+
+                    send(value: string) {
+                        this.body = value;
+                        return this;
+                    }
+                }
+
+                const response = new MockNextResponse();
+                const handler = webhookAdapters.nextJs(createReplyingBot());
+                await handler({
+                    body: testUpdate,
+                    headers: {},
+                    method: "POST",
+                    url: "/",
+                }, response);
+
+                assertEquals(response.body, webhookReply);
+            });
+        });
+
         it("should call respond when webhook reply is used", async () => {
             const bot = createTestBot();
             bot.handleUpdate = spy(async (_update, envelope) => {


### PR DESCRIPTION
> [!NOTE]
> This PR was primarily written by GPT-5.6 Sol xhigh in ChatGPT Work.

## Summary

This test-only draft PR adds three CI cases for webhook reply serialization:

1. `stdHttp` passes the serialized Bot API request through unchanged.
2. Hono is exercised through a real `Hono` application.
3. Next.js is exercised with a response double that implements the public `.json(value)` serialization contract.

All three cases use the same shared grammY webhook reply path and the same payload:

```json
{"method":"sendMessage","chat_id":1,"text":"hello"}
```

## What this demonstrates

The passing `stdHttp` control rules out the shared webhook reply envelope as the source of the corruption: it receives and returns the expected serialized JSON unchanged.

The Hono and Next.js cases then fail in their adapter-specific response paths. Both produce a JSON string literal instead of a Bot API request object:

```json
"{\"method\":\"sendMessage\",\"chat_id\":1,\"text\":\"hello\"}"
```

The Hono case uses the framework itself. The Next.js response double applies `JSON.stringify(value)`, matching the behavior of `NextApiResponse.json`.

## Current CI result

The [Ubuntu test job](https://github.com/grammyjs/grammY/actions/runs/31934252772) records the intended result:

```text
stdHttp should preserve serialized webhook replies ... ok
Hono should preserve serialized webhook replies ... FAILED
Next.js should preserve serialized webhook replies ... FAILED
```

Both failures show the extra outer quotes and escaped inner JSON. The rest of the webhook-reply tests continue to pass.

The separate CI job confirms that formatting, linting, type-checking, and the publish dry-run all pass.

## Purpose

This PR intentionally contains no production fix. It is a minimal reproducer and should not be merged in its current failing state.
