### PR TITLE
fix: correct retry backoff units

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -673,7 +673,7 @@ async function withRetries<T>(
         if (delay) {
             // Do not sleep for the first retry
             if (lastDelay !== INITIAL_DELAY) {
-                await sleep(lastDelay, signal);
+                await sleep(lastDelay / 1000, signal);
             }
             const TWENTY_MINUTES = 20 * 60 * 1000; // ms
             lastDelay = Math.min(TWENTY_MINUTES, 2 * lastDelay);

--- a/test/bot.test.ts
+++ b/test/bot.test.ts
@@ -162,6 +162,32 @@ describe("Bot initialization", () => {
         assertEquals(callCount, 2);
     });
 
+    it("should back off in milliseconds after repeated HttpErrors", async () => {
+        using time = new FakeTime();
+        const bot = new Bot(token);
+        const controller = new AbortController();
+        let callCount = 0;
+        using _ = stub(bot.api, "getMe", () => {
+            callCount++;
+            if (callCount < 3) {
+                throw new HttpError("Network error", {
+                    error: "ECONNREFUSED",
+                });
+            }
+            return Promise.resolve(botInfo);
+        });
+
+        const init = bot.init(controller.signal);
+        await time.tickAsync(0);
+        await time.tickAsync(100);
+        await time.tickAsync(100);
+        const callsAfterDelay = callCount;
+        controller.abort();
+        await init.catch(() => {});
+
+        assertEquals(callsAfterDelay, 3);
+    });
+
     it("should retry on 5xx errors during initialization", async () => {
         const bot = new Bot(token);
         let callCount = 0;


### PR DESCRIPTION
Fixes generic retry backoff delays being treated as seconds. Telegram `retry_after` values remain in seconds.

Tests: `deno task test`, `deno task check`, `deno fmt --check`, `deno lint`.