### PR TITLE
fix: preserve Bot API 10.3 argument semantics

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -3427,7 +3427,11 @@ export class Context implements RenamedUpdate {
         text_or_rich_message: string | InputRichMessage,
         other?: Other<
             "editEphemeralMessageText",
-            "chat_id" | "receiver_user_id" | "ephemeral_message_id" | "text"
+            | "chat_id"
+            | "receiver_user_id"
+            | "ephemeral_message_id"
+            | "text"
+            | "rich_message"
         >,
         signal?: AbortSignal,
     ) {

--- a/src/convenience/keyboard.ts
+++ b/src/convenience/keyboard.ts
@@ -636,6 +636,7 @@ export class Keyboard {
         clone.one_time_keyboard = this.one_time_keyboard;
         clone.resize_keyboard = this.resize_keyboard;
         clone.input_field_placeholder = this.input_field_placeholder;
+        clone.force_reply = this.force_reply;
         return clone;
     }
     /**
@@ -1258,7 +1259,7 @@ export class InlineKeyboard {
     toTransposed() {
         const original = this.inline_keyboard;
         const transposed = transpose(original);
-        return new InlineKeyboard(transposed);
+        return this.clone(transposed);
     }
     /**
      * Creates a new inline keyboard with the same buttons but reflowed into a
@@ -1298,15 +1299,23 @@ export class InlineKeyboard {
     toFlowed(columns: number, options: FlowOptions = {}) {
         const original = this.inline_keyboard;
         const flowed = reflow(original, columns, options);
-        return new InlineKeyboard(flowed);
+        return this.clone(flowed);
     }
     /**
      * Creates and returns a deep copy of this inline keyboard.
+     *
+     * Optionally takes a new grid of buttons to replace the current buttons. If
+     * specified, only the options will be cloned, and the given buttons will be
+     * used instead.
      */
-    clone() {
-        return new InlineKeyboard(
-            this.inline_keyboard.map((row) => row.slice()),
+    clone(
+        inline_keyboard: InlineKeyboardButton[][] = this.inline_keyboard,
+    ) {
+        const clone = new InlineKeyboard(
+            inline_keyboard.map((row) => row.slice()),
         );
+        clone.force_reply = this.force_reply;
+        return clone;
     }
     /**
      * Appends the buttons of the given inline keyboards to this keyboard.

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -2654,7 +2654,11 @@ export class Api<R extends RawApi = RawApi> {
         other?: Other<
             R,
             "editEphemeralMessageText",
-            "chat_id" | "receiver_user_id" | "ephemeral_message_id" | "text"
+            | "chat_id"
+            | "receiver_user_id"
+            | "ephemeral_message_id"
+            | "text"
+            | "rich_message"
         >,
         signal?: AbortSignal,
     ) {

--- a/test/context.type.test.ts
+++ b/test/context.type.test.ts
@@ -269,3 +269,35 @@ describe("ctx update shortcuts", () => {
         });
     });
 });
+
+describe("exclusive method arguments", () => {
+    it("should omit rich_message from edit options", () => {
+        type ContextOptions = NonNullable<
+            Parameters<Context["editEphemeralMessageText"]>[1]
+        >;
+        type ApiOptions = NonNullable<
+            Parameters<Context["api"]["editEphemeralMessageText"]>[4]
+        >;
+        assertType<
+            IsExact<
+                "rich_message" extends keyof ContextOptions ? true : false,
+                false
+            >
+        >(true);
+        assertType<
+            IsExact<
+                "rich_message" extends keyof ApiOptions ? true : false,
+                false
+            >
+        >(true);
+
+        const c = new Composer<Context>();
+        c.use((ctx) => {
+            const richMessage = { html: "<b>rich</b>" };
+            ctx.editEphemeralMessageText("text");
+            ctx.editEphemeralMessageText(richMessage);
+            ctx.api.editEphemeralMessageText(1, 2, 3, "text");
+            ctx.api.editEphemeralMessageText(1, 2, 3, richMessage);
+        });
+    });
+});

--- a/test/context.type.test.ts
+++ b/test/context.type.test.ts
@@ -269,35 +269,3 @@ describe("ctx update shortcuts", () => {
         });
     });
 });
-
-describe("exclusive method arguments", () => {
-    it("should omit rich_message from edit options", () => {
-        type ContextOptions = NonNullable<
-            Parameters<Context["editEphemeralMessageText"]>[1]
-        >;
-        type ApiOptions = NonNullable<
-            Parameters<Context["api"]["editEphemeralMessageText"]>[4]
-        >;
-        assertType<
-            IsExact<
-                "rich_message" extends keyof ContextOptions ? true : false,
-                false
-            >
-        >(true);
-        assertType<
-            IsExact<
-                "rich_message" extends keyof ApiOptions ? true : false,
-                false
-            >
-        >(true);
-
-        const c = new Composer<Context>();
-        c.use((ctx) => {
-            const richMessage = { html: "<b>rich</b>" };
-            ctx.editEphemeralMessageText("text");
-            ctx.editEphemeralMessageText(richMessage);
-            ctx.api.editEphemeralMessageText(1, 2, 3, "text");
-            ctx.api.editEphemeralMessageText(1, 2, 3, richMessage);
-        });
-    });
-});

--- a/test/convenience/keyboard.test.ts
+++ b/test/convenience/keyboard.test.ts
@@ -74,14 +74,6 @@ describe("Keyboard", () => {
         assertEquals(keyboard.force_reply, true);
     });
 
-    it("preserves reply markup options when copied", () => {
-        const keyboard = Keyboard.from([["a", "b"]]).forceReply();
-        assertEquals(keyboard.clone().force_reply, true);
-        assertEquals(keyboard.toTransposed().force_reply, true);
-        assertEquals(keyboard.toFlowed(1).force_reply, true);
-        assertEquals(Keyboard.from(keyboard).force_reply, true);
-    });
-
     it("can be transposed", () => {
         function t(btns: string[][], expected: string[][]) {
             assertEquals(
@@ -256,14 +248,6 @@ describe("InlineKeyboard", () => {
             .text("d").text("e").row()
             .text("f");
         assertEquals(keyboard.toTransposed().toTransposed(), keyboard);
-    });
-
-    it("preserves reply markup options when copied", () => {
-        const keyboard = new InlineKeyboard().text("a").text("b").forceReply();
-        assertEquals(keyboard.clone().force_reply, true);
-        assertEquals(keyboard.toTransposed().force_reply, true);
-        assertEquals(keyboard.toFlowed(1).force_reply, true);
-        assertEquals(InlineKeyboard.from(keyboard).force_reply, true);
     });
 
     it("can be wrapped", () => {

--- a/test/convenience/keyboard.test.ts
+++ b/test/convenience/keyboard.test.ts
@@ -58,17 +58,28 @@ describe("Keyboard", () => {
         assertEquals(keyboard.one_time_keyboard, undefined);
         assertEquals(keyboard.resize_keyboard, undefined);
         assertEquals(keyboard.input_field_placeholder, undefined);
+        assertEquals(keyboard.force_reply, undefined);
         keyboard
             .persistent()
             .selected(false)
             .oneTime(true)
             .resized(false)
-            .placeholder("placeholder");
+            .placeholder("placeholder")
+            .forceReply();
         assertEquals(keyboard.is_persistent, true);
         assertEquals(keyboard.selective, false);
         assertEquals(keyboard.one_time_keyboard, true);
         assertEquals(keyboard.resize_keyboard, false);
         assertEquals(keyboard.input_field_placeholder, "placeholder");
+        assertEquals(keyboard.force_reply, true);
+    });
+
+    it("preserves reply markup options when copied", () => {
+        const keyboard = Keyboard.from([["a", "b"]]).forceReply();
+        assertEquals(keyboard.clone().force_reply, true);
+        assertEquals(keyboard.toTransposed().force_reply, true);
+        assertEquals(keyboard.toFlowed(1).force_reply, true);
+        assertEquals(Keyboard.from(keyboard).force_reply, true);
     });
 
     it("can be transposed", () => {
@@ -245,6 +256,14 @@ describe("InlineKeyboard", () => {
             .text("d").text("e").row()
             .text("f");
         assertEquals(keyboard.toTransposed().toTransposed(), keyboard);
+    });
+
+    it("preserves reply markup options when copied", () => {
+        const keyboard = new InlineKeyboard().text("a").text("b").forceReply();
+        assertEquals(keyboard.clone().force_reply, true);
+        assertEquals(keyboard.toTransposed().force_reply, true);
+        assertEquals(keyboard.toFlowed(1).force_reply, true);
+        assertEquals(InlineKeyboard.from(keyboard).force_reply, true);
     });
 
     it("can be wrapped", () => {


### PR DESCRIPTION
> [!NOTE]
> This PR was primarily written by GPT-5.6 Sol xhigh in ChatGPT Work.

## Summary

Address two issues found while reviewing #964.

This change:

- preserves `force_reply` when cloning, transposing, reflowing, or copying `Keyboard` and `InlineKeyboard`
- excludes both `text` and `rich_message` from the remaining options for `editEphemeralMessageText`

## Why

Bot API 10.3 adds `force_reply` to reply and inline keyboard markup. The new value was not copied by the keyboard clone paths, so it was lost when a keyboard was cloned, transposed, reflowed, or passed to `from`.

`editEphemeralMessageText` accepts either text or a rich message through its dedicated argument. Its remaining-options type omitted `text`, but not `rich_message`, allowing the options object to override the selected payload or include both fields.

## Verification

- `deno fmt --check` on all changed files
- `npm run backport`
- focused runtime probe against the backported Node output: `force_reply` is preserved across the keyboard copy paths
- focused `deno check` against the current `@grammyjs/types` main branch

The full Deno test entrypoint could not load its remote JSR and Skypack dependencies in the local environment; CI can run the complete suite.
