### PR TITLE
fix: make polling startup cancellation-safe

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -161,6 +161,9 @@ export class Bot<
 > extends Composer<C> {
     private pollingRunning = false;
     private pollingAbortController: AbortController | undefined;
+    private pollingStopPromise: Promise<void> | undefined;
+    private pollingStartAbortController: AbortController | undefined;
+    private pollingStopGeneration = 0;
     private lastTriedUpdateId = 0;
 
     /**
@@ -302,18 +305,36 @@ export class Bot<
      *
      * @param signal Optional `AbortSignal` to cancel the initialization
      */
-    async init(signal?: AbortSignal) {
+    async init(signal?: AbortSignal): Promise<void> {
         if (!this.isInited()) {
             debug("Initializing bot");
-            this.mePromise ??= withRetries(
+            const mePromise = this.mePromise ?? withRetries(
                 () => this.api.getMe(signal),
                 signal,
             );
+            if (this.mePromise === undefined) {
+                this.mePromise = mePromise;
+                mePromise.then(
+                    () => {
+                        if (this.mePromise === mePromise) {
+                            this.mePromise = undefined;
+                        }
+                    },
+                    () => {
+                        if (this.mePromise === mePromise) {
+                            this.mePromise = undefined;
+                        }
+                    },
+                );
+            }
             let me: UserFromGetMe;
             try {
-                me = await this.mePromise;
-            } finally {
-                this.mePromise = undefined;
+                me = await abortable(() => mePromise, signal);
+            } catch (err) {
+                if (err instanceof AbortError && !signal?.aborted) {
+                    return this.init(signal);
+                }
+                throw err;
             }
             if (this.me === undefined) this.me = me;
             else debug("Bot info was set by now, will not overwrite");
@@ -425,38 +446,87 @@ a known bot info object.",
      * @param options Options to use for simple long polling
      */
     async start(options?: PollingOptions) {
-        // Perform setup
-        const setup: Promise<void>[] = [];
-        if (!this.isInited()) {
-            setup.push(this.init(this.pollingAbortController?.signal));
-        }
         if (this.pollingRunning) {
-            await Promise.all(setup);
+            const controller = this.pollingAbortController;
+            try {
+                await this.init(controller?.signal);
+            } catch (err) {
+                if (err instanceof AbortError && controller?.signal.aborted) {
+                    return;
+                }
+                throw err;
+            }
+            if (controller?.signal.aborted) return;
             debug("Simple long polling already running!");
             return;
         }
+        const stopGeneration = this.pollingStopGeneration;
+        const stopPromise = this.pollingStopPromise;
+        let controller: AbortController;
+        if (stopPromise !== undefined) {
+            controller = this.pollingStartAbortController ??
+                new AbortController();
+            this.pollingStartAbortController ??= controller;
+            try {
+                await stopPromise;
+            } finally {
+                if (this.pollingStartAbortController === controller) {
+                    this.pollingStartAbortController = undefined;
+                }
+            }
+            if (
+                controller.signal.aborted ||
+                this.pollingStopGeneration !== stopGeneration ||
+                this.pollingStopPromise !== undefined
+            ) return;
+            if (this.pollingRunning) {
+                try {
+                    await this.init(controller.signal);
+                } catch (err) {
+                    if (
+                        err instanceof AbortError && controller.signal.aborted
+                    ) {
+                        return;
+                    }
+                    throw err;
+                }
+                if (controller.signal.aborted) return;
+                debug("Simple long polling already running!");
+                return;
+            }
+        } else {
+            controller = new AbortController();
+        }
 
         this.pollingRunning = true;
-        this.pollingAbortController = new AbortController();
+        this.pollingAbortController = controller;
 
+        // Perform setup
+        const setup: Promise<void>[] = [];
+        if (!this.isInited()) {
+            setup.push(this.init(controller.signal));
+        }
         setup.push(withRetries(async () => {
             await this.api.deleteWebhook({
                 drop_pending_updates: options?.drop_pending_updates,
-            }, this.pollingAbortController?.signal);
-        }, this.pollingAbortController?.signal));
+            }, controller.signal);
+        }, controller.signal));
 
         try {
             await Promise.all(setup);
             // All async ops of setup complete, run callback
             await options?.onStart?.(this.botInfo);
         } catch (err) {
-            this.pollingRunning = false;
-            this.pollingAbortController = undefined;
+            if (err instanceof AbortError && controller.signal.aborted) return;
+            if (this.pollingAbortController === controller) {
+                this.pollingRunning = false;
+                this.pollingAbortController = undefined;
+            }
             throw err;
         }
 
         // Bot was stopped during `onStart`
-        if (!this.pollingRunning) return;
+        if (controller.signal.aborted) return;
 
         // Prevent common misuse that leads to missing updates
         validateAllowedUpdates(
@@ -468,7 +538,7 @@ a known bot info object.",
 
         // Start polling
         debug("Starting simple long polling");
-        await this.loop(options);
+        await this.loop(options, controller.signal);
         debug("Middleware is done running");
     }
 
@@ -493,11 +563,37 @@ a known bot info object.",
     async stop() {
         if (this.pollingRunning) {
             debug("Stopping bot, saving update offset");
+            const controller = this.pollingAbortController;
             this.pollingRunning = false;
-            this.pollingAbortController?.abort();
+            this.pollingStopGeneration++;
+            const { promise: stopPromise, resolve, reject } = deferred<void>();
+            this.pollingStopPromise = stopPromise;
+            const finish = (failed: boolean, error?: unknown) => {
+                if (this.pollingAbortController === controller) {
+                    this.pollingAbortController = undefined;
+                }
+                if (this.pollingStopPromise === stopPromise) {
+                    this.pollingStopPromise = undefined;
+                }
+                if (failed) reject(error);
+                else resolve();
+            };
+            controller?.abort();
             const offset = this.lastTriedUpdateId + 1;
-            await this.api.getUpdates({ offset, limit: 1 })
-                .finally(() => this.pollingAbortController = undefined);
+            try {
+                this.api.getUpdates({ offset, limit: 1 }).then(
+                    () => finish(false),
+                    (error) => finish(true, error),
+                );
+            } catch (error) {
+                finish(true, error);
+            }
+            await stopPromise;
+        } else if (this.pollingStartAbortController !== undefined) {
+            debug("Stopping bot before startup");
+            this.pollingStopGeneration++;
+            this.pollingStartAbortController.abort();
+            await this.pollingStopPromise;
         } else {
             debug("Bot is not running!");
         }
@@ -541,20 +637,31 @@ a known bot info object.",
      * Internal. Do not call. Enters a loop that will perform long polling until
      * the bot is stopped.
      */
-    private async loop(options?: PollingOptions) {
+    private async loop(
+        options: PollingOptions | undefined,
+        signal: AbortSignal,
+    ) {
         const limit = options?.limit;
         const timeout = options?.timeout ?? 30; // seconds
         let allowed_updates: PollingOptions["allowed_updates"] =
             options?.allowed_updates ?? []; // reset to default if unspecified
 
         try {
-            while (this.pollingRunning) {
+            while (
+                this.pollingRunning &&
+                this.pollingAbortController?.signal === signal
+            ) {
                 // fetch updates
                 const updates = await this.fetchUpdates(
                     { limit, timeout, allowed_updates },
+                    signal,
                 );
                 // check if polling stopped
-                if (updates === undefined) break;
+                if (
+                    updates === undefined ||
+                    signal.aborted ||
+                    this.pollingAbortController?.signal !== signal
+                ) break;
                 // handle updates
                 await this.handleUpdates(updates);
                 // Telegram uses the last setting if `allowed_updates` is omitted so
@@ -562,7 +669,9 @@ a known bot info object.",
                 allowed_updates = undefined;
             }
         } finally {
-            this.pollingRunning = false;
+            if (this.pollingAbortController?.signal === signal) {
+                this.pollingRunning = false;
+            }
         }
     }
 
@@ -576,6 +685,7 @@ a known bot info object.",
      */
     private async fetchUpdates(
         { limit, timeout, allowed_updates }: PollingOptions,
+        signal: AbortSignal,
     ) {
         const offset = this.lastTriedUpdateId + 1;
         let updates: Update[] | undefined = undefined;
@@ -583,12 +693,14 @@ a known bot info object.",
             try {
                 updates = await this.api.getUpdates(
                     { offset, limit, timeout, allowed_updates },
-                    this.pollingAbortController?.signal,
+                    signal,
                 );
             } catch (error) {
-                await this.handlePollingError(error);
+                await this.handlePollingError(error, signal);
             }
-        } while (updates === undefined && this.pollingRunning);
+        } while (
+            updates === undefined && this.pollingRunning && !signal.aborted
+        );
         return updates;
     }
 
@@ -596,8 +708,8 @@ a known bot info object.",
      * Internal. Do not call. Handles an error that occurred during long
      * polling.
      */
-    private async handlePollingError(error: unknown) {
-        if (!this.pollingRunning) {
+    private async handlePollingError(error: unknown, signal: AbortSignal) {
+        if (!this.pollingRunning || signal.aborted) {
             debug("Pending getUpdates request cancelled");
             return;
         }
@@ -615,7 +727,12 @@ a known bot info object.",
         debugErr(
             `Call to getUpdates failed, retrying in ${sleepSeconds} seconds ...`,
         );
-        await sleep(sleepSeconds);
+        try {
+            await sleep(sleepSeconds, signal);
+        } catch (err) {
+            if (err instanceof AbortError && signal.aborted) return;
+            throw err;
+        }
     }
 }
 
@@ -686,9 +803,10 @@ async function withRetries<T>(
     let result: { ok: false } | { ok: true; value: T } = { ok: false };
     while (!result.ok) {
         try {
-            result = { ok: true, value: await task() };
+            result = { ok: true, value: await abortable(task, signal) };
         } catch (error) {
             debugErr(error);
+            if (error instanceof AbortError) throw error;
             const strategy = await handleError(error);
             switch (strategy) {
                 case "retry":
@@ -701,6 +819,45 @@ async function withRetries<T>(
     return result.value;
 }
 
+class AbortError extends Error {
+    constructor() {
+        super("Operation aborted");
+        this.name = "AbortError";
+    }
+}
+
+function deferred<T>() {
+    let resolve: (value: T | PromiseLike<T>) => void = () => {};
+    let reject: (reason?: unknown) => void = () => {};
+    const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+    return { promise, resolve, reject };
+}
+
+async function abortable<T>(
+    task: () => Promise<T>,
+    signal?: AbortSignal,
+): Promise<T> {
+    if (signal === undefined) return await task();
+    if (signal.aborted) throw new AbortError();
+
+    let reject: (err: AbortError) => void = () => {};
+    function abort() {
+        reject(new AbortError());
+    }
+    const aborted = new Promise<never>((_, rej) => {
+        reject = rej;
+        signal.addEventListener("abort", abort);
+    });
+    try {
+        return await Promise.race([task(), aborted]);
+    } finally {
+        signal.removeEventListener("abort", abort);
+    }
+}
+
 /**
  * Returns a new promise that resolves after the specified number of seconds, or
  * rejects as soon as the given signal is aborted.
@@ -709,7 +866,7 @@ async function sleep(seconds: number, signal?: AbortSignal) {
     let handle: Parameters<typeof clearTimeout>[0];
     let reject: ((err: Error) => void) | undefined;
     function abort() {
-        reject?.(new Error("Aborted delay"));
+        reject?.(new AbortError());
         if (handle !== undefined) clearTimeout(handle);
     }
     try {

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -580,14 +580,10 @@ a known bot info object.",
             };
             controller?.abort();
             const offset = this.lastTriedUpdateId + 1;
-            try {
-                this.api.getUpdates({ offset, limit: 1 }).then(
-                    () => finish(false),
-                    (error) => finish(true, error),
-                );
-            } catch (error) {
-                finish(true, error);
-            }
+            this.api.getUpdates({ offset, limit: 1 }).then(
+                () => finish(false),
+                (error) => finish(true, error),
+            );
             await stopPromise;
         } else if (this.pollingStartAbortController !== undefined) {
             debug("Stopping bot before startup");

--- a/test/bot.test.ts
+++ b/test/bot.test.ts
@@ -463,6 +463,41 @@ describe("Bot error handling", () => {
             assertEquals(getUpdatesStub.calls.length, 3);
         });
 
+        it("should cancel retry delay when stopped", async () => {
+            using time = new FakeTime();
+            let callCount = 0;
+            using getUpdatesStub = stub(
+                bot.api,
+                "getUpdates",
+                () => {
+                    callCount++;
+                    if (callCount === 1) {
+                        return Promise.reject(
+                            new GrammyError(
+                                "Too Many Requests",
+                                {
+                                    ok: false,
+                                    error_code: 429,
+                                    description: "Too Many Requests",
+                                    parameters: { retry_after: 30 },
+                                },
+                                "getUpdates",
+                                {},
+                            ),
+                        );
+                    }
+                    return Promise.resolve([]);
+                },
+            );
+
+            const startPromise = bot.start();
+            await time.tickAsync(0);
+            await bot.stop();
+            await startPromise;
+
+            assertEquals(getUpdatesStub.calls.length, 2);
+        });
+
         it("should call custom error handler for middleware errors", async () => {
             const { promise: errorHandled, resolve: notifyErrorHandled } =
                 Promise.withResolvers<void>();
@@ -627,6 +662,27 @@ describe("Bot polling lifecycle", () => {
         assertEquals(onStartSpy.calls[0].args[0], botInfo);
     });
 
+    it("should throw errors from onStart after stop", async () => {
+        using _getUpdates = stub(
+            bot.api,
+            "getUpdates",
+            () => Promise.resolve([]),
+        );
+        const error = new Error("onStart failed");
+
+        await assertRejects(
+            () =>
+                bot.start({
+                    onStart: async () => {
+                        await bot.stop();
+                        throw error;
+                    },
+                }),
+            Error,
+            "onStart failed",
+        );
+    });
+
     it("should handle stop when not running", async () => {
         assertEquals(bot.isRunning(), false);
         await bot.stop(); // Should not throw
@@ -712,6 +768,350 @@ describe("Bot polling lifecycle", () => {
         await startPromise;
 
         assertEquals(deleteWebhookStub.calls.length, 1);
+    });
+
+    it("should stop immediately after start", async () => {
+        using getUpdatesStub = stub(
+            bot.api,
+            "getUpdates",
+            () => Promise.resolve([]),
+        );
+
+        const startPromise = bot.start();
+        await bot.stop();
+        await startPromise;
+
+        assertEquals(getUpdatesStub.calls.length, 1);
+        assertEquals(bot.isRunning(), false);
+    });
+
+    it("should not retry setup after stop", async () => {
+        const { promise: firstCallStarted, resolve: notifyFirstCall } = Promise
+            .withResolvers<void>();
+        let callCount = 0;
+        deleteWebhookStub.restore();
+        deleteWebhookStub = stub(
+            bot.api,
+            "deleteWebhook",
+            (_params, signal?: AbortSignal) => {
+                callCount++;
+                assertEquals(callCount, 1);
+                notifyFirstCall();
+                return new Promise((_, reject) => {
+                    signal!.addEventListener(
+                        "abort",
+                        () => reject(new HttpError("Aborted", new Error())),
+                    );
+                });
+            },
+        );
+        using _getUpdates = stub(
+            bot.api,
+            "getUpdates",
+            () => Promise.resolve([]),
+        );
+
+        const onStart = spy(() => {});
+        const startPromise = bot.start({ onStart });
+        await firstCallStarted;
+        await bot.stop();
+        await startPromise;
+
+        assertEquals(callCount, 1);
+        assertEquals(onStart.calls.length, 0);
+    });
+
+    it("should cancel initialization after stop", async () => {
+        const uninitializedBot = new Bot(token);
+        const { promise: getMeStarted, resolve: notifyGetMeStarted } = Promise
+            .withResolvers<void>();
+        let initSignal: AbortSignal | undefined;
+        let getMeCalls = 0;
+
+        using _getMe = stub(
+            uninitializedBot.api,
+            "getMe",
+            (signal?: AbortSignal) => {
+                getMeCalls++;
+                initSignal = signal;
+                notifyGetMeStarted();
+                return new Promise((_, reject) => {
+                    signal!.addEventListener(
+                        "abort",
+                        () => reject(new HttpError("Aborted", new Error())),
+                    );
+                });
+            },
+        );
+        using _deleteWebhook = stub(
+            uninitializedBot.api,
+            "deleteWebhook",
+            () => Promise.resolve(true as const),
+        );
+        using _getUpdates = stub(
+            uninitializedBot.api,
+            "getUpdates",
+            () => Promise.resolve([]),
+        );
+
+        const startPromise = uninitializedBot.start();
+        const duplicateStart = uninitializedBot.start();
+        await getMeStarted;
+        await uninitializedBot.stop();
+        await startPromise;
+        await duplicateStart;
+
+        assertEquals(initSignal?.aborted, true);
+        assertEquals(getMeCalls, 1);
+    });
+
+    it("should cancel startup while an external init is pending", async () => {
+        const uninitializedBot = new Bot(token);
+        const { promise: getMe, resolve: resolveGetMe } = Promise
+            .withResolvers<UserFromGetMe>();
+        const { promise: getMeStarted, resolve: notifyGetMeStarted } = Promise
+            .withResolvers<void>();
+        const { promise: pollingStarted, resolve: notifyPollingStarted } =
+            Promise.withResolvers<void>();
+        let getMeCalls = 0;
+        let getUpdatesCalls = 0;
+
+        using _getMe = stub(uninitializedBot.api, "getMe", () => {
+            getMeCalls++;
+            notifyGetMeStarted();
+            return getMe;
+        });
+        using _deleteWebhook = stub(
+            uninitializedBot.api,
+            "deleteWebhook",
+            () => Promise.resolve(true as const),
+        );
+        using _getUpdates = stub(
+            uninitializedBot.api,
+            "getUpdates",
+            (_params, signal?: AbortSignal) => {
+                getUpdatesCalls++;
+                if (getUpdatesCalls === 1) return Promise.resolve([]);
+                if (getUpdatesCalls === 2) {
+                    notifyPollingStarted();
+                    return new Promise((_, reject) => {
+                        signal!.addEventListener(
+                            "abort",
+                            () => reject(new Error("Aborted")),
+                        );
+                    });
+                }
+                return Promise.resolve([]);
+            },
+        );
+
+        const initPromise = uninitializedBot.init();
+        await getMeStarted;
+        const firstStart = uninitializedBot.start();
+        await uninitializedBot.stop();
+        await firstStart;
+
+        const restart = uninitializedBot.start();
+        resolveGetMe(botInfo);
+        await pollingStarted;
+        await uninitializedBot.stop();
+        await restart;
+        await initPromise;
+
+        assertEquals(getMeCalls, 1);
+    });
+
+    it("should throw setup errors that occur before stop", async () => {
+        const error = new Error("setup failed");
+        deleteWebhookStub.restore();
+        deleteWebhookStub = stub(
+            bot.api,
+            "deleteWebhook",
+            () => {
+                throw error;
+            },
+        );
+        using _getUpdates = stub(
+            bot.api,
+            "getUpdates",
+            () => Promise.resolve([]),
+        );
+
+        const startPromise = bot.start();
+        await bot.stop();
+
+        await assertRejects(() => startPromise, Error, "setup failed");
+    });
+
+    it("should wait for stop confirmation before restarting", async () => {
+        const { promise: firstSetupStarted, resolve: notifyFirstSetup } =
+            Promise
+                .withResolvers<void>();
+        const { promise: confirmation, resolve: confirmStop } = Promise
+            .withResolvers<Update[]>();
+        const { promise: secondPollingStarted, resolve: notifySecondPolling } =
+            Promise.withResolvers<void>();
+        let deleteWebhookCalls = 0;
+        let getUpdatesCalls = 0;
+        let secondStart: Promise<void> | undefined;
+        deleteWebhookStub.restore();
+        deleteWebhookStub = stub(
+            bot.api,
+            "deleteWebhook",
+            (_params, signal?: AbortSignal) => {
+                deleteWebhookCalls++;
+                if (deleteWebhookCalls === 1) {
+                    notifyFirstSetup();
+                    return new Promise((_, reject) => {
+                        signal!.addEventListener(
+                            "abort",
+                            () => {
+                                secondStart = bot.start();
+                                reject(new HttpError("Aborted", new Error()));
+                            },
+                        );
+                    });
+                }
+                return Promise.resolve(true as const);
+            },
+        );
+        using _getUpdates = stub(
+            bot.api,
+            "getUpdates",
+            (_params, signal?: AbortSignal) => {
+                getUpdatesCalls++;
+                if (getUpdatesCalls === 1) return confirmation;
+                if (getUpdatesCalls === 2) {
+                    notifySecondPolling();
+                    return new Promise((_, reject) => {
+                        signal!.addEventListener(
+                            "abort",
+                            () => reject(new Error("Aborted")),
+                        );
+                    });
+                }
+                return Promise.resolve([]);
+            },
+        );
+
+        const firstStart = bot.start();
+        await firstSetupStarted;
+        const firstStop = bot.stop();
+
+        assertEquals(deleteWebhookCalls, 1);
+        confirmStop([]);
+        await firstStop;
+        await secondPollingStarted;
+        await bot.stop();
+        await firstStart;
+        await secondStart;
+
+        assertEquals(bot.isRunning(), false);
+    });
+
+    it("should cancel a restart while stop confirmation is pending", async () => {
+        const { promise: pollingStarted, resolve: notifyPollingStarted } =
+            Promise.withResolvers<void>();
+        const { promise: confirmation, resolve: confirmStop } = Promise
+            .withResolvers<Update[]>();
+        let getUpdatesCalls = 0;
+        using _getUpdates = stub(
+            bot.api,
+            "getUpdates",
+            (_params, signal?: AbortSignal) => {
+                getUpdatesCalls++;
+                if (getUpdatesCalls === 1) {
+                    notifyPollingStarted();
+                    return new Promise((_, reject) => {
+                        signal!.addEventListener(
+                            "abort",
+                            () => reject(new Error("Aborted")),
+                        );
+                    });
+                }
+                if (getUpdatesCalls === 2) return confirmation;
+                return Promise.resolve([]);
+            },
+        );
+
+        const firstStart = bot.start();
+        await pollingStarted;
+        const firstStop = bot.stop();
+        const restart = bot.start();
+        const cancelRestart = bot.stop();
+
+        confirmStop([]);
+        await firstStop;
+        await cancelRestart;
+        await firstStart;
+        await restart;
+
+        assertEquals(deleteWebhookStub.calls.length, 1);
+        assertEquals(bot.isRunning(), false);
+    });
+
+    it("should reject restart when stop confirmation fails", async () => {
+        const { promise: pollingStarted, resolve: notifyPollingStarted } =
+            Promise.withResolvers<void>();
+        const error = new Error("confirmation failed");
+        let getUpdatesCalls = 0;
+        using _getUpdates = stub(
+            bot.api,
+            "getUpdates",
+            (_params, signal?: AbortSignal) => {
+                getUpdatesCalls++;
+                if (getUpdatesCalls === 1) {
+                    notifyPollingStarted();
+                    return new Promise((_, reject) => {
+                        signal!.addEventListener(
+                            "abort",
+                            () => reject(new Error("Aborted")),
+                        );
+                    });
+                }
+                if (getUpdatesCalls === 2) return Promise.reject(error);
+                return Promise.resolve([]);
+            },
+        );
+
+        const firstStart = bot.start();
+        await pollingStarted;
+        const stop = bot.stop();
+        const restart = bot.start();
+
+        await assertRejects(() => stop, Error, "confirmation failed");
+        await assertRejects(() => restart, Error, "confirmation failed");
+        await firstStart;
+    });
+
+    it("should discard updates returned after stop", async () => {
+        const { promise: pollingStarted, resolve: notifyPollingStarted } =
+            Promise.withResolvers<void>();
+        const { promise: updates, resolve: resolveUpdates } = Promise
+            .withResolvers<Update[]>();
+        let getUpdatesCalls = 0;
+        using _getUpdates = stub(
+            bot.api,
+            "getUpdates",
+            () => {
+                getUpdatesCalls++;
+                if (getUpdatesCalls === 1) {
+                    notifyPollingStarted();
+                    return updates;
+                }
+                return Promise.resolve([]);
+            },
+        );
+        const middlewareSpy = spy((_ctx: Context) => {});
+        bot.use(middlewareSpy);
+
+        const startPromise = bot.start();
+        await pollingStarted;
+        await bot.stop();
+        resolveUpdates([testUpdate]);
+        await startPromise;
+
+        assertEquals(middlewareSpy.calls.length, 0);
     });
 
     it("should process updates from polling", async () => {

--- a/test/bot.test.ts
+++ b/test/bot.test.ts
@@ -145,6 +145,30 @@ describe("Bot initialization", () => {
         assertEquals(getMeStub.calls.length, 1);
     });
 
+    it("should continue init when another caller aborts", async () => {
+        const bot = new Bot(token);
+        const first = new AbortController();
+        const second = new AbortController();
+        let getMeCalls = 0;
+        using _ = stub(bot.api, "getMe", () => {
+            getMeCalls++;
+            if (getMeCalls === 1) {
+                return new Promise<UserFromGetMe>(() => {});
+            }
+            return Promise.resolve(botInfo);
+        });
+
+        const firstInit = bot.init(first.signal);
+        const secondInit = bot.init(second.signal);
+        first.abort();
+
+        await assertRejects(() => firstInit, Error, "Operation aborted");
+        await secondInit;
+
+        assertEquals(getMeCalls, 2);
+        assertEquals(bot.botInfo, botInfo);
+    });
+
     it("should retry on HttpError during initialization", async () => {
         const bot = new Bot(token);
         let callCount = 0;
@@ -683,6 +707,19 @@ describe("Bot polling lifecycle", () => {
         );
     });
 
+    it("should stop from onStart", async () => {
+        using getUpdates = stub(
+            bot.api,
+            "getUpdates",
+            () => Promise.resolve([]),
+        );
+
+        await bot.start({ onStart: () => bot.stop() });
+
+        assertEquals(getUpdates.calls.length, 1);
+        assertEquals(bot.isRunning(), false);
+    });
+
     it("should handle stop when not running", async () => {
         assertEquals(bot.isRunning(), false);
         await bot.stop(); // Should not throw
@@ -732,6 +769,37 @@ describe("Bot polling lifecycle", () => {
 
         await bot.stop();
         await startPromise1;
+    });
+
+    it("should abandon a duplicate start stopped during initialization", async () => {
+        const { promise: pollingStarted, resolve: notifyPollingStarted } =
+            Promise.withResolvers<void>();
+        let getUpdatesCalls = 0;
+        using _ = stub(
+            bot.api,
+            "getUpdates",
+            (_params, signal?: AbortSignal) => {
+                getUpdatesCalls++;
+                if (getUpdatesCalls === 1) {
+                    notifyPollingStarted();
+                    return new Promise((_, reject) => {
+                        signal!.addEventListener(
+                            "abort",
+                            () => reject(new Error("Aborted")),
+                        );
+                    });
+                }
+                return Promise.resolve([]);
+            },
+        );
+
+        const firstStart = bot.start();
+        await pollingStarted;
+        const duplicateStart = bot.start();
+        const stop = bot.stop();
+
+        await Promise.all([firstStart, duplicateStart, stop]);
+        assertEquals(bot.isRunning(), false);
     });
 
     it("should delete webhook on start", async () => {
@@ -937,10 +1005,8 @@ describe("Bot polling lifecycle", () => {
             () => Promise.resolve([]),
         );
 
-        const startPromise = bot.start();
-        await bot.stop();
-
-        await assertRejects(() => startPromise, Error, "setup failed");
+        await assertRejects(() => bot.start(), Error, "setup failed");
+        assertEquals(bot.isRunning(), false);
     });
 
     it("should wait for stop confirmation before restarting", async () => {
@@ -1006,6 +1072,58 @@ describe("Bot polling lifecycle", () => {
         await firstStart;
         await secondStart;
 
+        assertEquals(bot.isRunning(), false);
+    });
+
+    it("should serialize concurrent restarts after stop confirmation", async () => {
+        const { promise: firstPollingStarted, resolve: notifyFirstPolling } =
+            Promise.withResolvers<void>();
+        const { promise: confirmation, resolve: confirmStop } = Promise
+            .withResolvers<Update[]>();
+        const { promise: secondPollingStarted, resolve: notifySecondPolling } =
+            Promise.withResolvers<void>();
+        let getUpdatesCalls = 0;
+        using _ = stub(
+            bot.api,
+            "getUpdates",
+            (_params, signal?: AbortSignal) => {
+                getUpdatesCalls++;
+                if (getUpdatesCalls === 1) {
+                    notifyFirstPolling();
+                    return new Promise((_, reject) => {
+                        signal!.addEventListener(
+                            "abort",
+                            () => reject(new Error("Aborted")),
+                        );
+                    });
+                }
+                if (getUpdatesCalls === 2) return confirmation;
+                if (getUpdatesCalls === 3) {
+                    notifySecondPolling();
+                    return new Promise((_, reject) => {
+                        signal!.addEventListener(
+                            "abort",
+                            () => reject(new Error("Aborted")),
+                        );
+                    });
+                }
+                return Promise.resolve([]);
+            },
+        );
+
+        const firstStart = bot.start();
+        await firstPollingStarted;
+        const firstStop = bot.stop();
+        const firstRestart = bot.start();
+        const secondRestart = bot.start();
+
+        confirmStop([]);
+        await firstStop;
+        await secondPollingStarted;
+        await bot.stop();
+        await Promise.all([firstStart, firstRestart, secondRestart]);
+
+        assertEquals(deleteWebhookStub.calls.length, 2);
         assertEquals(bot.isRunning(), false);
     });
 
@@ -1082,6 +1200,36 @@ describe("Bot polling lifecycle", () => {
         await assertRejects(() => stop, Error, "confirmation failed");
         await assertRejects(() => restart, Error, "confirmation failed");
         await firstStart;
+    });
+
+    it("should reject stop when confirmation throws synchronously", async () => {
+        const { promise: pollingStarted, resolve: notifyPollingStarted } =
+            Promise.withResolvers<void>();
+        const error = new Error("confirmation failed");
+        let getUpdatesCalls = 0;
+        using _ = stub(
+            bot.api,
+            "getUpdates",
+            (_params, signal?: AbortSignal) => {
+                getUpdatesCalls++;
+                if (getUpdatesCalls === 1) {
+                    notifyPollingStarted();
+                    return new Promise((_, reject) => {
+                        signal!.addEventListener(
+                            "abort",
+                            () => reject(new Error("Aborted")),
+                        );
+                    });
+                }
+                throw error;
+            },
+        );
+
+        const start = bot.start();
+        await pollingStarted;
+
+        await assertRejects(() => bot.stop(), Error, "confirmation failed");
+        await start;
     });
 
     it("should discard updates returned after stop", async () => {

--- a/test/bot.test.ts
+++ b/test/bot.test.ts
@@ -240,33 +240,6 @@ describe("Bot initialization", () => {
         assertEquals(callCount, 2);
     });
 
-    it("should wait for retry_after during initialization", async () => {
-        const bot = new Bot(token);
-        let callCount = 0;
-        using _ = stub(bot.api, "getMe", () => {
-            callCount++;
-            if (callCount === 1) {
-                throw new GrammyError(
-                    "Too Many Requests",
-                    {
-                        ok: false,
-                        error_code: 429,
-                        description: "Too Many Requests",
-                        parameters: { retry_after: 0 },
-                    },
-                    "getMe",
-                    {},
-                );
-            }
-            return Promise.resolve(botInfo);
-        });
-
-        const init = bot.init();
-        await init;
-
-        assertEquals(callCount, 2);
-    });
-
     it("should reject an already-aborted initialization", async () => {
         const bot = new Bot(token);
         const controller = new AbortController();
@@ -813,37 +786,6 @@ describe("Bot polling lifecycle", () => {
         await startPromise1;
     });
 
-    it("should abandon a duplicate start stopped during initialization", async () => {
-        const { promise: pollingStarted, resolve: notifyPollingStarted } =
-            Promise.withResolvers<void>();
-        let getUpdatesCalls = 0;
-        using _ = stub(
-            bot.api,
-            "getUpdates",
-            (_params, signal?: AbortSignal) => {
-                getUpdatesCalls++;
-                if (getUpdatesCalls === 1) {
-                    notifyPollingStarted();
-                    return new Promise((_, reject) => {
-                        signal!.addEventListener(
-                            "abort",
-                            () => reject(new Error("Aborted")),
-                        );
-                    });
-                }
-                return Promise.resolve([]);
-            },
-        );
-
-        const firstStart = bot.start();
-        await pollingStarted;
-        const duplicateStart = bot.start();
-        const stop = bot.stop();
-
-        await Promise.all([firstStart, duplicateStart, stop]);
-        assertEquals(bot.isRunning(), false);
-    });
-
     it("should reject duplicate start when initialization fails", async () => {
         const uninitializedBot = new Bot(token);
         const { promise: getMe, reject: rejectGetMe } = Promise
@@ -1267,36 +1209,6 @@ describe("Bot polling lifecycle", () => {
         await assertRejects(() => stop, Error, "confirmation failed");
         await assertRejects(() => restart, Error, "confirmation failed");
         await firstStart;
-    });
-
-    it("should reject stop when confirmation throws synchronously", async () => {
-        const { promise: pollingStarted, resolve: notifyPollingStarted } =
-            Promise.withResolvers<void>();
-        const error = new Error("confirmation failed");
-        let getUpdatesCalls = 0;
-        using _ = stub(
-            bot.api,
-            "getUpdates",
-            (_params, signal?: AbortSignal) => {
-                getUpdatesCalls++;
-                if (getUpdatesCalls === 1) {
-                    notifyPollingStarted();
-                    return new Promise((_, reject) => {
-                        signal!.addEventListener(
-                            "abort",
-                            () => reject(new Error("Aborted")),
-                        );
-                    });
-                }
-                throw error;
-            },
-        );
-
-        const start = bot.start();
-        await pollingStarted;
-
-        await assertRejects(() => bot.stop(), Error, "confirmation failed");
-        await start;
     });
 
     it("should discard updates returned after stop", async () => {

--- a/test/bot.test.ts
+++ b/test/bot.test.ts
@@ -239,6 +239,48 @@ describe("Bot initialization", () => {
         // Initial attempt + 1 retry
         assertEquals(callCount, 2);
     });
+
+    it("should wait for retry_after during initialization", async () => {
+        const bot = new Bot(token);
+        let callCount = 0;
+        using _ = stub(bot.api, "getMe", () => {
+            callCount++;
+            if (callCount === 1) {
+                throw new GrammyError(
+                    "Too Many Requests",
+                    {
+                        ok: false,
+                        error_code: 429,
+                        description: "Too Many Requests",
+                        parameters: { retry_after: 0 },
+                    },
+                    "getMe",
+                    {},
+                );
+            }
+            return Promise.resolve(botInfo);
+        });
+
+        const init = bot.init();
+        await init;
+
+        assertEquals(callCount, 2);
+    });
+
+    it("should reject an already-aborted initialization", async () => {
+        const bot = new Bot(token);
+        const controller = new AbortController();
+        controller.abort();
+        using getMe = spy(bot.api, "getMe");
+
+        await assertRejects(
+            () => bot.init(controller.signal),
+            Error,
+            "Operation aborted",
+        );
+
+        assertEquals(getMe.calls.length, 0);
+    });
 });
 
 describe("Bot handleUpdate", () => {
@@ -800,6 +842,31 @@ describe("Bot polling lifecycle", () => {
 
         await Promise.all([firstStart, duplicateStart, stop]);
         assertEquals(bot.isRunning(), false);
+    });
+
+    it("should reject duplicate start when initialization fails", async () => {
+        const uninitializedBot = new Bot(token);
+        const { promise: getMe, reject: rejectGetMe } = Promise
+            .withResolvers<UserFromGetMe>();
+        const error = new Error("initialization failed");
+        using _getMe = stub(uninitializedBot.api, "getMe", () => getMe);
+        using _deleteWebhook = stub(
+            uninitializedBot.api,
+            "deleteWebhook",
+            () => Promise.resolve(true as const),
+        );
+
+        const firstStart = uninitializedBot.start();
+        const duplicateStart = uninitializedBot.start();
+        rejectGetMe(error);
+
+        await assertRejects(() => firstStart, Error, "initialization failed");
+        await assertRejects(
+            () => duplicateStart,
+            Error,
+            "initialization failed",
+        );
+        assertEquals(uninitializedBot.isRunning(), false);
     });
 
     it("should delete webhook on start", async () => {


### PR DESCRIPTION
Fixes cancellation races between start, stop, and shared bot initialization

-Scope polling controllers and stop confirmation to each run
-Cancel pending setup/retry work and ignore stale polling results after a restart
- Preserve setup failures and shared initialization behavior for concurrent callers