### PR TITLE
fix: load Bot API types from jsDelivr

### DIFF
--- a/src/types.deno.ts
+++ b/src/types.deno.ts
@@ -44,13 +44,13 @@ import {
     type InputStoryContentPhoto as InputStoryContentPhotoF,
     type InputStoryContentVideo as InputStoryContentVideoF,
     type Opts as OptsF,
-} from "https://deno.land/x/grammy_types@v5.0.0/mod.ts";
+} from "https://cdn.jsdelivr.net/gh/grammyjs/types@5.0.0/mod.ts";
 import { debug as d, isDeno } from "./platform.deno.ts";
 
 const debug = d("grammy:warn");
 
 // === Export all API types
-export * from "https://deno.land/x/grammy_types@v5.0.0/mod.ts";
+export * from "https://cdn.jsdelivr.net/gh/grammyjs/types@5.0.0/mod.ts";
 
 /** A value, or a potentially async function supplying that value */
 type MaybeSupplier<T> = T | (() => T | Promise<T>);

--- a/src/types.web.ts
+++ b/src/types.web.ts
@@ -44,10 +44,10 @@ import {
     type InputStoryContentPhoto as InputStoryContentPhotoF,
     type InputStoryContentVideo as InputStoryContentVideoF,
     type Opts as OptsF,
-} from "https://deno.land/x/grammy_types@v5.0.0/mod.ts";
+} from "https://cdn.jsdelivr.net/gh/grammyjs/types@5.0.0/mod.ts";
 
 // === Export all API types
-export * from "https://deno.land/x/grammy_types@v5.0.0/mod.ts";
+export * from "https://cdn.jsdelivr.net/gh/grammyjs/types@5.0.0/mod.ts";
 
 /** Something that looks like a URL. */
 interface URLLike {


### PR DESCRIPTION
> [!NOTE]
> This PR was primarily written by GPT-5.6 Sol xhigh in ChatGPT Work.

## Summary

Load the Bot API 10.3 types from jsDelivr instead of `deno.land/x` in the Deno and web entrypoints.

This change:

- replaces the `@grammyjs/types` import URL in `src/types.deno.ts` and `src/types.web.ts`
- updates the corresponding wildcard re-exports
- keeps the dependency pinned to version 5.0.0

## Why

`deno.land/x` is now read-only, so new package versions can no longer be published there. Consequently, `@grammyjs/types` 5.0.0 is not available from `deno.land/x`, and the URL imports added for https://github.com/grammyjs/grammY/pull/964 cannot resolve the new version from that registry.

grammY therefore needs a different CDN that serves the repository's raw GitHub content for URL imports. jsDelivr is used as the default choice because it can also resolve semantic-version ranges.

## Verification

- confirmed that the diff only changes the import and re-export URLs in `src/types.deno.ts` and `src/types.web.ts`
- confirmed that both entrypoints use `https://cdn.jsdelivr.net/gh/grammyjs/types@5.0.0/mod.ts`
- full `grammY` workflow passed on https://github.com/KnightNiwrem/grammY/pull/9